### PR TITLE
Use a clone to allocate BytesStart

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -164,8 +164,9 @@ where
             a_extra = Some(&attrs.a.extra);
         }
 
+        let g_origin = BytesStart::borrowed_name(b"g");
         svg.write_event(Event::Start({
-            let mut g = BytesStart::borrowed_name(b"g").with_attributes(args!(
+            let mut g = g_origin.clone().with_attributes(args!(
                 "class" => class
             ));
             if let Some(style) = style {


### PR DESCRIPTION
Was inspired by #41 
Using a clone to allocate BytesStart allows to save calling `borrowed_name` in the loop resulting in some performance improvements:

> 
>   ==>  ./flamegraph/test/perf-iperf-stacks-pidtid-01.txt  <==
>   Benchmark #1: target/release/inferno-collapse-perf --all ./flamegraph/test/perf-iperf-stacks-pidtid-01.txt
>     Time (mean ± σ):      11.3 ms ±   3.1 ms    [User: 9.0 ms, System: 2.4 ms]
>     Range (min … max):     4.3 ms …  19.1 ms    189 runs
>    
>   Benchmark #2: target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-iperf-stacks-pidtid-01.txt
>     Time (mean ± σ):       9.0 ms ±   5.0 ms    [User: 7.1 ms, System: 2.0 ms]
>     Range (min … max):     3.5 ms …  19.3 ms    172 runs
>    
>   Summary
>     'target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-iperf-stacks-pidtid-01.txt' ran
>       1.26 ± 0.79 times faster than 'target/release/inferno-collapse-perf --all ./flamegraph/test/perf-iperf-stacks-pidtid-01.txt'
> 
> 
>   ==>  ./flamegraph/test/perf-java-stacks-01.txt  <==
>   Benchmark #1: target/release/inferno-collapse-perf --all ./flamegraph/test/perf-java-stacks-01.txt
>     Time (mean ± σ):       7.9 ms ±   1.5 ms    [User: 5.7 ms, System: 2.2 ms]
>     Range (min … max):     2.5 ms …  12.9 ms    877 runs
>    
>   Benchmark #2: target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-java-stacks-01.txt
>     Time (mean ± σ):       8.5 ms ±   1.3 ms    [User: 6.1 ms, System: 2.3 ms]
>     Range (min … max):     7.2 ms …  14.1 ms    238 runs
>    
>   Summary
>     'target/release/inferno-collapse-perf --all ./flamegraph/test/perf-java-stacks-01.txt' ran
>       1.08 ± 0.26 times faster than 'target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-java-stacks-01.txt'
> 
> 
>   ==>  ./flamegraph/test/perf-numa-stacks-01.txt  <==
>   Benchmark #1: target/release/inferno-collapse-perf --all ./flamegraph/test/perf-numa-stacks-01.txt
>     Time (mean ± σ):       8.1 ms ±   1.8 ms    [User: 6.5 ms, System: 1.8 ms]
>     Range (min … max):     3.7 ms …  14.3 ms    234 runs
>    
>   Benchmark #2: target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-numa-stacks-01.txt
>     Time (mean ± σ):       9.6 ms ±   1.3 ms    [User: 7.3 ms, System: 2.4 ms]
>     Range (min … max):     4.6 ms …  15.0 ms    288 runs
>    
>   Summary
>     'target/release/inferno-collapse-perf --all ./flamegraph/test/perf-numa-stacks-01.txt' ran
>       1.18 ± 0.31 times faster than 'target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-numa-stacks-01.txt'
> 
> 
>   ==>  ./flamegraph/test/perf-rust-Yamakaky-dcpu.txt  <==
>   Benchmark #1: target/release/inferno-collapse-perf --all ./flamegraph/test/perf-rust-Yamakaky-dcpu.txt
>     Time (mean ± σ):       6.3 ms ±   1.3 ms    [User: 4.7 ms, System: 1.9 ms]
>     Range (min … max):     1.6 ms …  10.2 ms    353 runs
>    
>   Benchmark #2: target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-rust-Yamakaky-dcpu.txt
>     Time (mean ± σ):       6.7 ms ±   1.1 ms    [User: 4.5 ms, System: 2.4 ms]
>     Range (min … max):     5.3 ms …  11.6 ms    360 runs
>    
>   Summary
>     'target/release/inferno-collapse-perf --all ./flamegraph/test/perf-rust-Yamakaky-dcpu.txt' ran
>       1.05 ± 0.27 times faster than 'target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-rust-Yamakaky-dcpu.txt'
> 
> 
>   ==>  ./flamegraph/test/perf-vertx-stacks-01.txt  <==
>   Benchmark #1: target/release/inferno-collapse-perf --all ./flamegraph/test/perf-vertx-stacks-01.txt
>     Time (mean ± σ):      33.4 ms ±   6.6 ms    [User: 30.7 ms, System: 2.8 ms]
>     Range (min … max):    16.8 ms …  51.0 ms    68 runs
>    
>   Benchmark #2: target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-vertx-stacks-01.txt
>     Time (mean ± σ):      30.5 ms ±   9.3 ms    [User: 27.7 ms, System: 2.9 ms]
>     Range (min … max):    11.2 ms …  47.7 ms    190 runs
>    
>   Summary
>     'target/release/inferno-collapse-perf-origin --all ./flamegraph/test/perf-vertx-stacks-01.txt' ran
>       1.10 ± 0.40 times faster than 'target/release/inferno-collapse-perf --all ./flamegraph/test/perf-vertx-stacks-01.txt'
> 

