### PR TITLE
Reduce the number of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "1.3.0"
 log = "0.4"
 num_cpus = "1.10"
 num-format = { version = "0.4", default-features = false }
-quick-xml = { version = "0.15", default-features = false }
+quick-xml = { version = "0.16", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 structopt = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ log = "0.4"
 num_cpus = "1.10"
 num-format = { version = "0.4", default-features = false }
 quick-xml = { version = "0.15", default-features = false }
-rand = "0.7"
 rgb = "0.8.13"
 str_stack = "0.1"
 structopt = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,19 +21,20 @@ cirrus-ci = { repository = "jonhoo/inferno" }
 codecov = { repository = "jonhoo/inferno", branch = "master", service = "github" }
 
 [features]
-default = ["cli"]
+default = ["cli", "multithreaded"]
 cli = ["structopt", "env_logger"]
+multithreaded = ["chashmap", "crossbeam", "num_cpus"]
 
 [dependencies]
-chashmap = "2.2"
-crossbeam = "0.7"
+chashmap = { version = "2.2", optional = true }
+crossbeam = { version = "0.7", optional = true }
 env_logger = { version = "0.6.0", optional = true }
 fnv = "1.0.3"
 indexmap = "1.0"
 itoa = "0.4.3"
 lazy_static = "1.3.0"
 log = "0.4"
-num_cpus = "1.10"
+num_cpus = { version = "1.10", optional = true }
 num-format = { version = "0.4", default-features = false }
 quick-xml = { version = "0.16", default-features = false }
 rgb = "0.8.13"

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -7,7 +7,6 @@ use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
 
-use rand::prelude::*;
 use rgb::RGB8;
 
 pub use self::palette_map::PaletteMap;
@@ -328,14 +327,19 @@ fn rgb_components_for_palette(palette: Palette, name: &str, v1: f32, v2: f32, v3
     }
 }
 
