### PR TITLE
Add CLI tests using assert_cmd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ pretty_assertions = "0.6"
 testing_logger = "0.1.1"
 libflate = "0.1"
 criterion = "0.2"
+assert_cmd = "0.11"
 
 [profile.release]
 debug = true

--- a/tests/collapse-dtrace.rs
+++ b/tests/collapse-dtrace.rs
@@ -5,10 +5,13 @@ extern crate inferno;
 
 mod collapse_common;
 
+use assert_cmd::prelude::*;
 use collapse_common::*;
 use inferno::collapse::dtrace::{Folder, Options};
 use log::Level;
-use std::io;
+use std::fs::File;
+use std::io::{self, BufReader, Cursor};
+use std::process::{Command, Stdio};
 
 fn test_collapse_dtrace(test_file: &str, expected_file: &str, options: Options) -> io::Result<()> {
     test_collapse(Folder::from(options), test_file, expected_file)
@@ -107,4 +110,33 @@ fn collapse_dtrace_scope_with_no_argument_list() {
     let test_file = "./tests/data/collapse-dtrace/scope_with_no_argument_list.txt";
     let result_file = "./tests/data/collapse-dtrace/results/scope_with_no_argument_list.txt";
     test_collapse_dtrace(test_file, result_file, Options::default()).unwrap()
+}
+
+#[test]
+fn collapse_dtrace_cli() {
+    let input_file = "./flamegraph/example-dtrace-stacks.txt";
+    let expected_file = "./tests/data/collapse-dtrace/results/dtrace-example.txt";
+
+    // Test with file passed in
+    let output = Command::cargo_bin("inferno-collapse-dtrace")
+        .unwrap()
+        .arg(input_file)
+        .output()
+        .expect("failed to execute process");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
+
+    // Test with STDIN
+    let mut child = Command::cargo_bin("inferno-collapse-dtrace")
+        .unwrap()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn child process");
+    let mut input = BufReader::new(File::open(input_file).unwrap());
+    let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+    io::copy(&mut input, stdin).unwrap();
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
 }

--- a/tests/collapse-guess.rs
+++ b/tests/collapse-guess.rs
@@ -5,10 +5,13 @@ extern crate inferno;
 
 mod collapse_common;
 
+use assert_cmd::prelude::*;
 use collapse_common::*;
 use inferno::collapse::guess::Folder;
 use log::Level;
-use std::io;
+use std::fs::File;
+use std::io::{self, BufReader, Cursor};
+use std::process::{Command, Stdio};
 
 fn test_collapse_guess(test_file: &str, expected_file: &str) -> io::Result<()> {
     test_collapse(Folder {}, test_file, expected_file)
@@ -103,4 +106,33 @@ fn collapse_guess_invalid_perf_should_log_error() {
             );
         },
     );
+}
+
+#[test]
+fn collapse_guess_cli() {
+    let input_file = "./tests/data/collapse-dtrace/java.txt";
+    let expected_file = "./tests/data/collapse-dtrace/results/java.txt";
+
+    // Test with file passed in
+    let output = Command::cargo_bin("inferno-collapse-guess")
+        .unwrap()
+        .arg(input_file)
+        .output()
+        .expect("failed to execute process");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
+
+    // Test with STDIN
+    let mut child = Command::cargo_bin("inferno-collapse-guess")
+        .unwrap()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn child process");
+    let mut input = BufReader::new(File::open(input_file).unwrap());
+    let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+    io::copy(&mut input, stdin).unwrap();
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
 }

--- a/tests/collapse-perf.rs
+++ b/tests/collapse-perf.rs
@@ -5,11 +5,14 @@ extern crate inferno;
 
 mod collapse_common;
 
+use assert_cmd::prelude::*;
 use collapse_common::*;
 use inferno::collapse::perf::{Folder, Options};
 use log::Level;
-use std::io;
+use std::fs::File;
+use std::io::{self, BufReader, Cursor};
 use std::path::Path;
+use std::process::{Command, Stdio};
 
 fn test_collapse_perf(test_file: &str, expected_file: &str, options: Options) -> io::Result<()> {
     test_collapse(Folder::from(options), test_file, expected_file)
@@ -254,4 +257,35 @@ fn collapse_perf_should_warn_about_weird_input_lines() {
             );
         },
     );
