### PR TITLE
Fix fractional samples false positive

### DIFF
--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -195,11 +195,15 @@ fn parse_nsamples(line: &mut &str, stripped_fractional_samples: &mut bool) -> Op
     // because of cumulative floating point errors. Instead we recommend to
     // use the --factor option. See https://github.com/brendangregg/FlameGraph/pull/18
     if let Some(doti) = samples.find('.') {
-        // Warn if we're stripping a non-zero fractional part, but only the first time.
-        if !*stripped_fractional_samples
-            && samples[..doti].chars().all(|c| c.is_digit(10))
-            && !samples[doti + 1..].chars().all(|c| c == '0')
+        if !samples[..doti]
+            .chars()
+            .chain(samples[doti + 1..].chars())
+            .all(|c| c.is_digit(10))
         {
+            return None;
+        }
+        // Warn if we're stripping a non-zero fractional part, but only the first time.
+        if !*stripped_fractional_samples && !samples[doti + 1..].chars().all(|c| c == '0') {
             *stripped_fractional_samples = true;
             warn!("The input data has fractional sample counts that will be truncated to integers. If you need to retain the extra precision you can scale up the sample data and use the --factor option to scale it back down.");
         }

--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -196,7 +196,10 @@ fn parse_nsamples(line: &mut &str, stripped_fractional_samples: &mut bool) -> Op
     // use the --factor option. See https://github.com/brendangregg/FlameGraph/pull/18
     if let Some(doti) = samples.find('.') {
         // Warn if we're stripping a non-zero fractional part, but only the first time.
-        if !*stripped_fractional_samples && !samples[doti + 1..].chars().all(|c| c == '0') {
+        if !*stripped_fractional_samples
+            && samples[..doti].chars().all(|c| c.is_digit(10))
+            && !samples[doti + 1..].chars().all(|c| c == '0')
+        {
             *stripped_fractional_samples = true;
             warn!("The input data has fractional sample counts that will be truncated to integers. If you need to retain the extra precision you can scale up the sample data and use the --factor option to scale it back down.");
         }

--- a/tests/data/fractional-samples/tricky-stack.txt
+++ b/tests/data/fractional-samples/tricky-stack.txt
@@ -1,0 +1,1 @@
+rustc;<alloc::vec::Vec<T> as alloc::vec::SpecExtend<T, I>>::from_iter;memcpy@GLIBC_2.2.5 3

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -213,6 +213,27 @@ fn flamegraph_should_not_warn_about_zero_fractional_samples() {
 }
 
 #[test]
+fn flamegraph_should_not_warn_about_fractional_sample_with_tricky_stack() {
+    test_flamegraph_logs(
+        "./tests/data/fractional-samples/tricky-stack.txt",
+        |captured_logs| {
+            let nwarnings = captured_logs
+                .into_iter()
+                .filter(|log| {
+                    log.body
+                        .starts_with("The input data has fractional sample counts")
+                        && log.level == Level::Warn
+                })
+                .count();
+            assert_eq!(
+                nwarnings, 0,
+                "warning about fractional samples not expected"
+            );
+        },
+    );
+}
+
+#[test]
 fn flamegraph_palette_map() {
     let input_file = "./flamegraph/test/results/perf-vertx-stacks-01-collapsed-all.txt";
     let expected_result_file = "./tests/data/palette-map/consistent-palette.svg";


### PR DESCRIPTION
While testing inferno-flamegraph on some Rust profiles I noticed I was getting some false positives for the fractional samples warning. It was because of lines like this.
```
rustc;<alloc::vec::Vec<T> as alloc::vec::SpecExtend<T, I>>::from_iter;memcpy@GLIBC_2.2.5 3
```
The `3` gets correctly parsed as a sample, but then we check for another sample in case we're creating a differential flame graph. It falsely detects `I>>::from_iter;memcpy@GLIBC_2.2.5` as a fractional sample since it ends in `.5`.

This change makes sure that the part before the `.` is all digits.