### PR TITLE
Mention the default value of Options::text_truncation_direction inline

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -172,9 +172,7 @@ pub struct Options<'a> {
     /// [Default value](defaults::FONT_WIDTH).
     pub font_width: f64,
 
-    /// When text doesn't fit in a frame, should we cut off left side or right side?
-    ///
-    /// [Default value](defaults::TEXT_TRUNCATE_DIRECTION)
+    /// When text doesn't fit in a frame, should we cut off left side (the default) or right side?
     pub text_truncate_direction: TextTruncateDirection,
 
     /// Count type label for the flame graph.


### PR DESCRIPTION
TextTruncateDirection gets its default value from an implementation of the
Default trait, not via an entry in the defaults module. As such, the link to its
default value didn't actually work: on
https://docs.rs/inferno/0.9.5/inferno/flamegraph/struct.Options.html#structfield.text_truncate_direction,
it's a link to `defaults::TEXT_TRUNCATE_DIRECTION` (no http or anything useful).
Similar to Options::direction, put `(the default)` after the default value in
the description.