### PR TITLE
Refactor - assigning to unbound _ unnecessary

### DIFF
--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -36,8 +36,8 @@ fn flow<'a, LI, TI>(
         }
 
         // move along prefix iterators
-        let _ = last.next();
-        let _ = this.next();
+        last.next();
+        this.next();
         shared_depth += 1;
     }
 


### PR DESCRIPTION
Removed unnecessary `let _`.  You can just call next, no need to declare with a let to an unbound `_`.