### PR TITLE
move to edition 2018 flavour: cargo fix --edition-idioms + cleanups

### DIFF
--- a/benches/collapse.rs
+++ b/benches/collapse.rs
@@ -1,6 +1,3 @@
-extern crate criterion;
-extern crate inferno;
-
 use criterion::*;
 use inferno::collapse::dtrace;
 use inferno::collapse::perf;

--- a/benches/flamegraph.rs
+++ b/benches/flamegraph.rs
@@ -1,6 +1,3 @@
-extern crate criterion;
-extern crate inferno;
-
 use criterion::*;
 use inferno::flamegraph::{self, Options};
 use std::fs::File;

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -241,6 +241,7 @@ fn save_consistent_palette_if_needed(
 mod tests {
     use super::Opt;
     use inferno::flamegraph::{color, Direction, Options, Palette};
+    use pretty_assertions::assert_eq;
     use std::path::PathBuf;
     use std::str::FromStr;
     use structopt::StructOpt;

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -1,5 +1,6 @@
 use super::Collapse;
 use hashbrown::HashMap;
+use log::warn;
 use std::collections::VecDeque;
 use std::io;
 use std::io::prelude::*;

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -249,6 +249,7 @@ impl Folder {
 }
 
 #[cfg(test)]
+use pretty_assertions::assert_eq;
 #[test]
 fn cpp_test() {
     let probe = "TestClass::TestClass2(const char*)[__1cJTestClass2t6Mpkc_v_]";

--- a/src/collapse/guess.rs
+++ b/src/collapse/guess.rs
@@ -1,5 +1,6 @@
 use super::Collapse;
 use super::{dtrace, perf};
+use log::{error, info};
 use std::io::prelude::*;
 use std::io::{self, Cursor};
 

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -1,5 +1,6 @@
 use super::Collapse;
 use hashbrown::HashMap;
+use log::warn;
 use std::collections::VecDeque;
 use std::io;
 use std::io::prelude::*;

--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -1,4 +1,5 @@
 use hashbrown::HashMap;
+use log::warn;
 use std::fs::File;
 use std::io;
 use std::io::prelude::*;

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -1,4 +1,5 @@
 use fnv::FnvHashMap;
+use log::warn;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs::File;

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -179,6 +179,7 @@ mod test {
     use super::*;
     use fnv::FnvHashMap;
     use maplit::{convert_args, hashmap};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn func_frame_attrs_map_from_reader() {

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -405,6 +405,7 @@ mod tests {
     use super::namehash;
     use super::parse_flat_bgcolor;
     use super::Color;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn bgcolor_parse_test() {

--- a/src/flamegraph/color/palette_map.rs
+++ b/src/flamegraph/color/palette_map.rs
@@ -171,6 +171,7 @@ fn parse_rgb_string(s: &str) -> Option<Color> {
 mod tests {
     use crate::flamegraph::color::palette_map::{parse_line, PaletteMap};
     use crate::flamegraph::color::Color;
+    use pretty_assertions::assert_eq;
     use std::io::Cursor;
 
     macro_rules! color {

--- a/src/flamegraph/color/palette_map.rs
+++ b/src/flamegraph/color/palette_map.rs
@@ -1,4 +1,5 @@
 use crate::flamegraph::color::Color;
+use log::warn;
 use std::collections::HashMap;
 use std::fs::File;
 use std::fs::OpenOptions;

--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use std::collections::HashMap;
 use std::io;
 use std::iter;

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -309,7 +309,7 @@ impl Rectangle {
 ///
 /// [differential flame graph]: http://www.brendangregg.com/blog/2014-11-09/differential-flame-graphs.html
 #[allow(clippy::cyclomatic_complexity)]
-pub fn from_lines<'a, I, W>(opt: &mut Options, lines: I, writer: W) -> quick_xml::Result<()>
+pub fn from_lines<'a, I, W>(opt: &mut Options<'_>, lines: I, writer: W) -> quick_xml::Result<()>
 where
     I: IntoIterator<Item = &'a str>,
     W: Write,
@@ -556,7 +556,7 @@ where
 
         let fitchars =
             (rect.width() as f64 / (opt.font_size as f64 * opt.font_width)).trunc() as usize;
-        let text: svg::TextArgument = if fitchars >= 3 {
+        let text: svg::TextArgument<'_> = if fitchars >= 3 {
             // room for one char plus two dots
             let f = deannotate(&frame.location.function);
 
@@ -607,7 +607,7 @@ where
 }
 
 /// Writes atributes to the container, container could be g or a
-fn write_container_attributes(event: &mut Event, frame_attributes: &FrameAttrs) {
+fn write_container_attributes(event: &mut Event<'_>, frame_attributes: &FrameAttrs) {
     if let Event::Start(ref mut c) = event {
         c.clear_attributes();
         c.extend_attributes(
@@ -626,7 +626,7 @@ fn write_container_attributes(event: &mut Event, frame_attributes: &FrameAttrs) 
 /// See [`from_sorted_lines`] for the expected format of each line.
 ///
 /// The resulting flame graph will be written out to `writer` in SVG format.
-pub fn from_reader<R, W>(opt: &mut Options, reader: R, writer: W) -> quick_xml::Result<()>
+pub fn from_reader<R, W>(opt: &mut Options<'_>, reader: R, writer: W) -> quick_xml::Result<()>
 where
     R: Read,
     W: Write,
@@ -639,7 +639,7 @@ where
 /// See [`from_sorted_lines`] for the expected format of each line.
 ///
 /// The resulting flame graph will be written out to `writer` in SVG format.
-pub fn from_readers<R, W>(opt: &mut Options, readers: R, writer: W) -> quick_xml::Result<()>
+pub fn from_readers<R, W>(opt: &mut Options<'_>, readers: R, writer: W) -> quick_xml::Result<()>
 where
     R: IntoIterator,
     R::Item: Read,
@@ -659,7 +659,7 @@ where
 ///
 /// If files is empty, STDIN will be used as input.
 pub fn from_files<W: Write>(
-    opt: &mut Options,
+    opt: &mut Options<'_>,
     files: &[PathBuf],
     writer: W,
 ) -> quick_xml::Result<()> {
@@ -673,7 +673,7 @@ pub fn from_files<W: Write>(
     } else {
         let stdin = io::stdin();
         let mut stdin_added = false;
-        let mut readers: Vec<Box<Read>> = Vec::with_capacity(files.len());
+        let mut readers: Vec<Box<dyn Read>> = Vec::with_capacity(files.len());
         for infile in files.iter() {
             if infile.to_str() == Some("-") {
                 if !stdin_added {
@@ -707,7 +707,7 @@ fn filled_rectangle<W: Write>(
     buffer: &mut StrStack,
     rect: &Rectangle,
     color: Color,
-    cache_rect: &mut Event,
+    cache_rect: &mut Event<'_>,
 ) -> quick_xml::Result<usize> {
     let x = write_usize(buffer, rect.x1);
     let y = write_usize(buffer, rect.y1);

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -14,6 +14,7 @@ pub use color::Palette;
 
 use crate::flamegraph::color::{Color, SearchColor};
 use attrs::FrameAttrs;
+use log::{error, warn};
 use num_format::Locale;
 use quick_xml::{
     events::{BytesEnd, BytesStart, BytesText, Event},
@@ -51,6 +52,7 @@ pub mod defaults {
 
             #[doc(hidden)]
             pub mod str {
+                use lazy_static::lazy_static;
             $(
                 lazy_static! {
                     pub static ref $name: String = ($val).to_string();

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -48,7 +48,7 @@ pub(super) struct StyleOptions<'a> {
 pub fn write_header<W>(
     svg: &mut Writer<W>,
     imageheight: usize,
-    opt: &Options,
+    opt: &Options<'_>,
 ) -> quick_xml::Result<()>
 where
     W: Write,
@@ -83,7 +83,7 @@ where
 pub(super) fn write_prelude<'a, W>(
     svg: &mut Writer<W>,
     style_options: &StyleOptions<'a>,
-    opt: &Options,
+    opt: &Options<'_>,
 ) -> quick_xml::Result<()>
 where
     W: Write,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,16 +124,6 @@
 
 #![deny(missing_docs)]
 
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-
-#[macro_use]
-extern crate log;
-
-#[macro_use]
-extern crate lazy_static;
-
 /// Stack collapsing for various input formats.
 ///
 /// See the [crate-level documentation] for details.

--- a/tests/collapse-dtrace.rs
+++ b/tests/collapse-dtrace.rs
@@ -1,14 +1,10 @@
-#[macro_use]
-extern crate pretty_assertions;
-
-extern crate inferno;
-
 mod collapse_common;
 
 use assert_cmd::prelude::*;
 use collapse_common::*;
 use inferno::collapse::dtrace::{Folder, Options};
 use log::Level;
+use pretty_assertions::assert_eq;
 use std::fs::File;
 use std::io::{self, BufReader, Cursor};
 use std::process::{Command, Stdio};

--- a/tests/collapse-guess.rs
+++ b/tests/collapse-guess.rs
@@ -1,14 +1,11 @@
-#[macro_use]
-extern crate pretty_assertions;
-
-extern crate inferno;
-
 mod collapse_common;
 
 use assert_cmd::prelude::*;
 use collapse_common::*;
+use inferno;
 use inferno::collapse::guess::Folder;
 use log::Level;
+use pretty_assertions::assert_eq;
 use std::fs::File;
 use std::io::{self, BufReader, Cursor};
 use std::process::{Command, Stdio};

--- a/tests/collapse-guess.rs
+++ b/tests/collapse-guess.rs
@@ -2,7 +2,6 @@ mod collapse_common;
 
 use assert_cmd::prelude::*;
 use collapse_common::*;
-use inferno;
 use inferno::collapse::guess::Folder;
 use log::Level;
 use pretty_assertions::assert_eq;

--- a/tests/collapse-perf.rs
+++ b/tests/collapse-perf.rs
@@ -2,7 +2,6 @@ mod collapse_common;
 
 use assert_cmd::prelude::*;
 use collapse_common::*;
-use inferno;
 use inferno::collapse::perf::{Folder, Options};
 use log::Level;
 use pretty_assertions::assert_eq;

--- a/tests/collapse-perf.rs
+++ b/tests/collapse-perf.rs
@@ -1,14 +1,11 @@
-#[macro_use]
-extern crate pretty_assertions;
-
-extern crate inferno;
-
 mod collapse_common;
 
 use assert_cmd::prelude::*;
 use collapse_common::*;
+use inferno;
 use inferno::collapse::perf::{Folder, Options};
 use log::Level;
+use pretty_assertions::assert_eq;
 use std::fs::File;
 use std::io::{self, BufReader, Cursor};
 use std::path::Path;

--- a/tests/collapse_common/mod.rs
+++ b/tests/collapse_common/mod.rs
@@ -1,4 +1,4 @@
-extern crate inferno;
+use inferno;
 
 use inferno::collapse::Collapse;
 use libflate::gzip::Decoder;

--- a/tests/collapse_common/mod.rs
+++ b/tests/collapse_common/mod.rs
@@ -1,5 +1,3 @@
-use inferno;
-
 use inferno::collapse::Collapse;
 use libflate::gzip::Decoder;
 use std::fs::{self, File};

--- a/tests/diff-folded.rs
+++ b/tests/diff-folded.rs
@@ -1,11 +1,7 @@
-#[macro_use]
-extern crate pretty_assertions;
-
-extern crate inferno;
-
 use assert_cmd::prelude::*;
 use inferno::differential::{self, Options};
 use log::Level;
+use pretty_assertions::assert_eq;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Cursor};
 use std::process::Command;

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -1,13 +1,9 @@
-#[macro_use]
-extern crate pretty_assertions;
-
-extern crate inferno;
-
 use assert_cmd::prelude::*;
 use inferno::flamegraph::{
     self, color::BackgroundColor, color::PaletteMap, Direction, Options, Palette,
 };
 use log::Level;
+use pretty_assertions::assert_eq;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Cursor};
 use std::path::{Path, PathBuf};
@@ -17,7 +13,7 @@ use std::str::FromStr;
 fn test_flamegraph(
     input_file: &str,
     expected_result_file: &str,
-    options: Options,
+    options: Options<'_>,
 ) -> quick_xml::Result<()> {
     test_flamegraph_multiple_files(
         vec![PathBuf::from_str(input_file).unwrap()],
@@ -29,7 +25,7 @@ fn test_flamegraph(
 fn test_flamegraph_multiple_files(
     input_files: Vec<PathBuf>,
     expected_result_file: &str,
-    mut options: Options,
+    mut options: Options<'_>,
 ) -> quick_xml::Result<()> {
     // Always pretty print XML to make it easier to find differences when tests fail.
     options.pretty_xml = true;
@@ -111,7 +107,7 @@ where
 fn test_flamegraph_logs_with_options<F>(
     input_file: &str,
     asserter: F,
-    mut options: flamegraph::Options,
+    mut options: flamegraph::Options<'_>,
 ) where
     F: Fn(&Vec<testing_logger::CapturedLog>),
 {


### PR DESCRIPTION
* apply `cargo fix --edition-idioms`
* remove `extern crate` and `macro_use` with `use`