### PR TITLE
Miscellaneous tidying up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ multithreaded = ["dashmap", "crossbeam", "num_cpus"]
 nameattr = ["indexmap"]
 
 [dependencies]
+ahash = "0.3"
 crossbeam = { version = "0.7", optional = true }
 dashmap = { version = "3", optional = true }
 env_logger = { version = "0.7", optional = true }
-fxhash = "0.2"
 indexmap = { version = "1.0", optional = true }
 itoa = "0.4.3"
 lazy_static = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,27 +23,27 @@ codecov = { repository = "jonhoo/inferno", branch = "master", service = "github"
 [features]
 default = ["cli", "multithreaded", "nameattr"]
 cli = ["structopt", "env_logger"]
-multithreaded = ["chashmap", "crossbeam", "num_cpus"]
+multithreaded = ["dashmap", "crossbeam", "num_cpus"]
 nameattr = ["indexmap"]
 
 [dependencies]
-chashmap = { version = "2.2", optional = true }
 crossbeam = { version = "0.7", optional = true }
-env_logger = { version = "0.6.0", optional = true }
-fnv = "1.0.3"
+dashmap = { version = "3", optional = true }
+env_logger = { version = "0.7", optional = true }
+fxhash = "0.2"
 indexmap = { version = "1.0", optional = true }
 itoa = "0.4.3"
 lazy_static = "1.3.0"
 log = "0.4"
 num_cpus = { version = "1.10", optional = true }
 num-format = { version = "0.4", default-features = false }
-quick-xml = { version = "0.16", default-features = false }
+quick-xml = { version = "0.17", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 structopt = { version = "0.3", optional = true }
 
 [dev-dependencies]
-assert_cmd = "0.11"
+assert_cmd = "0.12"
 criterion = "0.3"
 libflate = "0.1"
 maplit = "1.0.1"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ jobs:
   - template: default.yml@templates
     parameters:
       codecov_token: $(CODECOV_TOKEN_SECRET)
-      minrust: 1.36.0
+      minrust: 1.40.0
       env:
         RUST_BACKTRACE: 1
       setup:

--- a/src/bin/collapse-dtrace.rs
+++ b/src/bin/collapse-dtrace.rs
@@ -81,7 +81,7 @@ fn main() -> io::Result<()> {
             2 => "debug",
             _ => "trace",
         }))
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .init();
     }
 

--- a/src/bin/collapse-guess.rs
+++ b/src/bin/collapse-guess.rs
@@ -73,7 +73,7 @@ fn main() -> io::Result<()> {
             2 => "debug",
             _ => "trace",
         }))
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .init();
     }
 

--- a/src/bin/collapse-perf.rs
+++ b/src/bin/collapse-perf.rs
@@ -110,7 +110,7 @@ fn main() -> io::Result<()> {
             2 => "debug",
             _ => "trace",
         }))
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .init();
     }
 

--- a/src/bin/collapse-sample.rs
+++ b/src/bin/collapse-sample.rs
@@ -60,7 +60,7 @@ fn main() -> io::Result<()> {
             2 => "debug",
             _ => "trace",
         }))
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .init();
     }
 

--- a/src/bin/collapse-vtune.rs
+++ b/src/bin/collapse-vtune.rs
@@ -62,7 +62,7 @@ fn main() -> io::Result<()> {
             2 => "debug",
             _ => "trace",
         }))
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .init();
     }
 

--- a/src/bin/diff-folded.rs
+++ b/src/bin/diff-folded.rs
@@ -82,7 +82,7 @@ fn main() -> io::Result<()> {
             2 => "debug",
             _ => "trace",
         }))
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .init();
     }
 

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -256,7 +256,7 @@ fn main() -> quick_xml::Result<()> {
             2 => "debug",
             _ => "trace",
         }))
-        .default_format_timestamp(false)
+        .format_timestamp(None)
         .init();
     }
 

