### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -422,7 +422,7 @@ mod tests {
                 "./tests/data/collapse-dtrace/only-header-lines.txt",
                 "./tests/data/collapse-dtrace/scope_with_no_argument_list.txt",
             ]
-            .into_iter()
+            .iter()
             .map(PathBuf::from)
             .collect::<Vec<_>>()
         };

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -639,7 +639,7 @@ mod tests {
                 "./tests/data/collapse-perf/java-inline.txt",
                 "./tests/data/collapse-perf/weird-stack-line.txt",
             ]
-            .into_iter()
+            .iter()
             .map(PathBuf::from)
             .collect::<Vec<_>>()
         };

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -1,6 +1,6 @@
 macro_rules! args {
     ($($key:expr => $value:expr),*) => {{
-        [$(($key, $value),)*].into_iter().map(|(k, v): &(&str, &str)| (*k, *v))
+        [$(($key, $value),)*].iter().map(|(k, v): &(&str, &str)| (*k, *v))
     }};
 }
 


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
