### PR TITLE
Updates following hashbrown's inclusion in std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rgb = "0.8.13"
 lazy_static = "1.3.0"
 fnv = "1.0.3"
 itoa = "0.4.3"
+indexmap = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ log = "0.4"
 quick-xml = { version = "0.14", default-features = false }
 num-format = { version = "0.4", default-features = false }
 str_stack = "0.1"
-hashbrown = "0.2"
 rand = "0.6.5"
 structopt = { version = "0.2", optional = true }
 env_logger = { version = "0.6.0", optional = true }

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -1,6 +1,7 @@
 use super::Collapse;
+use fnv::FnvHashMap;
 use log::warn;
-use std::collections::{VecDeque, HashMap};
+use std::collections::VecDeque;
 use std::io;
 use std::io::prelude::*;
 
@@ -23,7 +24,7 @@ pub struct Folder {
     stack: VecDeque<String>,
 
     /// Number of times each call stack has been seen.
-    occurrences: HashMap<String, usize>,
+    occurrences: FnvHashMap<String, usize>,
 
     /// Keep track of stack string size while we consume a stack
     stack_str_size: usize,
@@ -114,7 +115,7 @@ impl From<Options> for Folder {
     fn from(opt: Options) -> Self {
         Self {
             stack: VecDeque::default(),
-            occurrences: HashMap::with_capacity(512),
+            occurrences: FnvHashMap::with_capacity_and_hasher(512, fnv::FnvBuildHasher::default()),
             cache_inlines: Vec::new(),
             opt,
             stack_str_size: 0,

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -1,7 +1,6 @@
 use super::Collapse;
-use hashbrown::HashMap;
 use log::warn;
-use std::collections::VecDeque;
+use std::collections::{VecDeque, HashMap};
 use std::io;
 use std::io::prelude::*;
 

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -1,6 +1,7 @@
 use super::Collapse;
+use fnv::FnvHashMap;
 use log::warn;
-use std::collections::{VecDeque, HashMap};
+use std::collections::VecDeque;
 use std::io;
 use std::io::prelude::*;
 
@@ -70,7 +71,7 @@ pub struct Folder {
     cache_line: Vec<String>,
 
     /// Number of times each call stack has been seen.
-    occurrences: HashMap<String, usize>,
+    occurrences: FnvHashMap<String, usize>,
 
     /// Current comm name.
     ///
@@ -159,7 +160,7 @@ impl From<Options> for Folder {
             skip_stack: false,
             stack: VecDeque::default(),
             cache_line: Vec::default(),
-            occurrences: HashMap::with_capacity(512),
+            occurrences: FnvHashMap::with_capacity_and_hasher(512, fnv::FnvBuildHasher::default()),
             pname: String::new(),
             event_filtering: EventFilterState::None,
             opt,

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -1,7 +1,6 @@
 use super::Collapse;
-use hashbrown::HashMap;
 use log::warn;
-use std::collections::VecDeque;
+use std::collections::{VecDeque, HashMap};
 use std::io;
 use std::io::prelude::*;
 

--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use std::collections::HashMap;
 use log::warn;
 use std::fs::File;
 use std::io;

--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -1,4 +1,4 @@
-use fnv::FnvHashMap as HashMap;
+use fnv::FnvHashMap;
 use log::warn;
 use std::fs::File;
 use std::io;
@@ -46,7 +46,7 @@ where
     R2: BufRead,
     W: Write,
 {
-    let mut stack_counts = HashMap::default();
+    let mut stack_counts = FnvHashMap::default();
     let total1 = parse_stack_counts(opt, &mut stack_counts, before, true)?;
     let total2 = parse_stack_counts(opt, &mut stack_counts, after, false)?;
     if opt.normalize && total1 != total2 {
@@ -82,7 +82,7 @@ where
 // Populate stack_counts based on lines from the reader and returns the sum of the sample counts.
 fn parse_stack_counts<R>(
     opt: Options,
-    stack_counts: &mut HashMap<String, Counts>,
+    stack_counts: &mut FnvHashMap<String, Counts>,
     mut reader: R,
     is_first: bool,
 ) -> io::Result<usize>
@@ -119,7 +119,7 @@ where
 
 // Write three-column lines with the folded stack trace and two value columns,
 // one for each profile.
-fn write_stacks<W>(stack_counts: &HashMap<String, Counts>, mut writer: W) -> io::Result<()>
+fn write_stacks<W>(stack_counts: &FnvHashMap<String, Counts>, mut writer: W) -> io::Result<()>
 where
     W: Write,
 {

--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use fnv::FnvHashMap as HashMap;
 use log::warn;
 use std::fs::File;
 use std::io;
@@ -46,7 +46,7 @@ where
     R2: BufRead,
     W: Write,
 {
-    let mut stack_counts = HashMap::new();
+    let mut stack_counts = HashMap::default();
     let total1 = parse_stack_counts(opt, &mut stack_counts, before, true)?;
     let total2 = parse_stack_counts(opt, &mut stack_counts, after, false)?;
     if opt.normalize && total1 != total2 {

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -1,10 +1,11 @@
-use fnv::FnvHashMap;
+use indexmap::map::Entry;
 use log::warn;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
+
+type AttrMap<K, V> = indexmap::IndexMap<K, V, fnv::FnvBuildHasher>;
 
 macro_rules! unwrap_or_continue {
     ($e:expr) => {{
@@ -101,7 +102,7 @@ pub(super) struct FrameAttrs {
     /// If set to None, the title is dynamically generated based on the function name.
     pub(super) title: Option<String>,
 
-    pub(super) attrs: FnvHashMap<String, String>,
+    pub(super) attrs: AttrMap<String, String>,
 }
 
 impl FrameAttrs {
@@ -212,7 +213,7 @@ mod test {
         let r = s.as_bytes();
 
         let mut expected_inner = HashMap::new();
-        let foo_attrs: FnvHashMap<String, String> = convert_args!(hashmap!(
+        let foo_attrs: AttrMap<String, String> = convert_args!(hashmap!(
             "class" => "foo class",
             "xlink:href" => "foo href",
             "target" => "foo target",
@@ -232,7 +233,7 @@ mod test {
             },
         );
 
-        let bar_attrs: FnvHashMap<String, String> = convert_args!(hashmap!(
+        let bar_attrs: AttrMap<String, String> = convert_args!(hashmap!(
             "class" => "bar class",
             "xlink:href" => "bar href",
             "aextra1" => "foo",

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -1,6 +1,6 @@
+use fnv::FnvHashMap;
 use indexmap::map::Entry;
 use log::warn;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
@@ -19,7 +19,7 @@ macro_rules! unwrap_or_continue {
 
 /// Provides a way to customize the attributes on the SVG elements for a frame.
 #[derive(PartialEq, Eq, Debug, Default)]
-pub struct FuncFrameAttrsMap(HashMap<String, FrameAttrs>);
+pub struct FuncFrameAttrsMap(FnvHashMap<String, FrameAttrs>);
 
 impl FuncFrameAttrsMap {
     /// Parse frame attributes from a file.
@@ -212,7 +212,7 @@ mod test {
         let s = vec![foo, bar].join("\n");
         let r = s.as_bytes();
 
-        let mut expected_inner = HashMap::new();
+        let mut expected_inner = FnvHashMap::default();
         let foo_attrs: AttrMap<String, String> = convert_args!(hashmap!(
             "class" => "foo class",
             "xlink:href" => "foo href",

--- a/tests/data/flamegraph/nameattr/nameattr.svg
+++ b/tests/data/flamegraph/nameattr/nameattr.svg
@@ -43,17 +43,17 @@ var searchcolor = 'rgb(230,0,230)';]]>
             <rect x="10" y="149" width="109" height="15" fill="rgb(247,154,46)"/>
             <text x="13.00" y="159.50">__libc_start_..</text>
         </g>
-        <a class="inferno" stroke-width="1" hreflang="en-us" rel="external" target="_blank" xlink:href="https://github.com/jonhoo/inferno" stroke="green">
+        <a class="inferno" stroke-width="1" stroke="green" xlink:href="https://github.com/jonhoo/inferno" target="_blank" rel="external" hreflang="en-us">
             <title>foo</title>
             <rect x="10" y="133" width="109" height="15" fill="rgb(247,83,46)"/>
             <text x="13.00" y="143.50">main</text>
         </a>
-        <a class="flames" target="_top" xlink:href="https://github.com/jonhoo/inferno">
+        <a class="flames" xlink:href="https://github.com/jonhoo/inferno" target="_top">
             <title>bar</title>
             <rect x="10" y="117" width="109" height="15" fill="rgb(226,95,23)"/>
             <text x="13.00" y="127.50">cksum</text>
         </a>
-        <a class="flames" target="_top" xlink:href="https://github.com/jonhoo/inferno">
+        <a class="flames" xlink:href="https://github.com/jonhoo/inferno" target="_top">
             <title>bar</title>
             <rect x="119" y="165" width="25" height="15" fill="rgb(226,95,23)"/>
             <text x="122.00" y="175.50">c..</text>
@@ -98,17 +98,17 @@ var searchcolor = 'rgb(230,0,230)';]]>
             <rect x="141" y="37" width="3" height="15" fill="rgb(236,145,34)"/>
             <text x="144.00" y="47.50"></text>
         </g>
-        <a class="flames" target="_top" xlink:href="https://github.com/jonhoo/inferno">
+        <a class="flames" xlink:href="https://github.com/jonhoo/inferno" target="_top">
             <title>bar</title>
             <rect x="10" y="181" width="201" height="15" fill="rgb(226,95,23)"/>
             <text x="13.00" y="191.50">cksum</text>
         </a>
-        <a class="inferno" stroke-width="1" hreflang="en-us" rel="external" target="_blank" xlink:href="https://github.com/jonhoo/inferno" stroke="green">
+        <a class="inferno" stroke-width="1" stroke="green" xlink:href="https://github.com/jonhoo/inferno" target="_blank" rel="external" hreflang="en-us">
             <title>foo</title>
             <rect x="144" y="165" width="67" height="15" fill="rgb(247,83,46)"/>
             <text x="147.00" y="175.50">main</text>
         </a>
-        <a class="flames" target="_top" xlink:href="https://github.com/jonhoo/inferno">
+        <a class="flames" xlink:href="https://github.com/jonhoo/inferno" target="_top">
             <title>bar</title>
             <rect x="144" y="149" width="67" height="15" fill="rgb(226,95,23)"/>
             <text x="147.00" y="159.50">cksum</text>
@@ -128,7 +128,7 @@ var searchcolor = 'rgb(230,0,230)';]]>
             <rect x="211" y="181" width="979" height="15" fill="rgb(248,212,47)"/>
             <text x="214.00" y="191.50">noploop</text>
         </g>
-        <a class="inferno" stroke-width="1" hreflang="en-us" rel="external" target="_blank" xlink:href="https://github.com/jonhoo/inferno" stroke="green">
+        <a class="inferno" stroke-width="1" stroke="green" xlink:href="https://github.com/jonhoo/inferno" target="_blank" rel="external" hreflang="en-us">
             <title>foo</title>
             <rect x="219" y="165" width="971" height="15" fill="rgb(247,83,46)"/>
             <text x="222.00" y="175.50">main</text>

--- a/tests/data/flamegraph/nameattr/nameattr_duplicate_attributes.svg
+++ b/tests/data/flamegraph/nameattr/nameattr_duplicate_attributes.svg
@@ -43,7 +43,7 @@ var searchcolor = 'rgb(230,0,230)';]]>
             <rect x="10" y="149" width="109" height="15" fill="rgb(247,154,46)"/>
             <text x="13.00" y="159.50">__libc_start_..</text>
         </g>
-        <a class="inferno2" stroke-width="1" hreflang="en-us" rel="external" target="_blank" xlink:href="https://github.com/jonhoo/inferno" stroke="green">
+        <a class="inferno2" stroke-width="1" stroke="green" xlink:href="https://github.com/jonhoo/inferno" target="_blank" rel="external" hreflang="en-us">
             <title>foo</title>
             <rect x="10" y="133" width="109" height="15" fill="rgb(247,83,46)"/>
             <text x="13.00" y="143.50">main</text>
@@ -103,7 +103,7 @@ var searchcolor = 'rgb(230,0,230)';]]>
             <rect x="10" y="181" width="201" height="15" fill="rgb(226,95,23)"/>
             <text x="13.00" y="191.50">cksum</text>
         </g>
-        <a class="inferno2" stroke-width="1" hreflang="en-us" rel="external" target="_blank" xlink:href="https://github.com/jonhoo/inferno" stroke="green">
+        <a class="inferno2" stroke-width="1" stroke="green" xlink:href="https://github.com/jonhoo/inferno" target="_blank" rel="external" hreflang="en-us">
             <title>foo</title>
             <rect x="144" y="165" width="67" height="15" fill="rgb(247,83,46)"/>
             <text x="147.00" y="175.50">main</text>
@@ -128,7 +128,7 @@ var searchcolor = 'rgb(230,0,230)';]]>
             <rect x="211" y="181" width="979" height="15" fill="rgb(248,212,47)"/>
             <text x="214.00" y="191.50">noploop</text>
         </g>
-        <a class="inferno2" stroke-width="1" hreflang="en-us" rel="external" target="_blank" xlink:href="https://github.com/jonhoo/inferno" stroke="green">
+        <a class="inferno2" stroke-width="1" stroke="green" xlink:href="https://github.com/jonhoo/inferno" target="_blank" rel="external" hreflang="en-us">
             <title>foo</title>
             <rect x="219" y="165" width="971" height="15" fill="rgb(247,83,46)"/>
             <text x="222.00" y="175.50">main</text>


### PR DESCRIPTION
`hashbrown` no longer needs to be included as a dependency. It also has a different ordering than the old `HashMap`, which caused our nameattr tests to start failing. Instead of relying on the new order (which would make tests fail on stable), I changed the implementation to use an `IndexMap` (which preserves insertion order) so that we aren't dependent on the map order any more. This is probably also more reasonable, since it means that the attribute order from the nameattr file will be preserved.

This PR also switches most maps to use FNV hashing, since we don't really need the adverserial robustness that randomized hashing gives us in this context.