### PR TITLE
Fix coverage timeouts caused by cli tests

### DIFF
--- a/src/bin/collapse-dtrace.rs
+++ b/src/bin/collapse-dtrace.rs
@@ -61,5 +61,5 @@ fn main() -> io::Result<()> {
     }
 
     let (infile, options) = opt.into_parts();
-    Folder::from(options).collapse_file(infile.as_ref())
+    Folder::from(options).collapse_file(infile.as_ref(), io::stdout().lock())
 }

--- a/src/bin/collapse-perf.rs
+++ b/src/bin/collapse-perf.rs
@@ -90,5 +90,5 @@ fn main() -> io::Result<()> {
     }
 
     let (infile, options) = opt.into_parts();
-    Folder::from(options).collapse_file(infile.as_ref())
+    Folder::from(options).collapse_file(infile.as_ref(), io::stdout().lock())
 }

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -103,32 +103,6 @@ impl<'a> Opt {
 
 const PALETTE_MAP_FILE: &str = "palette.map"; // default name for the palette map file
 
-impl<'a> Into<Options<'a>> for Opt {
-    fn into(self) -> Options<'a> {
-        let mut options = Options::default();
-        options.colors = self.colors;
-        options.bgcolors = self.bgcolors;
-        options.hash = self.hash;
-        if let Some(file) = self.nameattr_file {
-            match FuncFrameAttrsMap::from_file(&file) {
-                Ok(m) => {
-                    options.func_frameattrs = m;
-                }
-                Err(e) => panic!("Error reading {}: {:?}", file.display(), e),
-            }
-        };
-        if self.inverted {
-            options.direction = Direction::Inverted;
-            options.title = "Icicle Graph".to_string();
-        }
-        options.negate_differentials = self.negate;
-        options.factor = self.factor;
-        options.pretty_xml = self.pretty_xml;
-        options.no_javascript = self.no_javascript;
-        options
-    }
-}
-
 fn main() -> quick_xml::Result<()> {
     let opt = Opt::from_args();
 

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -1,6 +1,5 @@
 use env_logger::Env;
-use std::fs::File;
-use std::io::{self, BufReader, Read};
+use std::io;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
@@ -76,6 +75,32 @@ struct Opt {
     no_javascript: bool,
 }
 
+impl<'a> Opt {
+    fn into_parts(self) -> (Vec<PathBuf>, Options<'a>) {
+        let mut options = Options::default();
+        options.colors = self.colors;
+        options.bgcolors = self.bgcolors;
+        options.hash = self.hash;
+        if let Some(file) = self.nameattr_file {
+            match FuncFrameAttrsMap::from_file(&file) {
+                Ok(m) => {
+                    options.func_frameattrs = m;
+                }
+                Err(e) => panic!("Error reading {}: {:?}", file.display(), e),
+            }
+        };
+        if self.inverted {
+            options.direction = Direction::Inverted;
+            options.title = "Icicle Graph".to_string();
+        }
+        options.negate_differentials = self.negate;
+        options.factor = self.factor;
+        options.pretty_xml = self.pretty_xml;
+        options.no_javascript = self.no_javascript;
+        (self.infiles, options)
+    }
+}
+
 const PALETTE_MAP_FILE: &str = "palette.map"; // default name for the palette map file
 
 impl<'a> Into<Options<'a>> for Opt {
@@ -124,52 +149,11 @@ fn main() -> quick_xml::Result<()> {
         Err(e) => panic!("Error reading {}: {:?}", PALETTE_MAP_FILE, e),
     };
 
-    if opt.infiles.is_empty() || opt.infiles.len() == 1 && opt.infiles[0].to_str() == Some("-") {
-        let stdin = io::stdin();
-        let r = BufReader::with_capacity(128 * 1024, stdin.lock());
-        flamegraph::from_reader(
-            build_options(opt, palette_map.as_mut()),
-            r,
-            io::stdout().lock(),
-        )?;
-    } else if opt.infiles.len() == 1 {
-        let r = File::open(&opt.infiles[0]).map_err(quick_xml::Error::Io)?;
-        flamegraph::from_reader(
-            build_options(opt, palette_map.as_mut()),
-            r,
-            io::stdout().lock(),
-        )?;
-    } else {
-        let stdin = io::stdin();
-        let mut stdin_added = false;
-        let mut readers: Vec<Box<Read>> = Vec::with_capacity(opt.infiles.len());
-        for infile in opt.infiles.iter() {
-            if infile.to_str() == Some("-") {
-                if !stdin_added {
-                    let r = BufReader::with_capacity(128 * 1024, stdin.lock());
-                    readers.push(Box::new(r));
-                    stdin_added = true;
-                }
-            } else {
-                let r = File::open(infile).map_err(quick_xml::Error::Io)?;
-                readers.push(Box::new(r));
-            }
-        }
+    let (infiles, mut options) = opt.into_parts();
+    options.palette_map = palette_map.as_mut();
 
-        flamegraph::from_readers(
-            build_options(opt, palette_map.as_mut()),
-            readers,
-            io::stdout().lock(),
-        )?;
-    }
-
+    flamegraph::from_files(options, infiles, io::stdout().lock())?;
     save_consistent_palette_if_needed(&palette_map, PALETTE_MAP_FILE).map_err(quick_xml::Error::Io)
-}
-
-fn build_options(opt: Opt, palette_map: Option<&mut PaletteMap>) -> Options {
-    let mut options: Options = opt.into();
-    options.palette_map = palette_map;
-    options
 }
 
 fn fetch_consistent_palette_if_needed(

--- a/src/collapse/mod.rs
+++ b/src/collapse/mod.rs
@@ -13,7 +13,7 @@ pub mod dtrace;
 pub mod perf;
 
 use std::fs::File;
-use std::io;
+use std::io::{self, Write};
 use std::path::Path;
 
 const READER_CAPACITY: usize = 128 * 1024;
@@ -38,13 +38,12 @@ pub trait Collapse {
         W: io::Write;
 
     /// Collapses the contents of a file (or of STDIN if `infile` is `None`) and writes folded
-    /// stack lines to `STDOUT`.
-    fn collapse_file<P>(&mut self, infile: Option<P>) -> io::Result<()>
+    /// stack lines to provided `writer`.
+    fn collapse_file<P, W>(&mut self, infile: Option<P>, writer: W) -> io::Result<()>
     where
         P: AsRef<Path>,
+        W: Write,
     {
-        let stdout = io::stdout();
-        let writer = stdout.lock();
         match infile {
             Some(ref path) => {
                 let file = File::open(path)?;

--- a/tests/collapse-dtrace.rs
+++ b/tests/collapse-dtrace.rs
@@ -7,9 +7,7 @@ mod collapse_common;
 
 use collapse_common::*;
 use inferno::collapse::dtrace::{Folder, Options};
-use std::fs::File;
-use std::io::{self, BufReader, Cursor};
-use std::process::{Command, Stdio};
+use std::io;
 
 fn test_collapse_dtrace(test_file: &str, expected_file: &str, options: Options) -> io::Result<()> {
     test_collapse(Folder::from(options), test_file, expected_file)
@@ -60,37 +58,4 @@ fn collapse_dtrace_compare_to_flamegraph_bug() {
         },
     )
     .unwrap()
-}
-
-#[test]
-fn collapse_dtrace_cli() {
-    let input_file = "./flamegraph/example-dtrace-stacks.txt";
-    let expected_file = "./tests/data/collapse-dtrace/results/dtrace-example.txt";
-
-    // Test with file passed in
-    let output = Command::new("cargo")
-        .arg("run")
-        .arg("--bin")
-        .arg("inferno-collapse-dtrace")
-        .arg(input_file)
-        .output()
-        .expect("failed to execute process");
-    let expected = BufReader::new(File::open(expected_file).unwrap());
-    compare_results(Cursor::new(output.stdout), expected, expected_file);
-
-    // Test with STDIN
-    let mut child = Command::new("cargo")
-        .arg("run")
-        .arg("--bin")
-        .arg("inferno-collapse-dtrace")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn child process");
-    let mut input = BufReader::new(File::open(input_file).unwrap());
-    let stdin = child.stdin.as_mut().expect("Failed to open stdin");
-    io::copy(&mut input, stdin).unwrap();
-    let output = child.wait_with_output().expect("Failed to read stdout");
-    let expected = BufReader::new(File::open(expected_file).unwrap());
-    compare_results(Cursor::new(output.stdout), expected, expected_file);
 }

--- a/tests/collapse_common/mod.rs
+++ b/tests/collapse_common/mod.rs
@@ -13,18 +13,18 @@ pub(crate) fn test_collapse<C>(
 where
     C: Collapse,
 {
-    let test_file =
-        File::open(test_filename).expect(&format!("Test file {} not found.", test_filename));
-    let r: Box<BufRead> = if test_filename.ends_with(".gz") {
-        Box::new(BufReader::new(Decoder::new(test_file).unwrap()))
-    } else {
-        Box::new(BufReader::new(test_file))
-    };
     let expected_len = fs::metadata(expected_filename)
         .expect(&format!("Result file {} not found.", expected_filename))
         .len() as usize;
     let mut result = Cursor::new(Vec::with_capacity(expected_len));
-    let return_value = collapser.collapse(r, &mut result);
+    let return_value = if test_filename.ends_with(".gz") {
+        let test_file =
+            File::open(test_filename).expect(&format!("Test file {} not found.", test_filename));
+        let r = BufReader::new(Decoder::new(test_file).unwrap());
+        collapser.collapse(r, &mut result)
+    } else {
+        collapser.collapse_file(Some(test_filename), &mut result)
+    };
     let expected = BufReader::new(
         File::open(expected_filename)
             .expect(&format!("Result file {} not found.", expected_filename)),


### PR DESCRIPTION
I removed tests that call out to the CLIs and instead test much of what the main functions did.

I added `from_files` to flamegraph and moved most of the main function over to it. The tests now use this instead of calling `from_reader` or `from_readers` directly.

The collapse tests now call `collapse_file` instead of calling `collapse` directly, unless the file is a gzip. I had to change `collapse_file` to take a writer instead of always writing to STDOUT so it could be used in tests.