+}
+
+#[test]
+fn collapse_perf_cli() {
+    let input_file = "./flamegraph/test/perf-vertx-stacks-01.txt";
+    let expected_file = "./flamegraph/test/results/perf-vertx-stacks-01-collapsed-all.txt";
+
+    // Test with file passed in
+    let output = Command::cargo_bin("inferno-collapse-perf")
+        .unwrap()
+        .arg("--all")
+        .arg(input_file)
+        .output()
+        .expect("failed to execute process");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
+
+    // Test with STDIN
+    let mut child = Command::cargo_bin("inferno-collapse-perf")
+        .unwrap()
+        .arg("--all")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn child process");
+    let mut input = BufReader::new(File::open(input_file).unwrap());
+    let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+    io::copy(&mut input, stdin).unwrap();
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
 }

--- a/tests/diff-folded.rs
+++ b/tests/diff-folded.rs
@@ -3,10 +3,12 @@ extern crate pretty_assertions;
 
 extern crate inferno;
 
+use assert_cmd::prelude::*;
 use inferno::differential::{self, Options};
 use log::Level;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Cursor};
+use std::process::Command;
 
 fn test_diff_folded(
     infile1: &str,
@@ -186,4 +188,21 @@ fn diff_folded_should_log_warning_about_fractional_samples() {
             );
         },
     );
+}
+
+#[test]
+fn diff_folded_cli() {
+    let infile1 = "./tests/data/diff-folded/before.txt";
+    let infile2 = "./tests/data/diff-folded/after.txt";
+    let expected_file = "./tests/data/diff-folded/results/strip_hex.txt";
+
+    let output = Command::cargo_bin("inferno-diff-folded")
+        .unwrap()
+        .arg("--strip-hex")
+        .arg(infile1)
+        .arg(infile2)
+        .output()
+        .expect("failed to execute process");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
 }

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -3,6 +3,7 @@ extern crate pretty_assertions;
 
 extern crate inferno;
 
+use assert_cmd::prelude::*;
 use inferno::flamegraph::{
     self, color::BackgroundColor, color::PaletteMap, Direction, Options, Palette,
 };
@@ -10,6 +11,7 @@ use log::Level;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Cursor};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 use std::str::FromStr;
 
 fn test_flamegraph(
@@ -790,4 +792,56 @@ fn flamegraph_should_warn_about_bad_input_lines_with_reversed_stack_ordering() {
         },
         options,
     );
+}
+
+#[test]
+fn flamegraph_cli() {
+    let input_file = "./flamegraph/test/results/perf-vertx-stacks-01-collapsed-all.txt";
+    let expected_file =
+        "./tests/data/flamegraph/perf-vertx-stacks/perf-vertx-stacks-01-collapsed-all.svg";
+    // Test with file passed in
+    let output = Command::cargo_bin("inferno-flamegraph")
+        .unwrap()
+        .arg("--pretty-xml")
+        .arg("--no-javascript")
+        .arg("--hash")
+        .arg(input_file)
+        .output()
+        .expect("failed to execute process");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
+
+    // Test with STDIN
+    let mut child = Command::cargo_bin("inferno-flamegraph")
+        .unwrap()
+        .arg("--pretty-xml")
+        .arg("--no-javascript")
+        .arg("--hash")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn child process");
+    let mut input = BufReader::new(File::open(input_file).unwrap());
+    let stdin = child.stdin.as_mut().expect("Failed to open stdin");
+    io::copy(&mut input, stdin).unwrap();
+    let output = child.wait_with_output().expect("Failed to read stdout");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
+
+    // Test with multiple files passed in
+    let input_file_part1 =
+        "./tests/data/flamegraph/multiple-inputs/perf-vertx-stacks-01-collapsed-all-unsorted-1.txt";
+    let input_file_part2 =
+        "./tests/data/flamegraph/multiple-inputs/perf-vertx-stacks-01-collapsed-all-unsorted-2.txt";
+    let output = Command::cargo_bin("inferno-flamegraph")
+        .unwrap()
+        .arg("--pretty-xml")
+        .arg("--no-javascript")
+        .arg("--hash")
+        .arg(input_file_part1)
+        .arg(input_file_part2)
+        .output()
+        .expect("failed to execute process");
+    let expected = BufReader::new(File::open(expected_file).unwrap());
+    compare_results(Cursor::new(output.stdout), expected, expected_file);
 }


### PR DESCRIPTION
Test calling the various CLI programs, including the use of STDIN.

Some of these were originally added in #84, but had to be removed because they were causing problems with CI because of the way the commands were using `cargo run`. Using `assert_cmd` instead should fix this.