### PR TITLE
Add tests for flamegraph CLI options

### DIFF
--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -42,7 +42,7 @@ const GRAY_GRADIENT: (&str, &str) = ("#f8f8f8", "#e8e8e8");
 ///  - All other [`MultiPalette`] variants default to [`BackgroundColor::Yellow`].
 ///
 /// `BackgroundColor::default()` is `Yellow`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BackgroundColor {
     /// A yellow gradient from `#EEEEEE` to `#EEEEB0`.
     Yellow,
@@ -165,7 +165,7 @@ fn parse_flat_bgcolor(s: &str) -> Option<Color> {
 }
 
 /// `SearchColor::default()` is `rgb(230,0,230)`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SearchColor(Color);
 
 impl FromStr for SearchColor {

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -70,7 +70,7 @@ pub mod defaults {
 }
 
 /// Configure the flame graph.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Options<'a> {
     /// The color palette to use when plotting.
     pub colors: color::Palette,


### PR DESCRIPTION
The `default_options` test makes sure the defaults of the CLI match the defaults of the library.

The `options` test checks that the command line options get set correctly on the `Options` of the library.

The tests also found a bug where the `--title` option didn't actually do anything.