### PR TITLE
Do not allocate memory additionally for tags `title` and closed `text`

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -428,8 +428,10 @@ where
     let mut cache_g = Event::Start({ BytesStart::owned_name("g") });
     let mut cache_a = Event::Start({ BytesStart::owned_name("a") });
     let mut cache_rect = Event::Empty(BytesStart::owned_name("rect"));
+    let cache_title = Event::Start({ BytesStart::owned_name("title") });
     let cache_g_end = Event::End(BytesEnd::borrowed(b"g"));
     let cache_a_end = Event::End(BytesEnd::borrowed(b"a"));
+    let cache_title_end = Event::End(BytesEnd::borrowed(b"title"));
 
     // create frames container
     if let Event::Start(ref mut g) = cache_g {
@@ -524,9 +526,9 @@ where
             svg.write_event(&cache_g)?;
         }
 
-        svg.write_event(Event::Start(BytesStart::borrowed_name(b"title")))?;
+        svg.write_event(&cache_title)?;
         svg.write_event(Event::Text(BytesText::from_plain_str(title)))?;
-        svg.write_event(Event::End(BytesEnd::borrowed(b"title")))?;
+        svg.write_event(&cache_title_end)?;
 
         // select the color of the rectangle
         let color = if frame.location.function == "--" {

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -1,4 +1,5 @@
 use super::{Direction, Options};
+use lazy_static::lazy_static;
 use quick_xml::{
     events::{BytesEnd, BytesStart, BytesText, Event},
     Writer,
@@ -248,6 +249,10 @@ where
 
     let TextItem { text, extra, .. } = item;
 
+    lazy_static! {
+        static ref TEXT_END: Event<'static> = Event::End(BytesEnd::borrowed(b"text"));
+    }
+
     thread_local! {
         // reuse for all text elements to avoid allocations
         static TEXT: RefCell<Event<'static>> = RefCell::new(Event::Start(BytesStart::owned_name("text")))
@@ -271,7 +276,7 @@ where
         TextArgument::FromBuffer(i) => &buf[i],
     };
     svg.write_event(Event::Text(BytesText::from_plain_str(s)))?;
-    svg.write_event(Event::End(BytesEnd::borrowed(b"text")))
+    svg.write_event(&*TEXT_END)
 }
 
 // Imported from the `enquote` crate @ 1.0.3.


### PR DESCRIPTION
* cache `title` tags
* use lazy static for closed tag `text`