--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -360,7 +360,7 @@ pub trait CollapsePrivate: Send + Sized {
 pub enum Occurrences {
     SingleThreaded(AHashMap<String, usize>),
     #[cfg(feature = "multithreaded")]
-    MultiThreaded(Arc<DashMap<String, usize>>),
+    MultiThreaded(Arc<DashMap<String, usize, ahash::RandomState>>),
 }
 
 impl Occurrences {

--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{self, prelude::*};
 use std::path::Path;
 
-use fxhash::FxHashMap;
+use ahash::AHashMap;
 use log::warn;
 
 const READER_CAPACITY: usize = 128 * 1024;
@@ -46,7 +46,7 @@ where
     R2: BufRead,
     W: Write,
 {
-    let mut stack_counts = FxHashMap::default();
+    let mut stack_counts = AHashMap::default();
     let total1 = parse_stack_counts(opt, &mut stack_counts, before, true)?;
     let total2 = parse_stack_counts(opt, &mut stack_counts, after, false)?;
     if opt.normalize && total1 != total2 {
@@ -82,7 +82,7 @@ where
 // Populate stack_counts based on lines from the reader and returns the sum of the sample counts.
 fn parse_stack_counts<R>(
     opt: Options,
-    stack_counts: &mut FxHashMap<String, Counts>,
+    stack_counts: &mut AHashMap<String, Counts>,
     mut reader: R,
     is_first: bool,
 ) -> io::Result<usize>
@@ -119,7 +119,7 @@ where
 
 // Write three-column lines with the folded stack trace and two value columns,
 // one for each profile.
-fn write_stacks<W>(stack_counts: &FxHashMap<String, Counts>, mut writer: W) -> io::Result<()>
+fn write_stacks<W>(stack_counts: &AHashMap<String, Counts>, mut writer: W) -> io::Result<()>
 where
     W: Write,
 {

--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{self, prelude::*};
 use std::path::Path;
 
-use fnv::FnvHashMap;
+use fxhash::FxHashMap;
 use log::warn;
 
 const READER_CAPACITY: usize = 128 * 1024;
@@ -46,7 +46,7 @@ where
     R2: BufRead,
     W: Write,
 {
-    let mut stack_counts = FnvHashMap::default();
+    let mut stack_counts = FxHashMap::default();
     let total1 = parse_stack_counts(opt, &mut stack_counts, before, true)?;
     let total2 = parse_stack_counts(opt, &mut stack_counts, after, false)?;
     if opt.normalize && total1 != total2 {
@@ -82,7 +82,7 @@ where
 // Populate stack_counts based on lines from the reader and returns the sum of the sample counts.
 fn parse_stack_counts<R>(
     opt: Options,
-    stack_counts: &mut FnvHashMap<String, Counts>,
+    stack_counts: &mut FxHashMap<String, Counts>,
     mut reader: R,
     is_first: bool,
 ) -> io::Result<usize>
@@ -119,7 +119,7 @@ where
 
 // Write three-column lines with the folded stack trace and two value columns,
 // one for each profile.
-fn write_stacks<W>(stack_counts: &FnvHashMap<String, Counts>, mut writer: W) -> io::Result<()>
+fn write_stacks<W>(stack_counts: &FxHashMap<String, Counts>, mut writer: W) -> io::Result<()>
 where
     W: Write,
 {

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -2,11 +2,11 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 
-use fnv::FnvHashMap;
+use fxhash::FxHashMap;
 use indexmap::map::Entry;
 use log::warn;
 
-type AttrMap<K, V> = indexmap::IndexMap<K, V, fnv::FnvBuildHasher>;
+type AttrMap<K, V> = indexmap::IndexMap<K, V, fxhash::FxBuildHasher>;
 
 macro_rules! unwrap_or_continue {
     ($e:expr) => {{
@@ -20,7 +20,7 @@ macro_rules! unwrap_or_continue {
 
 /// Provides a way to customize the attributes on the SVG elements for a frame.
 #[derive(PartialEq, Eq, Debug, Default)]
-pub struct FuncFrameAttrsMap(FnvHashMap<String, FrameAttrs>);
+pub struct FuncFrameAttrsMap(FxHashMap<String, FrameAttrs>);
 
 impl FuncFrameAttrsMap {
     /// Parse frame attributes from a file.
@@ -179,7 +179,7 @@ impl<'a> Iterator for AttrIter<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use fnv::FnvHashMap;
+    use fxhash::FxHashMap;
     use maplit::{convert_args, hashmap};
     use pretty_assertions::assert_eq;
 
@@ -213,7 +213,7 @@ mod test {
         let s = vec![foo, bar].join("\n");
         let r = s.as_bytes();
 
-        let mut expected_inner = FnvHashMap::default();
+        let mut expected_inner = FxHashMap::default();
         let foo_attrs: AttrMap<String, String> = convert_args!(hashmap!(
             "class" => "foo class",
             "xlink:href" => "foo href",

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -2,11 +2,11 @@ use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::PathBuf;
 
-use fxhash::FxHashMap;
+use ahash::AHashMap;
 use indexmap::map::Entry;
 use log::warn;
 
-type AttrMap<K, V> = indexmap::IndexMap<K, V, fxhash::FxBuildHasher>;
+type AttrMap<K, V> = indexmap::IndexMap<K, V, ahash::RandomState>;
 
 macro_rules! unwrap_or_continue {
     ($e:expr) => {{
@@ -20,7 +20,7 @@ macro_rules! unwrap_or_continue {
 
 /// Provides a way to customize the attributes on the SVG elements for a frame.
 #[derive(PartialEq, Eq, Debug, Default)]
-pub struct FuncFrameAttrsMap(FxHashMap<String, FrameAttrs>);
+pub struct FuncFrameAttrsMap(AHashMap<String, FrameAttrs>);
 
 impl FuncFrameAttrsMap {
     /// Parse frame attributes from a file.
@@ -179,7 +179,7 @@ impl<'a> Iterator for AttrIter<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use fxhash::FxHashMap;
+    use ahash::AHashMap;
     use maplit::{convert_args, hashmap};
     use pretty_assertions::assert_eq;
 
@@ -213,7 +213,7 @@ mod test {
         let s = vec![foo, bar].join("\n");
         let r = s.as_bytes();
 
-        let mut expected_inner = FxHashMap::default();
+        let mut expected_inner = AHashMap::default();
         let foo_attrs: AttrMap<String, String> = convert_args!(hashmap!(
             "class" => "foo class",
             "xlink:href" => "foo href",

--- a/tests/collapse-dtrace.rs
+++ b/tests/collapse-dtrace.rs
@@ -97,7 +97,7 @@ fn collapse_dtrace_should_log_warning_for_only_header_lines() {
         "./tests/data/collapse-dtrace/only-header-lines.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body == "File ended while skipping headers" && log.level == Level::Warn
                 })

--- a/tests/collapse-guess.rs
+++ b/tests/collapse-guess.rs
@@ -83,7 +83,7 @@ fn collapse_guess_unknown_format_should_log_error() {
         "./tests/data/collapse-guess/unknown-format.txt",
         |captured_logs| {
             let nerrors = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.level == Level::Error
                         && log.body == "No applicable collapse implementation found for input"
@@ -104,7 +104,7 @@ fn collapse_guess_invalid_perf_should_log_error() {
         "./tests/data/collapse-guess/invalid-perf-with-empty-line-after-event-line.txt",
         |captured_logs| {
             let nerrors = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.level == Level::Error
                         && log.body == "No applicable collapse implementation found for input"

--- a/tests/collapse-perf.rs
+++ b/tests/collapse-perf.rs
@@ -249,7 +249,7 @@ fn collapse_perf_should_warn_about_empty_input_lines() {
         "./tests/data/collapse-perf/empty-line.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body.starts_with("Weird event line: ") && log.level == Level::Warn
                 })
@@ -269,7 +269,7 @@ fn collapse_perf_should_warn_about_weird_input_lines() {
         "./tests/data/collapse-perf/weird-stack-line.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body.starts_with("Weird stack line: ") && log.level == Level::Warn
                 })

--- a/tests/collapse-sample.rs
+++ b/tests/collapse-sample.rs
@@ -43,15 +43,7 @@ fn collapse_sample_default() {
 fn collapse_sample_no_modules() {
     let test_file = "./tests/data/collapse-sample/sample.txt";
     let result_file = "./tests/data/collapse-sample/results/sample-no-modules.txt";
-    test_collapse_sample(
-        test_file,
-        result_file,
-        Options {
-            no_modules: true,
-            ..Default::default()
-        },
-    )
-    .unwrap()
+    test_collapse_sample(test_file, result_file, Options { no_modules: true }).unwrap()
 }
 
 #[test]
@@ -60,7 +52,7 @@ fn collapse_sample_should_log_warning_for_ending_before_call_graph_start() {
         "./tests/data/collapse-sample/end-before-call-graph-start.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body == "File ended before start of call graph" && log.level == Level::Warn
                 })

--- a/tests/collapse-vtune.rs
+++ b/tests/collapse-vtune.rs
@@ -43,15 +43,7 @@ fn collapse_vtune_default() {
 fn collapse_vtune_no_modules() {
     let test_file = "./tests/data/collapse-vtune/vtune.csv";
     let result_file = "./tests/data/collapse-vtune/results/vtune-no-modules.txt";
-    test_collapse_vtune(
-        test_file,
-        result_file,
-        Options {
-            no_modules: true,
-            ..Default::default()
-        },
-    )
-    .unwrap()
+    test_collapse_vtune(test_file, result_file, Options { no_modules: true }).unwrap()
 }
 
 #[test]
@@ -60,7 +52,7 @@ fn collapse_vtune_should_log_warning_for_ending_before_header() {
         "./tests/data/collapse-vtune/end-before-header.csv",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| log.body == "File ended before header" && log.level == Level::Warn)
                 .count();
             assert_eq!(

--- a/tests/common/collapse.rs
+++ b/tests/common/collapse.rs
@@ -49,7 +49,7 @@ where
 {
     if let Err(e) = fs::metadata(test_filename) {
         eprintln!("Failed to open input file '{}'", test_filename);
-        return Err(e.into());
+        return Err(e);
     }
 
     let mut collapse = move |out: &mut dyn io::Write| {
@@ -72,14 +72,14 @@ where
                 fs::metadata(expected_filename).unwrap()
             } else {
                 eprintln!("Tried to open {}.", expected_filename);
-                return Err(e.into());
+                return Err(e);
             }
         }
     };
 
     let expected_len = metadata.len() as usize;
     let mut result = Cursor::new(Vec::with_capacity(expected_len));
-    let return_value = collapse(&mut result)?;
+    collapse(&mut result)?;
     let expected = BufReader::new(File::open(expected_filename)?);
     // write out the expected result to /tmp for easy restoration
     result.set_position(0);
@@ -90,7 +90,7 @@ where
     }
     // and then compare
     compare_results(result, expected, expected_filename, strip_quotes);
-    Ok(return_value)
+    Ok(())
 }
 
 pub fn test_collapse_logs<C, F>(mut collapser: C, input_file: &str, asserter: F)

--- a/tests/diff-folded.rs
+++ b/tests/diff-folded.rs
@@ -25,14 +25,14 @@ fn test_diff_folded(
                 differential::from_files(options, &infile1, &infile2, &mut f)?;
                 fs::metadata(expected_result_file).unwrap()
             } else {
-                return Err(e.into());
+                return Err(e);
             }
         }
     };
 
     let expected_len = metadata.len() as usize;
     let mut result = Cursor::new(Vec::with_capacity(expected_len));
-    let return_value = differential::from_files(options, infile1, infile2, &mut result)?;
+    differential::from_files(options, infile1, infile2, &mut result)?;
     let expected = BufReader::new(File::open(expected_result_file).unwrap());
     // write out the expected result to /tmp for easy restoration
     result.set_position(0);
@@ -44,7 +44,7 @@ fn test_diff_folded(
     // and then compare
     result.set_position(0);
     compare_results(result, expected, expected_result_file);
-    Ok(return_value)
+    Ok(())
 }
 
 fn compare_results<R, E>(result: R, expected: E, expected_file: &str)
@@ -155,7 +155,7 @@ fn diff_folded_should_log_warning_on_bad_input_line() {
         "./tests/data/diff-folded/after.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body.starts_with("Unable to parse line: ") && log.level == Level::Warn
                 })
@@ -176,7 +176,7 @@ fn diff_folded_should_log_warning_about_fractional_samples() {
         "./tests/data/diff-folded/after.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body == "The input data has fractional sample counts that will be truncated to integers" && log.level == Level::Warn
                 })

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -52,7 +52,7 @@ fn test_flamegraph_multiple_files(
 
     let expected_len = metadata.len() as usize;
     let mut result = Cursor::new(Vec::with_capacity(expected_len));
-    let return_value = flamegraph::from_files(&mut options, &input_files, &mut result)?;
+    flamegraph::from_files(&mut options, &input_files, &mut result)?;
     let expected = BufReader::new(File::open(expected_result_file).unwrap());
     // write out the expected result to /tmp for easy restoration
     result.set_position(0);
@@ -64,7 +64,7 @@ fn test_flamegraph_multiple_files(
     // and then compare
     result.set_position(0);
     compare_results(result, expected, expected_result_file);
-    Ok(return_value)
+    Ok(())
 }
 
 fn compare_results<R, E>(result: R, mut expected: E, expected_file: &str)
@@ -259,7 +259,7 @@ fn flamegraph_nameattr_should_warn_about_duplicate_attributes() {
     let _ = flamegraph::FuncFrameAttrsMap::from_file(&PathBuf::from(nameattr_file));
     testing_logger::validate(|captured_logs| {
         let nwarnings = captured_logs
-            .into_iter()
+            .iter()
             .filter(|log| log.body.starts_with("duplicate attribute") && log.level == Level::Warn)
             .count();
         assert_eq!(
@@ -278,7 +278,7 @@ fn flamegraph_nameattr_should_warn_about_invalid_attribute() {
     let _ = flamegraph::FuncFrameAttrsMap::from_file(&PathBuf::from(nameattr_file));
     testing_logger::validate(|captured_logs| {
         let nwarnings = captured_logs
-            .into_iter()
+            .iter()
             .filter(|log| log.body.starts_with("invalid attribute") && log.level == Level::Warn)
             .count();
         assert_eq!(
@@ -295,7 +295,7 @@ fn flamegraph_should_warn_about_fractional_samples() {
         "./tests/data/flamegraph/fractional-samples/fractional.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body
                         .starts_with("The input data has fractional sample counts")
@@ -317,7 +317,7 @@ fn flamegraph_should_not_warn_about_zero_fractional_samples() {
         "./tests/data/flamegraph/fractional-samples/zero-fractionals.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body
                         .starts_with("The input data has fractional sample counts")
@@ -338,7 +338,7 @@ fn flamegraph_should_not_warn_about_fractional_sample_with_tricky_stack() {
         "./tests/data/flamegraph/fractional-samples/tricky-stack.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body
                         .starts_with("The input data has fractional sample counts")
@@ -380,7 +380,7 @@ fn flamegraph_palette_map_should_warn_about_invalid_lines() {
     let _ = load_palette_map_file(palette_file);
     testing_logger::validate(|captured_logs| {
         let nwarnings = captured_logs
-            .into_iter()
+            .iter()
             .filter(|log| {
                 log.body == ("Ignored 5 lines with invalid format") && log.level == Level::Warn
             })
@@ -399,7 +399,7 @@ fn flamegraph_should_warn_about_bad_input_lines() {
         "./tests/data/flamegraph/bad-lines/bad-lines.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body.starts_with("Ignored")
                         && log.body.ends_with(" lines with invalid format")
@@ -419,7 +419,7 @@ fn flamegraph_should_warn_about_bad_input_lines() {
 fn flamegraph_should_warn_about_empty_input() {
     test_flamegraph_logs("./tests/data/flamegraph/empty/empty.txt", |captured_logs| {
         let nwarnings = captured_logs
-            .into_iter()
+            .iter()
             .filter(|log| log.body == "No stack counts found" && log.level == Level::Error)
             .count();
         assert_eq!(
@@ -793,7 +793,7 @@ fn flamegraph_should_warn_about_no_sort_when_reversing_stack_ordering() {
         "./flamegraph/test/results/perf-funcab-cmd-01-collapsed-all.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-            .into_iter()
+            .iter()
             .filter(|log| log.body == "Input lines are always sorted when `reverse_stack_order` is `true`. The `no_sort` option is being ignored." && log.level == Level::Warn)
             .count();
             assert_eq!(
@@ -816,7 +816,7 @@ fn flamegraph_should_warn_about_bad_input_lines_with_reversed_stack_ordering() {
         "./tests/data/flamegraph/bad-lines/bad-lines.txt",
         |captured_logs| {
             let nwarnings = captured_logs
-                .into_iter()
+                .iter()
                 .filter(|log| {
                     log.body.starts_with("Ignored")
                         && log.body.ends_with(" lines with invalid format")


### PR DESCRIPTION
* Replace chashmap with dashmap
* ~~Replace fnv with fxhash~~ Replace fnv with ahash
* Update some outdated dependencies
* Fix some clippy warnings
* Upgrade MSRV to 1.40.0 (required by dashmap)

Signed-off-by: koushiro <koushiro.cqx@gmail.com>

```
$ cargo tree --no-indent | sed 's/ (\*)//' | sort -u | wc -l
110 => 108
```