### PR TITLE
Support symbol mangle v0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ quick-xml = { version = "0.18", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 structopt = { version = "0.3", optional = true }
+rustc-demangle = "0.1"
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -299,6 +299,10 @@ impl Folder {
     fn fix_rust_symbol<'a>(&self, frame: &'a str) -> Cow<'a, str> {
         let mut parts = frame.splitn(2, '`');
         if let (Some(pname), Some(func)) = (parts.next(), parts.next()) {
+            // Support rust symbol mangling (v0)
+            if let Ok(demangled_func) = rustc_demangle::try_demangle(func) {
+                return Cow::Owned(format!("{}`{}", pname, demangled_func));
+            }
             if self.opt.includeoffset {
                 let mut parts = func.rsplitn(2, '+');
                 if let (Some(offset), Some(func)) = (parts.next(), parts.next()) {


### PR DESCRIPTION
Dtrace doesn't demangle symbol mangle v0. Inferno needs to do it.