### PR TITLE
Alternative defaults implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ hashbrown = "0.1"
 rand = "0.6.5"
 structopt = { version = "0.2", optional = true }
 env_logger = { version = "0.6.0", optional = true }
-rgb ="0.8.13"
+rgb = "0.8.13"
+lazy_static = "1.3.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -61,15 +61,15 @@ struct Opt {
     subtitle: Option<String>,
 
     /// Width of image
-    #[structopt(long = "width", raw(default_value = "defaults::str::IMAGE_WIDTH"))]
+    #[structopt(long = "width", raw(default_value = "&defaults::str::IMAGE_WIDTH"))]
     image_width: usize,
 
     /// Height of each frame
-    #[structopt(long = "height", raw(default_value = "defaults::str::FRAME_HEIGHT"))]
+    #[structopt(long = "height", raw(default_value = "&defaults::str::FRAME_HEIGHT"))]
     frame_height: usize,
 
     /// Omit smaller functions (default 0.1 pixels)
-    #[structopt(long = "minwidth", raw(default_value = "defaults::str::MIN_WIDTH"))]
+    #[structopt(long = "minwidth", raw(default_value = "&defaults::str::MIN_WIDTH"))]
     min_width: f64,
 
     /// Font type
@@ -77,11 +77,11 @@ struct Opt {
     font_type: String,
 
     /// Font size
-    #[structopt(long = "fontsize", raw(default_value = "defaults::str::FONT_SIZE"))]
+    #[structopt(long = "fontsize", raw(default_value = "&defaults::str::FONT_SIZE"))]
     font_size: usize,
 
     /// Font width
-    #[structopt(long = "fontwidth", raw(default_value = "defaults::str::FONT_WIDTH"))]
+    #[structopt(long = "fontwidth", raw(default_value = "&defaults::str::FONT_WIDTH"))]
     font_width: f64,
 
     /// Count type label
@@ -101,7 +101,7 @@ struct Opt {
     negate: bool,
 
     /// Factor to scale sample counts by
-    #[structopt(long = "factor", raw(default_value = "defaults::str::FACTOR"))]
+    #[structopt(long = "factor", raw(default_value = "&defaults::str::FACTOR"))]
     factor: f64,
 
     /// Silence all log output

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -37,7 +37,7 @@ pub mod defaults {
         ($($name:ident : $t:ty = $val:tt),*) => {
             $(
                 doc!(
-                    concat!("`", stringify!($val), "`"),
+                    stringify!($val),
                     pub const $name: $t = $val;
                 );
             )*
@@ -45,7 +45,9 @@ pub mod defaults {
             #[doc(hidden)]
             pub mod str {
             $(
-                pub const $name: &str = stringify!($val);
+                lazy_static! {
+                    pub static ref $name: String = ($val).to_string();
+                }
             )*
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,9 @@ extern crate pretty_assertions;
 #[macro_use]
 extern crate log;
 
+#[macro_use]
+extern crate lazy_static;
+
 /// Stack collapsing for various input formats.
 ///
 /// See the [crate-level documentation] for details.


### PR DESCRIPTION
This is my proposed solution to the problems with the `&str` versions of the defaults that were discussed in #104.

The versions of the defaults in `defaults::str` now use `lazy_static` so we can call `to_string` on the `$val` expressions instead of using `stringify!`.

This change has the following advantages:
- The constants of type `&str` will no longer have the quotes inside the string in the version in `defaults::str`.
- You can now use `_` as a separator or add type ascriptions to numbers without having problems with the str version since `to_string` won't include those. Note however that the doc for the constant will be the result of calling `stringify!` on $val, so separators and type ascriptions will still appear in the docs, but that seems fine.

The downside is having to bring in `lazy_static` and not being able to use `const` for the str versions. Of course the versions of the constants that are used by the library in `defaults` don't need to be static. It's only for the CLI that the `lazy_static`s get initialized so they can be used by `structopt`.

 