### PR TITLE
flamegraph: fix "unnecessary braces" warning

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -477,8 +477,8 @@ where
     let mut thread_rng = rand::thread_rng();
 
     // structs to reuse accross loops to avoid allocations
-    let mut cache_g = Event::Start({ BytesStart::owned_name("g") });
-    let mut cache_a = Event::Start({ BytesStart::owned_name("a") });
+    let mut cache_g = Event::Start(BytesStart::owned_name("g"));
+    let mut cache_a = Event::Start(BytesStart::owned_name("a"));
     let mut cache_rect = Event::Empty(BytesStart::owned_name("rect"));
     let cache_g_end = Event::End(BytesEnd::borrowed(b"g"));
     let cache_a_end = Event::End(BytesEnd::borrowed(b"a"));


### PR DESCRIPTION
Fixes the following warnings:

```
warning: unnecessary braces around function argument
   --> src/flamegraph/mod.rs:480:36
    |
480 |     let mut cache_g = Event::Start({ BytesStart::owned_name("g") });
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these braces
    |
    = note: `#[warn(unused_braces)]` on by default

warning: unnecessary braces around function argument
   --> src/flamegraph/mod.rs:481:36
    |
481 |     let mut cache_a = Event::Start({ BytesStart::owned_name("a") });
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these braces
```

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>