### PR TITLE
Rewrite with_module_fallback without format macro

### DIFF
--- a/src/collapse-perf.rs
+++ b/src/collapse-perf.rs
@@ -325,23 +325,34 @@ impl PerfState {
 // massage function name to be nicer
 // NOTE: ignoring https://github.com/jvm-profiling-tools/perf-map-agent/pull/35
 fn with_module_fallback(module: &str, rawfunc: &str, pc: &str, include_addrs: bool) -> String {
-    if rawfunc == "[unknown]" {
-        // try to use part of module name as function if unknown
-        let rawfunc = if module != "[unknown]" {
-            // use everything following last / of module as function name
-            &module[module.rfind('/').map(|i| i + 1).unwrap_or(0)..]
-        } else {
-            "unknown"
-        };
-
-        if include_addrs {
-            format!("[{} <{}>]", rawfunc, pc)
-        } else {
-            format!("[{}]", rawfunc)
-        }
-    } else {
-        rawfunc.to_string()
+    if rawfunc != "[unknown]" {
+        return rawfunc.to_string()
     }
+
+    // try to use part of module name as function if unknown
+    let rawfunc = if module != "[unknown]" {
+        // use everything following last / of module as function name
+        &module[module.rfind('/').map(|i| i + 1).unwrap_or(0)..]
+    } else {
+        "unknown"
+    };
+
+    // output string is a bit longer than rawfunc but not much
+    let mut res = String::with_capacity(rawfunc.len() + 12);
+
+    if include_addrs {
+        res.push_str("[");
+        res.push_str(rawfunc);
+        res.push_str(" <");
+        res.push_str(pc);
+        res.push_str(">]");
+    } else {
+        res.push_str("[");
+        res.push_str(rawfunc);
+        res.push_str("]");
+    }
+
+    res
 }
 
 fn tidy_generic(mut func: String) -> String {

--- a/src/collapse-perf.rs
+++ b/src/collapse-perf.rs
@@ -326,15 +326,20 @@ impl PerfState {
 // NOTE: ignoring https://github.com/jvm-profiling-tools/perf-map-agent/pull/35
 fn with_module_fallback(module: &str, rawfunc: &str, pc: &str, include_addrs: bool) -> String {
     if rawfunc != "[unknown]" {
-        return rawfunc.to_string()
+        return rawfunc.to_string();
     }
 
     // try to use part of module name as function if unknown
-    let rawfunc = if module != "[unknown]" {
-        // use everything following last / of module as function name
-        &module[module.rfind('/').map(|i| i + 1).unwrap_or(0)..]
-    } else {
-        "unknown"
+    let rawfunc = match (module, include_addrs) {
+        ("[unknown]", true) => "unknown",
+        ("[unknown]", false) => {
+            // no need to process this further
+            return rawfunc.to_string();
+        }
+        (module, _) => {
+            // use everything following last / of module as function name
+            &module[module.rfind('/').map(|i| i + 1).unwrap_or(0)..]
+        }
     };
 
     // output string is a bit longer than rawfunc but not much


### PR DESCRIPTION
Also swaps the if/else branches to reduce indentation (and make the
possibly hotter non-unknown case ore obvious).