-pub(super) fn color(palette: Palette, hash: bool, name: &str, thread_rng: &mut ThreadRng) -> Color {
+pub(super) fn color(
+    palette: Palette,
+    hash: bool,
+    name: &str,
+    mut rng: impl FnMut() -> f32,
+) -> Color {
     let (v1, v2, v3) = if hash {
         let name_hash = namehash(name.bytes());
         let reverse_name_hash = namehash(name.bytes().rev());
 
         (name_hash, reverse_name_hash, reverse_name_hash)
     } else {
-        (thread_rng.gen(), thread_rng.gen(), thread_rng.gen())
+        (rng(), rng(), rng())
     };
 
     rgb_components_for_palette(palette, name, v1, v2, v3)

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -7,6 +7,7 @@ macro_rules! args {
 mod attrs;
 pub mod color;
 mod merge;
+mod rand;
 mod svg;
 
 use std::fs::File;

--- a/src/flamegraph/rand.rs
+++ b/src/flamegraph/rand.rs
@@ -1,0 +1,77 @@
+use std::cell::RefCell;
+
+pub struct XorShift64 {
+    a: u64,
+}
+
+impl XorShift64 {
+    pub fn new(seed: u64) -> XorShift64 {
+        XorShift64 { a: seed }
+    }
+
+    pub fn next(&mut self) -> u64 {
+        let mut x = self.a;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.a = x;
+        x
+    }
+
+    pub fn next_f64(&mut self) -> f64 {
+        sample(self.next())
+    }
+}
+
+thread_local! {
+    pub static RNG: RefCell<XorShift64> = RefCell::new(XorShift64::new(1234));
+}
+
+// Copied from `rand` with minor modifications.
+fn sample(value: u64) -> f64 {
+    let fraction_bits = 52;
+
+    // Multiply-based method; 24/53 random bits; [0, 1) interval.
+    // We use the most significant bits because for simple RNGs
+    // those are usually more random.
+    let float_size = std::mem::size_of::<f64>() as u32 * 8;
+    let precision = fraction_bits + 1;
+    let scale = 1.0 / ((1_u64 << precision) as f64);
+
+    let value = value >> (float_size - precision);
+    scale * (value as f64)
+}
+
+pub fn thread_rng() -> impl Fn() -> f32 {
+    || RNG.with(|rng| rng.borrow_mut().next_f64() as f32)
+}
+
+#[test]
+fn test_rng() {
+    const ITERATIONS: usize = 10000;
+
+    let mut rng = XorShift64::new(1234);
+    let mut sum = rng.next_f64();
+    let mut min = sum;
+    let mut max = sum;
+    for _ in 0..ITERATIONS - 1 {
+        let value = rng.next_f64();
+        sum += value;
+        if value < min {
+            min = value;
+        }
+        if value > max {
+            max = value;
+        }
+    }
+
+    let avg = sum / ITERATIONS as f64;
+
+    // Make sure the RNG is uniform.
+    assert!(min >= 0.000);
+    assert!(min <= 0.001);
+    assert!(max <= 1.000);
+    assert!(max >= 0.999);
+    assert!(avg >= 0.490);
+    assert!(avg <= 0.510);
+}


### PR DESCRIPTION
* I've updated to newer `quick-xml` which has less dependencies.
* The `rand` dependency seems unnecessary considering what we need it for, so I just replaced it with a simple xorshift64 generator. As as side effect the RNG now always starts with the same seed.
* I've gated the dependencies related to multithreading with a `multithreaded` feature flag.

`cargo-tree` before my changes (with `--no-default-features`):

```
inferno v0.8.0 (/tmp/inferno)
├── chashmap v2.2.2
│   ├── owning_ref v0.3.3
│   │   └── stable_deref_trait v1.1.1
│   └── parking_lot v0.4.8
│       ├── owning_ref v0.3.3 (*)
│       └── parking_lot_core v0.2.14
│           ├── libc v0.2.62
│           ├── rand v0.4.6
│           │   └── libc v0.2.62 (*)
│           └── smallvec v0.6.10
├── crossbeam v0.7.2
│   ├── cfg-if v0.1.9
│   ├── crossbeam-channel v0.3.9
│   │   └── crossbeam-utils v0.6.6
│   │       ├── cfg-if v0.1.9 (*)
│   │       └── lazy_static v1.4.0
│   ├── crossbeam-deque v0.7.1
│   │   ├── crossbeam-epoch v0.7.2
│   │   │   ├── arrayvec v0.4.11
│   │   │   │   └── nodrop v0.1.13
│   │   │   ├── cfg-if v0.1.9 (*)
│   │   │   ├── crossbeam-utils v0.6.6 (*)
│   │   │   ├── lazy_static v1.4.0 (*)
│   │   │   ├── memoffset v0.5.1
│   │   │   │   [build-dependencies]
│   │   │   │   └── rustc_version v0.2.3
│   │   │   │       └── semver v0.9.0
│   │   │   │           └── semver-parser v0.7.0
│   │   │   └── scopeguard v1.0.0
│   │   └── crossbeam-utils v0.6.6 (*)
│   ├── crossbeam-epoch v0.7.2 (*)
│   ├── crossbeam-queue v0.1.2
│   │   └── crossbeam-utils v0.6.6 (*)
│   └── crossbeam-utils v0.6.6 (*)
├── fnv v1.0.6
├── indexmap v1.1.0
├── itoa v0.4.4
├── lazy_static v1.4.0 (*)
├── log v0.4.8
│   └── cfg-if v0.1.9 (*)
├── num-format v0.4.0
│   ├── arrayvec v0.4.11 (*)
│   └── itoa v0.4.4 (*)
├── num_cpus v1.10.1
│   └── libc v0.2.62 (*)
├── quick-xml v0.15.0
│   ├── derive_more v0.14.1
│   │   ├── proc-macro2 v0.4.30
│   │   │   └── unicode-xid v0.1.0
│   │   ├── quote v0.6.13
│   │   │   └── proc-macro2 v0.4.30 (*)
│   │   └── syn v0.15.44
│   │       ├── proc-macro2 v0.4.30 (*)
│   │       ├── quote v0.6.13 (*)
│   │       └── unicode-xid v0.1.0 (*)
│   │   [build-dependencies]
│   │   └── rustc_version v0.2.3 (*)
│   ├── encoding_rs v0.8.19
│   │   └── cfg-if v0.1.9 (*)
│   ├── log v0.4.8 (*)
│   └── memchr v2.2.1
│       └── libc v0.2.62 (*)
├── rand v0.7.0
│   ├── getrandom v0.1.12
│   │   ├── cfg-if v0.1.9 (*)
│   │   └── libc v0.2.62 (*)
│   ├── libc v0.2.62 (*)
│   ├── rand_chacha v0.2.1
│   │   ├── c2-chacha v0.2.2
│   │   │   ├── lazy_static v1.4.0 (*)
│   │   │   └── ppv-lite86 v0.2.5
│   │   └── rand_core v0.5.1
│   │       └── getrandom v0.1.12 (*)
│   ├── rand_core v0.5.1 (*)
│   └── rand_pcg v0.2.0
│       └── rand_core v0.5.1 (*)
│       [build-dependencies]
│       └── autocfg v0.1.6
│   [dev-dependencies]
│   ├── rand_hc v0.2.0
│   │   └── rand_core v0.5.1 (*)
│   └── rand_pcg v0.2.0 (*)
├── rgb v0.8.14
└── str_stack v0.1.0
```

`cargo-tree` after my changes (with `--no-default-features`):

```
inferno v0.8.0 (/tmp/inferno)
├── fnv v1.0.6
├── indexmap v1.1.0
├── itoa v0.4.4
├── lazy_static v1.4.0
├── log v0.4.8
│   └── cfg-if v0.1.9
├── num-format v0.4.0
│   ├── arrayvec v0.4.11
│   │   └── nodrop v0.1.13
│   └── itoa v0.4.4 (*)
├── quick-xml v0.16.1
│   └── memchr v2.2.1
│       └── libc v0.2.62
├── rgb v0.8.14
└── str_stack v0.1.0
```