### PR TITLE
Unify defaults across CLI and impl Default

### DIFF
--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -96,8 +96,8 @@ struct Opt {
     name_type: String,
 
     /// Set embedded notes in SVG
-    #[structopt(long = "notes", raw(default_value = "defaults::NOTES.strval"))]
-    notes: String,
+    #[structopt(long = "notes")]
+    notes: Option<String>,
 
     /// Switch differential hues (green<->red)
     #[structopt(long = "negate")]
@@ -174,7 +174,9 @@ impl<'a> Opt {
         options.font_width = self.font_width;
         options.count_name = self.count_name;
         options.name_type = self.name_type;
-        options.notes = self.notes;
+        if let Some(notes) = self.notes {
+            options.notes = notes;
+        }
         options.negate_differentials = self.negate;
         options.factor = self.factor;
         options.search_color = self.search_color;

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -29,7 +29,7 @@ struct Opt {
     #[structopt(
         short = "c",
         long = "colors",
-        raw(default_value = "defaults::COLORS.strval"),
+        raw(default_value = "defaults::str::COLORS"),
         raw(
             possible_values = r#"&["hot","mem","io","wakeup","java","js","perl","red","green","blue","aqua","yellow","purple","orange"]"#
         )
@@ -51,12 +51,12 @@ struct Opt {
     /// Search color
     #[structopt(
         long = "search-color",
-        raw(default_value = "defaults::SEARCH_COLOR.strval")
+        raw(default_value = "defaults::str::SEARCH_COLOR")
     )]
     search_color: SearchColor,
 
     /// Change title text
-    #[structopt(long = "title", raw(default_value = "defaults::TITLE.strval"))]
+    #[structopt(long = "title", raw(default_value = "defaults::str::TITLE"))]
     title: String,
 
     /// Second level title (optional)
@@ -64,35 +64,35 @@ struct Opt {
     subtitle: Option<String>,
 
     /// Width of image
-    #[structopt(long = "width", raw(default_value = "defaults::IMAGE_WIDTH.strval"))]
+    #[structopt(long = "width", raw(default_value = "defaults::str::IMAGE_WIDTH"))]
     image_width: usize,
 
     /// Height of each frame
-    #[structopt(long = "height", raw(default_value = "defaults::FRAME_HEIGHT.strval"))]
+    #[structopt(long = "height", raw(default_value = "defaults::str::FRAME_HEIGHT"))]
     frame_height: usize,
 
     /// Omit smaller functions (default 0.1 pixels)
-    #[structopt(long = "minwidth", raw(default_value = "defaults::MIN_WIDTH.strval"))]
+    #[structopt(long = "minwidth", raw(default_value = "defaults::str::MIN_WIDTH"))]
     min_width: f64,
 
     /// Font type
-    #[structopt(long = "fonttype", raw(default_value = "defaults::FONT_TYPE.strval"))]
+    #[structopt(long = "fonttype", raw(default_value = "defaults::str::FONT_TYPE"))]
     font_type: String,
 
     /// Font size
-    #[structopt(long = "fontsize", raw(default_value = "defaults::FONT_SIZE.strval"))]
+    #[structopt(long = "fontsize", raw(default_value = "defaults::str::FONT_SIZE"))]
     font_size: usize,
 
     /// Font width
-    #[structopt(long = "fontwidth", raw(default_value = "defaults::FONT_WIDTH.strval"))]
+    #[structopt(long = "fontwidth", raw(default_value = "defaults::str::FONT_WIDTH"))]
     font_width: f64,
 
     /// Count type label
-    #[structopt(long = "countname", raw(default_value = "defaults::COUNT_NAME.strval"))]
+    #[structopt(long = "countname", raw(default_value = "defaults::str::COUNT_NAME"))]
     count_name: String,
 
     /// Name type label
-    #[structopt(long = "nametype", raw(default_value = "defaults::NAME_TYPE.strval"))]
+    #[structopt(long = "nametype", raw(default_value = "defaults::str::NAME_TYPE"))]
     name_type: String,
 
     /// Set embedded notes in SVG
@@ -104,7 +104,7 @@ struct Opt {
     negate: bool,
 
     /// Factor to scale sample counts by
-    #[structopt(long = "factor", raw(default_value = "defaults::FACTOR.strval"))]
+    #[structopt(long = "factor", raw(default_value = "defaults::str::FACTOR"))]
     factor: f64,
 
     /// Silence all log output
@@ -153,7 +153,7 @@ impl<'a> Opt {
         };
         if self.inverted {
             options.direction = Direction::Inverted;
-            if self.title == defaults::TITLE.strval {
+            if self.title == defaults::TITLE {
                 options.title = "Icicle Graph".to_string();
             }
         }

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
 use inferno::flamegraph::{
-    self, color::BackgroundColor, color::PaletteMap, color::SearchColor, Direction,
-    FuncFrameAttrsMap, Options, Palette, DEFAULT_TITLE,
+    self, color::BackgroundColor, color::PaletteMap, color::SearchColor, defaults, Direction,
+    FuncFrameAttrsMap, Options, Palette,
 };
 
 #[derive(Debug, StructOpt)]
@@ -29,7 +29,7 @@ struct Opt {
     #[structopt(
         short = "c",
         long = "colors",
-        default_value = "hot",
+        raw(default_value = "defaults::COLORS.strval"),
         raw(
             possible_values = r#"&["hot","mem","io","wakeup","java","js","perl","red","green","blue","aqua","yellow","purple","orange"]"#
         )
@@ -49,11 +49,14 @@ struct Opt {
     cp: bool,
 
     /// Search color
-    #[structopt(long = "search-color", default_value = "#e600e6")]
+    #[structopt(
+        long = "search-color",
+        raw(default_value = "defaults::SEARCH_COLOR.strval")
+    )]
     search_color: SearchColor,
 
     /// Change title text
-    #[structopt(long = "title", default_value = "Flame Graph")]
+    #[structopt(long = "title", raw(default_value = "defaults::TITLE.strval"))]
     title: String,
 
     /// Second level title (optional)
@@ -61,39 +64,39 @@ struct Opt {
     subtitle: Option<String>,
 
     /// Width of image
-    #[structopt(long = "width", default_value = "1200")]
+    #[structopt(long = "width", raw(default_value = "defaults::IMAGE_WIDTH.strval"))]
     image_width: usize,
 
     /// Height of each frame
-    #[structopt(long = "height", default_value = "16")]
+    #[structopt(long = "height", raw(default_value = "defaults::FRAME_HEIGHT.strval"))]
     frame_height: usize,
 
     /// Omit smaller functions (default 0.1 pixels)
-    #[structopt(long = "minwidth", default_value = "0.1")]
+    #[structopt(long = "minwidth", raw(default_value = "defaults::MIN_WIDTH.strval"))]
     min_width: f64,
 
     /// Font type
-    #[structopt(long = "fonttype", default_value = "Verdana")]
+    #[structopt(long = "fonttype", raw(default_value = "defaults::FONT_TYPE.strval"))]
     font_type: String,
 
     /// Font size
-    #[structopt(long = "fontsize", default_value = "12")]
+    #[structopt(long = "fontsize", raw(default_value = "defaults::FONT_SIZE.strval"))]
     font_size: usize,
 
     /// Font width
-    #[structopt(long = "fontwidth", default_value = "0.59")]
+    #[structopt(long = "fontwidth", raw(default_value = "defaults::FONT_WIDTH.strval"))]
     font_width: f64,
 
     /// Count type label
-    #[structopt(long = "countname", default_value = "samples")]
+    #[structopt(long = "countname", raw(default_value = "defaults::COUNT_NAME.strval"))]
     count_name: String,
 
     /// Name type label
-    #[structopt(long = "nametype", default_value = "Function:")]
+    #[structopt(long = "nametype", raw(default_value = "defaults::NAME_TYPE.strval"))]
     name_type: String,
 
     /// Set embedded notes in SVG
-    #[structopt(long = "notes", default_value = "")]
+    #[structopt(long = "notes", raw(default_value = "defaults::NOTES.strval"))]
     notes: String,
 
     /// Switch differential hues (green<->red)
@@ -101,7 +104,7 @@ struct Opt {
     negate: bool,
 
     /// Factor to scale sample counts by
-    #[structopt(long = "factor", default_value = "1.0")]
+    #[structopt(long = "factor", raw(default_value = "defaults::FACTOR.strval"))]
     factor: f64,
 
     /// Silence all log output
@@ -150,7 +153,7 @@ impl<'a> Opt {
         };
         if self.inverted {
             options.direction = Direction::Inverted;
-            if self.title == DEFAULT_TITLE {
+            if self.title == defaults::TITLE.strval {
                 options.title = "Icicle Graph".to_string();
             }
         }

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -168,16 +168,6 @@ fn parse_flat_bgcolor(s: &str) -> Option<Color> {
 #[derive(Clone, Copy, Debug)]
 pub struct SearchColor(Color);
 
-impl Default for SearchColor {
-    fn default() -> Self {
-        SearchColor(Color {
-            r: 230,
-            g: 0,
-            b: 230,
-        })
-    }
-}
-
 impl FromStr for SearchColor {
     type Err = String;
 

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -26,15 +26,6 @@ const FRAMEPAD: usize = 1; // vertical padding for frames
 
 /// Default values for [`Options`].
 pub mod defaults {
-    /// Default value with a string representation
-    pub struct DefaultValue<T> {
-        /// Default value
-        pub value: T,
-
-        /// Default value string representation
-        pub strval: &'static str,
-    }
-
     macro_rules! doc {
         ($str:expr, $($def:tt)*) => {
             #[doc = $str]
@@ -43,29 +34,37 @@ pub mod defaults {
     }
 
     macro_rules! define {
-        ($name:ident : $t:ty = $val:tt) => {
-            doc!(
-                concat!("`", stringify!($val), "`"),
-                pub const $name: DefaultValue<$t> = DefaultValue {
-                    value: $val,
-                    strval: stringify!($val),
-                };
-            );
-        };
+        ($($name:ident : $t:ty = $val:tt),*) => {
+            $(
+                doc!(
+                    concat!("`", stringify!($val), "`"),
+                    pub const $name: $t = $val;
+                );
+            )*
+
+            #[doc(hidden)]
+            pub mod str {
+            $(
+                pub const $name: &str = stringify!($val);
+            )*
+            }
+        }
     }
 
-    define!(COLORS: &str = "hot");
-    define!(SEARCH_COLOR: &str = "#e600e6");
-    define!(TITLE: &str = "Flame Graph");
-    define!(IMAGE_WIDTH: usize = 1200);
-    define!(FRAME_HEIGHT: usize = 16);
-    define!(MIN_WIDTH: f64 = 0.1);
-    define!(FONT_TYPE: &str = "Verdana");
-    define!(FONT_SIZE: usize = 12);
-    define!(FONT_WIDTH: f64 = 0.59);
-    define!(COUNT_NAME: &str = "samples");
-    define!(NAME_TYPE: &str = "Function:");
-    define!(FACTOR: f64 = 1.0);
+    define! {
+        COLORS: &str = "hot",
+        SEARCH_COLOR: &str = "#e600e6",
+        TITLE: &str = "Flame Graph",
+        IMAGE_WIDTH: usize = 1200,
+        FRAME_HEIGHT: usize = 16,
+        MIN_WIDTH: f64 = 0.1,
+        FONT_TYPE: &str = "Verdana",
+        FONT_SIZE: usize = 12,
+        FONT_WIDTH: f64 = 0.59,
+        COUNT_NAME: &str = "samples",
+        NAME_TYPE: &str = "Function:",
+        FACTOR: f64 = 1.0
+    }
 }
 
 /// Configure the flame graph.
@@ -222,18 +221,18 @@ impl<'a> Options<'a> {
 impl<'a> Default for Options<'a> {
     fn default() -> Self {
         Options {
-            colors: Palette::from_str(defaults::COLORS.value).unwrap(),
-            search_color: SearchColor::from_str(defaults::SEARCH_COLOR.value).unwrap(),
-            title: defaults::TITLE.value.to_string(),
-            image_width: defaults::IMAGE_WIDTH.value,
-            frame_height: defaults::FRAME_HEIGHT.value,
-            min_width: defaults::MIN_WIDTH.value,
-            font_type: defaults::FONT_TYPE.value.to_string(),
-            font_size: defaults::FONT_SIZE.value,
-            font_width: defaults::FONT_WIDTH.value,
-            count_name: defaults::COUNT_NAME.value.to_string(),
-            name_type: defaults::NAME_TYPE.value.to_string(),
-            factor: defaults::FACTOR.value,
+            colors: Palette::from_str(defaults::COLORS).unwrap(),
+            search_color: SearchColor::from_str(defaults::SEARCH_COLOR).unwrap(),
+            title: defaults::TITLE.to_string(),
+            image_width: defaults::IMAGE_WIDTH,
+            frame_height: defaults::FRAME_HEIGHT,
+            min_width: defaults::MIN_WIDTH,
+            font_type: defaults::FONT_TYPE.to_string(),
+            font_size: defaults::FONT_SIZE,
+            font_width: defaults::FONT_WIDTH,
+            count_name: defaults::COUNT_NAME.to_string(),
+            name_type: defaults::NAME_TYPE.to_string(),
+            factor: defaults::FACTOR,
             notes: Default::default(),
             subtitle: Default::default(),
             bgcolors: Default::default(),

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -24,9 +24,9 @@ use svg::StyleOptions;
 const XPAD: usize = 10; // pad lefm and right
 const FRAMEPAD: usize = 1; // vertical padding for frames
 
-/// Default values for `Options`
-#[doc(hidden)]
+/// Default values for [`Options`].
 pub mod defaults {
+    /// Default value with a string representation
     pub struct DefaultValue<T> {
         /// Default value
         pub value: T,
@@ -35,12 +35,22 @@ pub mod defaults {
         pub strval: &'static str,
     }
 
+    macro_rules! doc {
+        ($str:expr, $($def:tt)*) => {
+            #[doc = $str]
+            $($def)*
+        };
+    }
+
     macro_rules! define {
         ($name:ident : $t:ty = $val:tt) => {
-            pub const $name: DefaultValue<$t> = DefaultValue {
-                value: $val,
-                strval: stringify!($val),
-            };
+            doc!(
+                concat!("`", stringify!($val), "`"),
+                pub const $name: DefaultValue<$t> = DefaultValue {
+                    value: $val,
+                    strval: stringify!($val),
+                };
+            );
         };
     }
 
@@ -55,7 +65,6 @@ pub mod defaults {
     define!(FONT_WIDTH: f64 = 0.59);
     define!(COUNT_NAME: &str = "samples");
     define!(NAME_TYPE: &str = "Function:");
-    define!(NOTES: &str = "");
     define!(FACTOR: f64 = 1.0);
 }
 
@@ -96,64 +105,62 @@ pub struct Options<'a> {
     /// Whether to plot a plot that grows top-to-bottom or bottom-up (the default).
     pub direction: Direction,
 
-    /// The search color for flame chart.
+    /// The search color for flame graph.
     ///
-    /// Defaults to `rgb(230,0,230)`.
+    /// [Default value](defaults::SEARCH_COLOR)
     pub search_color: SearchColor,
 
-    /// The title for the flame chart.
+    /// The title for the flame graph.
     ///
-    /// Defaults to "Flame Graph".
+    /// [Default value](defaults::TITLE)
     pub title: String,
 
-    /// The subtitle for the flame chart.
+    /// The subtitle for the flame graph.
     ///
     /// Defaults to None.
     pub subtitle: Option<String>,
 
-    /// Width of for the flame chart
+    /// Width of for the flame graph
     ///
-    /// Defaults to 1200.
+    /// [Default value](defaults::IMAGE_WIDTH)
     pub image_width: usize,
 
     /// Height of each frame.
     ///
-    /// Defaults to 16.
+    /// [Default value](defaults::FRAME_HEIGHT)
     pub frame_height: usize,
 
     /// Minimal width to omit smaller functions
     ///
-    /// Defaults to 0.1.
+    /// [Default value](defaults::MIN_WIDTH)
     pub min_width: f64,
 
-    /// The font type for the flame chart.
+    /// The font type for the flame graph.
     ///
-    /// Defaults to "Verdana".
+    /// [Default value](defaults::FONT_TYPE)
     pub font_type: String,
 
-    /// Font size for the flame chart.
+    /// Font size for the flame graph.
     ///
-    /// Defaults to 12.
+    /// [Default value](defaults::FONT_SIZE)
     pub font_size: usize,
 
-    /// Font width for the flame chart.
+    /// Font width for the flame graph.
     ///
-    /// Defaults to 0.59.
+    /// [Default value](defaults::FONT_WIDTH)
     pub font_width: f64,
 
-    /// Count type label for the flame chart.
+    /// Count type label for the flame graph.
     ///
-    /// Defaults to "samples".
+    /// [Default value](defaults::COUNT_NAME)
     pub count_name: String,
 
-    /// Name type label for the flame chart.
+    /// Name type label for the flame graph.
     ///
-    /// Defaults to "Function:".
+    /// [Default value](defaults::NAME_TYPE)
     pub name_type: String,
 
-    /// The notes for the flame chart.
-    ///
-    /// Defaults to "".
+    /// The notes for the flame graph.
     pub notes: String,
 
     /// By default, if [differential] samples are included in the provided stacks, the resulting
@@ -172,7 +179,7 @@ pub struct Options<'a> {
     /// For example, if you have `23.4` as a sample count you can upscale it to `234`, then set `factor`
     /// to `0.1`.
     ///
-    /// Defaults to 1.0.
+    /// [Default value](defaults::FACTOR)
     pub factor: f64,
 
     /// Pretty print XML with newlines and indentation.
@@ -226,8 +233,8 @@ impl<'a> Default for Options<'a> {
             font_width: defaults::FONT_WIDTH.value,
             count_name: defaults::COUNT_NAME.value.to_string(),
             name_type: defaults::NAME_TYPE.value.to_string(),
-            notes: defaults::NOTES.value.to_string(),
             factor: defaults::FACTOR.value,
+            notes: Default::default(),
             subtitle: Default::default(),
             bgcolors: Default::default(),
             hash: Default::default(),

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -17,14 +17,47 @@ use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::iter;
 use std::path::PathBuf;
+use std::str::FromStr;
 use str_stack::StrStack;
 use svg::StyleOptions;
 
 const XPAD: usize = 10; // pad lefm and right
 const FRAMEPAD: usize = 1; // vertical padding for frames
 
-/// Default title
-pub const DEFAULT_TITLE: &str = "Flame Graph";
+/// Default values for `Options`
+#[doc(hidden)]
+pub mod defaults {
+    pub struct DefaultValue<T> {
+        /// Default value
+        pub value: T,
+
+        /// Default value string representation
+        pub strval: &'static str,
+    }
+
+    macro_rules! define {
+        ($name:ident : $t:ty = $val:tt) => {
+            pub const $name: DefaultValue<$t> = DefaultValue {
+                value: $val,
+                strval: stringify!($val),
+            };
+        };
+    }
+
+    define!(COLORS: &str = "hot");
+    define!(SEARCH_COLOR: &str = "#e600e6");
+    define!(TITLE: &str = "Flame Graph");
+    define!(IMAGE_WIDTH: usize = 1200);
+    define!(FRAME_HEIGHT: usize = 16);
+    define!(MIN_WIDTH: f64 = 0.1);
+    define!(FONT_TYPE: &str = "Verdana");
+    define!(FONT_SIZE: usize = 12);
+    define!(FONT_WIDTH: f64 = 0.59);
+    define!(COUNT_NAME: &str = "samples");
+    define!(NAME_TYPE: &str = "Function:");
+    define!(NOTES: &str = "");
+    define!(FACTOR: f64 = 1.0);
+}
 
 /// Configure the flame graph.
 #[derive(Debug)]
@@ -182,23 +215,23 @@ impl<'a> Options<'a> {
 impl<'a> Default for Options<'a> {
     fn default() -> Self {
         Options {
-            title: DEFAULT_TITLE.to_string(),
-            subtitle: None,
-            image_width: 1200,
-            frame_height: 16,
-            min_width: 0.1,
-            font_type: "Verdana".to_owned(),
-            font_size: 12,
-            font_width: 0.59,
-            count_name: "samples".to_owned(),
-            name_type: "Function:".to_owned(),
-            notes: "".to_owned(),
-            factor: 1.0,
-            colors: Default::default(),
+            colors: Palette::from_str(defaults::COLORS.value).unwrap(),
+            search_color: SearchColor::from_str(defaults::SEARCH_COLOR.value).unwrap(),
+            title: defaults::TITLE.value.to_string(),
+            image_width: defaults::IMAGE_WIDTH.value,
+            frame_height: defaults::FRAME_HEIGHT.value,
+            min_width: defaults::MIN_WIDTH.value,
+            font_type: defaults::FONT_TYPE.value.to_string(),
+            font_size: defaults::FONT_SIZE.value,
+            font_width: defaults::FONT_WIDTH.value,
+            count_name: defaults::COUNT_NAME.value.to_string(),
+            name_type: defaults::NAME_TYPE.value.to_string(),
+            notes: defaults::NOTES.value.to_string(),
+            factor: defaults::FACTOR.value,
+            subtitle: Default::default(),
             bgcolors: Default::default(),
             hash: Default::default(),
             palette_map: Default::default(),
-            search_color: Default::default(),
             func_frameattrs: Default::default(),
             direction: Default::default(),
             negate_differentials: Default::default(),

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -106,12 +106,12 @@ pub struct Options<'a> {
 
     /// The search color for flame graph.
     ///
-    /// [Default value](defaults::SEARCH_COLOR)
+    /// [Default value](defaults::SEARCH_COLOR).
     pub search_color: SearchColor,
 
     /// The title for the flame graph.
     ///
-    /// [Default value](defaults::TITLE)
+    /// [Default value](defaults::TITLE).
     pub title: String,
 
     /// The subtitle for the flame graph.
@@ -121,42 +121,42 @@ pub struct Options<'a> {
 
     /// Width of for the flame graph
     ///
-    /// [Default value](defaults::IMAGE_WIDTH)
+    /// [Default value](defaults::IMAGE_WIDTH).
     pub image_width: usize,
 
     /// Height of each frame.
     ///
-    /// [Default value](defaults::FRAME_HEIGHT)
+    /// [Default value](defaults::FRAME_HEIGHT).
     pub frame_height: usize,
 
     /// Minimal width to omit smaller functions
     ///
-    /// [Default value](defaults::MIN_WIDTH)
+    /// [Default value](defaults::MIN_WIDTH).
     pub min_width: f64,
 
     /// The font type for the flame graph.
     ///
-    /// [Default value](defaults::FONT_TYPE)
+    /// [Default value](defaults::FONT_TYPE).
     pub font_type: String,
 
     /// Font size for the flame graph.
     ///
-    /// [Default value](defaults::FONT_SIZE)
+    /// [Default value](defaults::FONT_SIZE).
     pub font_size: usize,
 
     /// Font width for the flame graph.
     ///
-    /// [Default value](defaults::FONT_WIDTH)
+    /// [Default value](defaults::FONT_WIDTH).
     pub font_width: f64,
 
     /// Count type label for the flame graph.
     ///
-    /// [Default value](defaults::COUNT_NAME)
+    /// [Default value](defaults::COUNT_NAME).
     pub count_name: String,
 
     /// Name type label for the flame graph.
     ///
-    /// [Default value](defaults::NAME_TYPE)
+    /// [Default value](defaults::NAME_TYPE).
     pub name_type: String,
 
     /// The notes for the flame graph.
@@ -178,7 +178,7 @@ pub struct Options<'a> {
     /// For example, if you have `23.4` as a sample count you can upscale it to `234`, then set `factor`
     /// to `0.1`.
     ///
-    /// [Default value](defaults::FACTOR)
+    /// [Default value](defaults::FACTOR).
     pub factor: f64,
 
     /// Pretty print XML with newlines and indentation.


### PR DESCRIPTION
Fixes #91

One problem this PR doesn't address is the fact that the default values are also in the doc comments of the library's `Options` struct. It would be really nice if these could also use the constants. Unfortunately solving this isn't as easy. We could probably do it with an attribute macro, but is it worth it?