### PR TITLE
use latest stable tarpaulin docker image for the coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,19 +51,14 @@ jobs:
         - touch ./src/lib.rs && cargo clippy -- -D warnings
     - os: linux
       stage: coverage
-      rust: nightly
       sudo: required
       dist: trusty
-      addons:
-        apt:
-          packages:
-            - libssl-dev
-      env: CACHE_NAME=coverage
+      cache: false
+      services:
+        - docker
       script:
-        - RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin || true
-        - cargo tarpaulin --out Xml
+        - docker run --security-opt seccomp=unconfined -v "$PWD:/volume" xd009642/tarpaulin:latest sh -c "cargo tarpaulin --out Xml"
         - bash <(curl -s https://codecov.io/bash)
-        - cargo clean -p inferno # ensure we don't cache build for coverage
 stages:
  - check
  - test


### PR DESCRIPTION
speedup coverage report by using tarpaulin official docker image