### PR TITLE
Use itoa to format integers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ env_logger = { version = "0.6.0", optional = true }
 rgb = "0.8.13"
 lazy_static = "1.3.0"
 fnv = "1.0.3"
+itoa = "0.4.3"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -733,6 +733,7 @@ fn filled_rectangle<W: Write>(
 
 fn write_usize(buffer: &mut StrStack, value: usize) -> usize {
     let mut writer = buffer.writer();
+    // OK to unwrap here because this `fmt::Write` implementation never returns an error.
     itoa::fmt(&mut writer, value).unwrap();
     writer.finish()
 }

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -709,10 +709,10 @@ fn filled_rectangle<W: Write>(
     color: Color,
     cache_rect: &mut Event,
 ) -> quick_xml::Result<usize> {
-    let x = write!(buffer, "{}", rect.x1);
-    let y = write!(buffer, "{}", rect.y1);
-    let width = write!(buffer, "{}", rect.width());
-    let height = write!(buffer, "{}", rect.height());
+    let x = write_usize(buffer, rect.x1);
+    let y = write_usize(buffer, rect.y1);
+    let width = write_usize(buffer, rect.width());
+    let height = write_usize(buffer, rect.height());
     let color = write!(buffer, "rgb({},{},{})", color.r, color.g, color.b);
 
     if let Event::Empty(bytes_start) = cache_rect {
@@ -729,4 +729,10 @@ fn filled_rectangle<W: Write>(
         unreachable!("cache wrapper was of wrong type: {:?}", cache_rect);
     }
     svg.write_event(&cache_rect)
+}
+
+fn write_usize(buffer: &mut StrStack, value: usize) -> usize {
+    let mut writer = buffer.writer();
+    itoa::fmt(&mut writer, value).unwrap();
+    writer.finish()
 }


### PR DESCRIPTION
It looks like this gives a bit of a performance improvement to help with #102.
```
flamegraph/dtrace       time:   [982.81 us 988.74 us 996.74 us]
                        thrpt:  [76.219 MiB/s 76.836 MiB/s 77.300 MiB/s]
                 change:
                        time:   [-3.5311% -2.6140% -1.7557%] (p = 0.00 < 0.05)
                        thrpt:  [+1.7871% +2.6842% +3.6604%]
                        Performance has improved.

flamegraph/perf         time:   [3.8627 ms 3.8702 ms 3.8785 ms]
                        thrpt:  [158.96 MiB/s 159.30 MiB/s 159.61 MiB/s]
                 change:
                        time:   [-3.2288% -2.9726% -2.6979%] (p = 0.00 < 0.05)
                        thrpt:  [+2.7727% +3.0636% +3.3365%]
                        Performance has improved.
```