### PR TITLE
Fix comparison script on macOS

### DIFF
--- a/compare.sh
+++ b/compare.sh
@@ -6,7 +6,7 @@ BIN="${CARGO_TARGET_DIR:-target}/release/"
 
 cargo build --release --bin inferno-collapse-perf
 f=flamegraph/example-perf-stacks.txt
-zcat flamegraph/example-perf-stacks.txt.gz > "$f"
+zcat < flamegraph/example-perf-stacks.txt.gz > "$f"
 echo "==>  perf  <=="
 hyperfine --warmup 20 -m 50 "$BIN/inferno-collapse-perf --all $f" "./flamegraph/stackcollapse-perf.pl --all $f"
 rm "$f"
@@ -24,7 +24,7 @@ echo
 
 cargo build --release --bin inferno-collapse-sample
 f=tests/data/collapse-sample/large.txt
-zcat tests/data/collapse-sample/large.txt.gz > "$f"
+zcat < tests/data/collapse-sample/large.txt.gz > "$f"
 echo "==>  sample  <=="
 hyperfine --warmup 20 -m 50 "$BIN/inferno-collapse-sample $f" "./flamegraph/stackcollapse-sample.awk $f"
 rm "$f"


### PR DESCRIPTION
`zcat` seems to behave differently on macOS and fails with `zcat: can't stat:` as described here: https://serverfault.com/questions/570024/zcat-gzcat-works-in-linux-not-on-osx-general-linux-osx-compatibility/570026#570026 

The fix is also from that serverfault answer, I think this should still work on linux.

Signed-off-by: Bastian Rinsche <bastian.rinsche@gmail.com>