### PR TITLE
Performance improvements on the dtrace collapser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ quick-xml = "0.13.3"
 num-format = { version = "0.4", default-features = false }
 str_stack = "0.1"
 indexmap = "1.0"
+hashbrown = "0.1"
 rand = "0.6.5"
 structopt = { version = "0.2", optional = true }
 env_logger = { version = "0.6.0", optional = true }

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -114,7 +114,7 @@ impl From<Options> for Folder {
     fn from(opt: Options) -> Self {
         Self {
             stack: VecDeque::default(),
-            occurrences: HashMap::default(),
+            occurrences: HashMap::with_capacity(100),
             cache_inlines: Vec::new(),
             opt,
             stack_str_size: 0,

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -138,7 +138,7 @@ impl Folder {
     }
 
     fn remove_offset(line: &str) -> &str {
-        if let Some(offset) = line.find('+') {
+        if let Some(offset) = line.rfind('+') {
             &line[..offset]
         } else {
             line
@@ -153,7 +153,6 @@ impl Folder {
     //     unix`sys_syscall+0x10e
     //       1
     fn on_stack_line(&mut self, line: &str) {
-        let line = line.trim_start();
         let frame = if self.opt.includeoffset {
             line
         } else {
@@ -192,7 +191,7 @@ impl Folder {
             if first {
                 first = false
             } else {
-                stack_str.push_str(";");
+                stack_str.push(';');
             }
             //trim leaf offset if these were retained:
             if self.opt.includeoffset && i == last {

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -142,6 +142,9 @@ impl Folder {
         let mut could_be_cpp = false;
         let mut has_semicolon = false;
         let mut last_offset = line.len() - 1;
+        // This seems risly but dtrace stacks are c-strings as can be seen in the function
+        // responsible for printing them:
+        // https://github.com/opendtrace/opendtrace/blob/1a03ea5576a9219a43f28b4f159ff8a4b1f9a9fd/lib/libdtrace/common/dt_consume.c#L1331
         let bytes = line.as_bytes();
         for offset in 0..bytes.len() {
             match bytes[offset] {

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -114,7 +114,7 @@ impl From<Options> for Folder {
     fn from(opt: Options) -> Self {
         Self {
             stack: VecDeque::default(),
-            occurrences: HashMap::with_capacity(100),
+            occurrences: HashMap::with_capacity(512),
             cache_inlines: Vec::new(),
             opt,
             stack_str_size: 0,
@@ -194,12 +194,10 @@ impl Folder {
             while let Some(func) = self.cache_inlines.pop() {
                 self.stack.push_front(func);
             }
+        } else if has_colon {
+            self.stack.push_front(frame.replace(';', ":"))
         } else {
-            if has_colon {
-                self.stack.push_front(frame.replace(';', ":"))
-            } else {
-                self.stack.push_front(frame.to_owned())
-            }
+            self.stack.push_front(frame.to_owned())
         }
     }
 

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -208,10 +208,10 @@ impl Folder {
     }
 
     fn finish<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        let mut keys: Vec<_> = self.occurrences.keys().collect();
+        let mut keys: Vec<(&String, &usize)> = self.occurrences.iter().collect();
         keys.sort();
-        for key in keys {
-            writeln!(writer, "{} {}", key, self.occurrences[key])?;
+        for (key, count) in keys {
+            writeln!(writer, "{} {}", key, count)?;
         }
         Ok(())
     }

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -1,5 +1,6 @@
 use super::Collapse;
-use std::collections::{HashMap, VecDeque};
+use hashbrown::HashMap;
+use std::collections::VecDeque;
 use std::io;
 use std::io::prelude::*;
 

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -141,7 +141,7 @@ impl Folder {
         let mut has_inlines = false;
         let mut could_be_cpp = false;
         let mut has_semicolon = false;
-        let mut last_offset = line.len() - 1;
+        let mut last_offset = line.len();
         // This seems risly but dtrace stacks are c-strings as can be seen in the function
         // responsible for printing them:
         // https://github.com/opendtrace/opendtrace/blob/1a03ea5576a9219a43f28b4f159ff8a4b1f9a9fd/lib/libdtrace/common/dt_consume.c#L1331

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -141,17 +141,23 @@ impl Folder {
         let mut has_inlines = false;
         let mut could_be_cpp = false;
         let mut has_semicolon = false;
+        let mut last_offset = line.len() - 1;
         let bytes = line.as_bytes();
         for offset in 0..bytes.len() {
             match bytes[offset] {
                 b'>' if offset > 0 && bytes[offset - 1] == b'-' => has_inlines = true,
                 b':' if offset > 0 && bytes[offset - 1] == b':' => could_be_cpp = true,
                 b';' => has_semicolon = true,
-                b'+' => return (has_inlines, could_be_cpp, has_semicolon, &line[..offset]),
+                b'+' => last_offset = offset,
                 _ => (),
             }
         }
-        (has_inlines, could_be_cpp, has_semicolon, line)
+        (
+            has_inlines,
+            could_be_cpp,
+            has_semicolon,
+            &line[..last_offset],
+        )
     }
 
     // we have a stack line that shows one stack entry from the preceeding event, like:

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -138,13 +138,10 @@ impl Folder {
     }
 
     fn remove_offset(line: &str) -> &str {
-        let mut line = line.rsplitn(2, '+');
-        // at least one element will be returned
-        let second = line.next().unwrap();
-        if let Some(first) = line.next() {
-            first
+        if let Some(offset) = line.find('+') {
+            &line[..offset]
         } else {
-            second
+            line
         }
     }
 

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -394,10 +394,10 @@ impl Folder {
     }
 
     fn finish<W: Write>(&self, mut writer: W) -> io::Result<()> {
-        let mut keys: Vec<_> = self.occurrences.keys().collect();
+        let mut keys: Vec<_> = self.occurrences.iter().collect();
         keys.sort();
-        for key in keys {
-            writeln!(writer, "{} {}", key, self.occurrences[key])?;
+        for (key, value) in keys {
+            writeln!(writer, "{} {}", key, value)?;
         }
         Ok(())
     }

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -1,5 +1,6 @@
 use super::Collapse;
-use std::collections::{HashMap, VecDeque};
+use hashbrown::HashMap;
+use std::collections::VecDeque;
 use std::io;
 use std::io::prelude::*;
 

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -159,7 +159,7 @@ impl From<Options> for Folder {
             skip_stack: false,
             stack: VecDeque::default(),
             cache_line: Vec::default(),
-            occurrences: HashMap::default(),
+            occurrences: HashMap::with_capacity(512),
             pname: String::new(),
             event_filtering: EventFilterState::None,
             opt,


### PR DESCRIPTION
Each change is one commit with perf delta appended.
Overall towards master:

```
collapse/dtrace         time:   [11.244 ms 11.398 ms 11.585 ms]
                        thrpt:  [113.80 MiB/s 115.68 MiB/s 117.25 MiB/s]
                 change:
                        time:   [-39.575% -37.504% -35.438%] (p = 0.00 < 0.05)
                        thrpt:  [+54.891% +60.011% +65.493%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```