### PR TITLE
add freebsd ci support using cirrus ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,26 @@
+task:
+  name: stable-x86_64-unknown-freebsd
+  freebsd_instance:
+    matrix:
+      - image: freebsd-12-0-release-amd64
+      - image: freebsd-11-2-release-amd64
+  env:
+    RUST_BACKTRACE: 1
+  setup_script:
+    - pkg install -y curl git
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y
+    - . $HOME/.cargo/env
+    - rustup component add rustfmt
+  submodule_script:
+    - git submodule sync --recursive
+    - git submodule update --init --recursive
+  check_script:
+    - . $HOME/.cargo/env
+    - cargo check --all-targets
+  build_script:
+    - . $HOME/.cargo/env
+    - cargo build --all-targets --verbose
+  test_script:
+    - . $HOME/.cargo/env
+    - cargo test --no-fail-fast --verbose --all -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = ["/tests/**", "/flamegraph/**", "/*.perf"]
 
 [badges]
 travis-ci = { repository = "jonhoo/inferno" }
+cirrus-ci = { repository = "jonhoo/inferno" }
 codecov = { repository = "jonhoo/inferno", branch = "master", service = "github" }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Crates.io](https://img.shields.io/crates/v/inferno.svg)](https://crates.io/crates/inferno)
 [![Documentation](https://docs.rs/inferno/badge.svg)](https://docs.rs/inferno/)
-[![Build Status](https://travis-ci.com/jonhoo/inferno.svg?branch=master)](https://travis-ci.com/jonhoo/inferno)
+[![Travis Build Status](https://travis-ci.com/jonhoo/inferno.svg?branch=master)](https://travis-ci.com/jonhoo/inferno)
+[![Cirrus CI Build Status](https://api.cirrus-ci.com/github/jonhoo/inferno.svg)](https://cirrus-ci.com/github/jonhoo/inferno)
 [![Codecov](https://codecov.io/github/jonhoo/inferno/coverage.svg?branch=master)](https://codecov.io/gh/jonhoo/inferno)
 [![Dependency status](https://deps.rs/repo/github/jonhoo/inferno/status.svg)](https://deps.rs/repo/github/jonhoo/inferno)
 


### PR DESCRIPTION
Enable cirrus ci with 2 FreeBSD targets: 11.2 and 12.0.

Example run: https://cirrus-ci.com/build/6257168578772992
Time run: about 5-6 minutes.

To enable it: install Github application: https://github.com/marketplace/cirrus-ci and enable the repo.