### PR TITLE
Implement --deterministic, for chaotic but repeatable color selection

### DIFF
--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -20,9 +20,14 @@ struct Opt {
     #[structopt(long = "cp")]
     cp: bool,
 
-    /// Colors are keyed by function name hash
+    /// Colors are selected by hashing the function name, weighting the first characters more
+    /// heavily
     #[structopt(long = "hash")]
     hash: bool,
+
+    /// Colors are selected chaotically but the color of a function does not change between runs
+    #[structopt(long = "deterministic")]
+    deterministic: bool,
 
     /// Plot the flame graph up-side-down
     #[structopt(short = "i", long = "inverted")]
@@ -208,6 +213,7 @@ impl<'a> Opt {
         options.colors = self.colors;
         options.bgcolors = self.bgcolors;
         options.hash = self.hash;
+        options.deterministic = self.deterministic;
 
         self.set_func_frameattrs(&mut options);
 

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -26,7 +26,7 @@ struct Opt {
     hash: bool,
 
     /// Colors are selected such that the color of a function does not change between runs
-    #[structopt(long = "deterministic")]
+    #[structopt(long = "deterministic", conflicts_with = "hash")]
     deterministic: bool,
 
     /// Plot the flame graph up-side-down

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -22,11 +22,11 @@ struct Opt {
 
     /// Colors are selected by hashing the function name, weighting the first characters more
     /// heavily
-    #[structopt(long = "hash")]
+    #[structopt(long = "hash", conflicts_with = "deterministic")]
     hash: bool,
 
     /// Colors are selected chaotically but the color of a function does not change between runs
-    #[structopt(long = "deterministic")]
+    #[structopt(long = "deterministic", conflicts_with = "hash")]
     deterministic: bool,
 
     /// Plot the flame graph up-side-down

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -331,6 +331,7 @@ fn rgb_components_for_palette(palette: Palette, name: &str, v1: f32, v2: f32, v3
 pub(super) fn color(
     palette: Palette,
     hash: bool,
+    deterministic: bool,
     name: &str,
     mut rng: impl FnMut() -> f32,
 ) -> Color {
@@ -339,6 +340,13 @@ pub(super) fn color(
         let reverse_name_hash = namehash(name.bytes().rev());
 
         (name_hash, reverse_name_hash, reverse_name_hash)
+    } else if deterministic {
+        use std::hash::Hasher;
+        let mut hasher = ahash::AHasher::default();
+        hasher.write(name.as_bytes());
+        let hash = hasher.finish() as f32 / u64::MAX as f32;
+
+        (hash, hash, hash)
     } else {
         (rng(), rng(), rng())
     };

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -342,7 +342,8 @@ pub(super) fn color(
         (name_hash, reverse_name_hash, reverse_name_hash)
     } else if deterministic {
         use std::hash::Hasher;
-        let mut hasher = ahash::AHasher::default();
+        // Do not use AHasher::default; it is seeded with a compile-time RNG
+        let mut hasher = ahash::AHasher::new_with_keys(1234, 5678);
         hasher.write(name.as_bytes());
         let hash1 = (hasher.finish() as f64 / std::u64::MAX as f64) as f32;
         hasher.write_u8(0);

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -342,17 +342,15 @@ pub(super) fn color(
         (name_hash, reverse_name_hash, reverse_name_hash)
     } else if deterministic {
         use std::hash::Hasher;
-        let prefixed_hash = |name: &str, prefix: u8| {
-            let mut hasher = ahash::AHasher::default();
-            hasher.write_u8(prefix);
-            hasher.write(name.as_bytes());
-            (hasher.finish() as f64 / u64::MAX as f64) as f32
-        };
-        (
-            prefixed_hash(name, 0),
-            prefixed_hash(name, 1),
-            prefixed_hash(name, 2),
-        )
+        let mut hasher = ahash::AHasher::default();
+        hasher.write(name.as_bytes());
+        let hash1 = (hasher.finish() as f64 / u64::MAX as f64) as f32;
+        hasher.write_u8(0);
+        let hash2 = (hasher.finish() as f64 / u64::MAX as f64) as f32;
+        hasher.write_u8(1);
+        let hash3 = (hasher.finish() as f64 / u64::MAX as f64) as f32;
+
+        (hash1, hash2, hash3)
     } else {
         (rng(), rng(), rng())
     };

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -342,11 +342,17 @@ pub(super) fn color(
         (name_hash, reverse_name_hash, reverse_name_hash)
     } else if deterministic {
         use std::hash::Hasher;
-        let mut hasher = ahash::AHasher::default();
-        hasher.write(name.as_bytes());
-        let hash = hasher.finish() as f32 / u64::MAX as f32;
-
-        (hash, hash, hash)
+        let prefixed_hash = |name: &str, prefix: u8| {
+            let mut hasher = ahash::AHasher::default();
+            hasher.write_u8(prefix);
+            hasher.write(name.as_bytes());
+            (hasher.finish() as f64 / u64::MAX as f64) as f32
+        };
+        (
+            prefixed_hash(name, 0),
+            prefixed_hash(name, 1),
+            prefixed_hash(name, 2),
+        )
     } else {
         (rng(), rng(), rng())
     };

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -344,11 +344,11 @@ pub(super) fn color(
         use std::hash::Hasher;
         let mut hasher = ahash::AHasher::default();
         hasher.write(name.as_bytes());
-        let hash1 = (hasher.finish() as f64 / u64::MAX as f64) as f32;
+        let hash1 = (hasher.finish() as f64 / std::u64::MAX as f64) as f32;
         hasher.write_u8(0);
-        let hash2 = (hasher.finish() as f64 / u64::MAX as f64) as f32;
-        hasher.write_u8(1);
-        let hash3 = (hasher.finish() as f64 / u64::MAX as f64) as f32;
+        let hash2 = (hasher.finish() as f64 / std::u64::MAX as f64) as f32;
+        hasher.write_u8(0);
+        let hash3 = (hasher.finish() as f64 / std::u64::MAX as f64) as f32;
 
         (hash1, hash2, hash3)
     } else {

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -107,6 +107,10 @@ pub struct Options<'a> {
     /// This will cause similar functions to be colored similarly.
     pub hash: bool,
 
+    /// Choose names based on the hashes of function names, without the weighting scheme that
+    /// `hash` uses.
+    pub deterministic: bool,
+
     /// Store the choice of color for each function so that later invocations use the same colors.
     ///
     /// With this option enabled, a file called `palette.map` will be created the first time a
@@ -297,6 +301,7 @@ impl<'a> Default for Options<'a> {
             subtitle: Default::default(),
             bgcolors: Default::default(),
             hash: Default::default(),
+            deterministic: Default::default(),
             palette_map: Default::default(),
             direction: Default::default(),
             negate_differentials: Default::default(),
@@ -623,13 +628,15 @@ where
         } else if let Some(ref mut palette_map) = opt.palette_map {
             let colors = opt.colors;
             let hash = opt.hash;
+            let deterministic = opt.deterministic;
             palette_map.find_color_for(&frame.location.function, |name| {
-                color::color(colors, hash, name, &mut thread_rng)
+                color::color(colors, hash, deterministic, name, &mut thread_rng)
             })
         } else {
             color::color(
                 opt.colors,
                 opt.hash,
+                opt.deterministic,
                 frame.location.function,
                 &mut thread_rng,
             )

--- a/tests/data/flamegraph/colors/deterministic.svg
+++ b/tests/data/flamegraph/colors/deterministic.svg
@@ -37,1177 +37,1177 @@ var truncate_text_right = false;]]>
     <svg id="frames" x="10" width="1180">
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8575.1705890900.apply$mcV$sp (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(220,102,51)"/>
+            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(225,215,45)"/>
             <text x="0.2500%" y="751.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$124 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(252,157,54)"/>
+            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(212,220,53)"/>
             <text x="0.2500%" y="735.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(252,47,46)"/>
+            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(253,41,30)"/>
             <text x="0.2500%" y="719.50">c..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(214,41,30)"/>
+            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(209,7,17)"/>
             <text x="0.2500%" y="703.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(227,222,18)"/>
+            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(251,90,35)"/>
             <text x="0.2500%" y="687.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(235,88,33)"/>
+            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(230,226,1)"/>
             <text x="0.2500%" y="671.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(243,78,7)"/>
+            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(237,131,42)"/>
             <text x="0.2500%" y="655.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(219,50,13)"/>
+            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(218,195,8)"/>
             <text x="0.2500%" y="639.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(247,202,37)"/>
+            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(215,129,4)"/>
             <text x="0.2500%" y="623.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(251,172,43)"/>
+            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(236,107,6)"/>
             <text x="0.2500%" y="607.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(246,68,6)"/>
+            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(235,109,2)"/>
             <text x="0.2500%" y="591.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(216,70,17)"/>
+            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(211,182,17)"/>
             <text x="0.2500%" y="575.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(215,141,13)"/>
+            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(206,82,40)"/>
             <text x="0.2500%" y="559.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(233,29,52)"/>
+            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(210,133,6)"/>
             <text x="0.2500%" y="543.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(206,61,49)"/>
+            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(242,43,9)"/>
             <text x="0.2500%" y="527.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(253,187,28)"/>
+            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(209,84,2)"/>
             <text x="0.2500%" y="511.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(247,145,48)"/>
+            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(242,213,11)"/>
             <text x="0.2500%" y="495.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(215,131,2)"/>
+            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(238,128,48)"/>
             <text x="0.2500%" y="479.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(215,141,13)"/>
+            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(206,82,40)"/>
             <text x="0.2500%" y="463.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(233,29,52)"/>
+            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(210,133,6)"/>
             <text x="0.2500%" y="447.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(206,61,49)"/>
+            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(242,43,9)"/>
             <text x="0.2500%" y="431.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(253,187,28)"/>
+            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(209,84,2)"/>
             <text x="0.2500%" y="415.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(247,145,48)"/>
+            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(242,213,11)"/>
             <text x="0.2500%" y="399.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(215,131,2)"/>
+            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(238,128,48)"/>
             <text x="0.2500%" y="383.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(216,3,21)"/>
+            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(245,127,31)"/>
             <text x="0.2500%" y="367.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(233,47,47)"/>
+            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(219,196,36)"/>
             <text x="0.2500%" y="351.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(216,134,5)"/>
+            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(229,97,43)"/>
             <text x="0.2500%" y="335.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(240,37,30)"/>
+            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(221,31,3)"/>
             <text x="0.2500%" y="319.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(251,33,48)"/>
+            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(249,11,24)"/>
             <text x="0.2500%" y="303.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(226,75,42)"/>
+            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(244,27,39)"/>
             <text x="0.2500%" y="287.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(246,74,53)"/>
+            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(230,215,6)"/>
             <text x="0.2500%" y="271.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(240,194,24)"/>
+            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(230,138,10)"/>
             <text x="0.2500%" y="255.50">o..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$9984.1092558103.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(222,39,47)"/>
+            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(220,216,1)"/>
             <text x="0.2500%" y="239.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(219,158,2)"/>
+            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(205,16,18)"/>
             <text x="0.2500%" y="223.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(227,60,42)"/>
+            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(210,13,27)"/>
             <text x="0.2500%" y="207.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$5 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(230,55,48)"/>
+            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(237,67,26)"/>
             <text x="0.2500%" y="191.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase16AsBytes (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(224,155,39)"/>
+            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(236,126,9)"/>
             <text x="0.2500%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase16 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(224,196,28)"/>
+            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(221,35,51)"/>
             <text x="0.2500%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(227,5,50)"/>
+            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(210,125,16)"/>
             <text x="0.2500%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(221,97,42)"/>
+            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(233,62,6)"/>
             <text x="0.2500%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(243,168,19)"/>
+            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(225,86,26)"/>
             <text x="0.2500%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(231,157,5)"/>
+            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(222,126,39)"/>
             <text x="0.2500%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(231,137,49)"/>
+            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(221,167,16)"/>
             <text x="0.2500%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(218,82,49)"/>
+            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(219,118,3)"/>
             <text x="0.2500%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(242,134,29)"/>
+            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(209,20,33)"/>
             <text x="0.2500%" y="47.50">s..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64AsBytes (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(223,109,7)"/>
+            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(209,105,20)"/>
             <text x="2.3543%" y="175.50"></text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(220,67,53)"/>
+            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(207,90,20)"/>
             <text x="2.3543%" y="159.50"></text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(227,5,50)"/>
+            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(210,125,16)"/>
             <text x="2.3543%" y="143.50"></text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(221,97,42)"/>
+            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(233,62,6)"/>
             <text x="2.3543%" y="127.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(243,168,19)"/>
+            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(225,86,26)"/>
             <text x="2.3543%" y="111.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(231,157,5)"/>
+            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(222,126,39)"/>
             <text x="2.3543%" y="95.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(231,137,49)"/>
+            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(221,167,16)"/>
             <text x="2.3543%" y="79.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(218,82,49)"/>
+            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(219,118,3)"/>
             <text x="2.3543%" y="63.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(242,134,29)"/>
+            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(209,20,33)"/>
             <text x="2.3543%" y="47.50"></text>
         </g>
         <g>
             <title>java.lang.Thread.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(210,79,46)"/>
+            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(213,174,21)"/>
             <text x="0.2500%" y="1903.50">java.la..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor$Worker.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(219,191,46)"/>
+            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(209,144,39)"/>
             <text x="0.2500%" y="1887.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor.runWorker (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(244,50,22)"/>
+            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(242,72,13)"/>
             <text x="0.2500%" y="1871.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(227,24,21)"/>
+            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(215,40,35)"/>
             <text x="0.2500%" y="1855.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.Executors$RunnableAdapter.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(213,3,17)"/>
+            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(218,19,14)"/>
             <text x="0.2500%" y="1839.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(227,24,21)"/>
+            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(215,40,35)"/>
             <text x="0.2500%" y="1823.50">java.ut..</text>
         </g>
         <g>
             <title>sbt.CompletionService$$anon$2.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(241,45,17)"/>
+            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(226,31,49)"/>
             <text x="0.2500%" y="1807.50">sbt.Com..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4$$Lambda$2176.1600330912.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(229,111,36)"/>
+            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(222,111,4)"/>
             <text x="0.2500%" y="1791.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(249,213,27)"/>
+            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(207,114,41)"/>
             <text x="0.2500%" y="1775.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2169.2034046523.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(247,77,17)"/>
+            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(235,94,28)"/>
             <text x="0.2500%" y="1759.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(222,188,33)"/>
+            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(242,157,34)"/>
             <text x="0.2500%" y="1743.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(210,59,43)"/>
+            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(242,36,44)"/>
             <text x="0.2500%" y="1727.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.internal.util.ErrorHandling$.wideConvert (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(220,65,2)"/>
+            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(233,30,10)"/>
             <text x="0.2500%" y="1711.50">sbt.int..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2178.2095669414.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(237,77,4)"/>
+            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(207,99,19)"/>
             <text x="0.2500%" y="1695.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(228,225,21)"/>
+            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(214,107,28)"/>
             <text x="0.2500%" y="1679.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$4.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(226,122,31)"/>
+            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(205,49,51)"/>
             <text x="0.2500%" y="1663.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3$$Lambda$2167.231900526.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(206,55,4)"/>
+            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(218,54,43)"/>
             <text x="0.2500%" y="1647.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3.$anonfun$apply$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(244,37,11)"/>
+            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(247,141,38)"/>
             <text x="0.2500%" y="1631.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.Tests$$$Lambda$7842.1208470949.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(233,51,37)"/>
+            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(207,11,20)"/>
             <text x="0.2500%" y="1615.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.Tests$.$anonfun$toTask$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(210,126,29)"/>
+            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(213,7,24)"/>
             <text x="0.2500%" y="1599.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFunction.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(252,157,48)"/>
+            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(218,154,23)"/>
             <text x="0.2500%" y="1583.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(251,34,11)"/>
+            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(219,19,36)"/>
             <text x="0.2500%" y="1567.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(251,34,11)"/>
+            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(219,19,36)"/>
             <text x="0.2500%" y="1551.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$.sbt$TestFramework$$withContextLoader (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(228,164,52)"/>
+            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(249,109,23)"/>
             <text x="0.2500%" y="1535.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1$$Lambda$7850.1117892339.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(222,204,47)"/>
+            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(208,221,41)"/>
             <text x="0.2500%" y="1519.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(250,71,9)"/>
+            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(211,124,16)"/>
             <text x="0.2500%" y="1503.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(227,90,30)"/>
+            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(230,148,3)"/>
             <text x="0.2500%" y="1487.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(231,59,29)"/>
+            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(244,13,21)"/>
             <text x="0.2500%" y="1471.50">sbt.Tes..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework$ScalaTestTask.execute (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(241,135,42)"/>
+            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(240,188,27)"/>
             <text x="0.2500%" y="1455.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(220,149,36)"/>
+            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(216,179,6)"/>
             <text x="0.2500%" y="1439.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(239,142,14)"/>
+            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(224,34,33)"/>
             <text x="0.2500%" y="1423.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(253,183,53)"/>
+            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(215,190,11)"/>
             <text x="0.2500%" y="1407.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(208,161,30)"/>
+            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(205,7,7)"/>
             <text x="0.2500%" y="1391.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(250,2,18)"/>
+            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(205,185,22)"/>
             <text x="0.2500%" y="1375.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7943.1056778999.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(234,62,31)"/>
+            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(229,206,35)"/>
             <text x="0.2500%" y="1359.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(240,58,13)"/>
+            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(239,159,17)"/>
             <text x="0.2500%" y="1343.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(234,42,46)"/>
+            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(207,118,29)"/>
             <text x="0.2500%" y="1327.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(211,114,32)"/>
+            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(247,0,17)"/>
             <text x="0.2500%" y="1311.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(222,31,9)"/>
+            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(232,81,42)"/>
             <text x="0.2500%" y="1295.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(249,222,8)"/>
+            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(209,38,47)"/>
             <text x="0.2500%" y="1279.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(225,134,17)"/>
+            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(205,212,45)"/>
             <text x="0.2500%" y="1263.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(211,171,24)"/>
+            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(230,139,47)"/>
             <text x="0.2500%" y="1247.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(226,168,40)"/>
+            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(242,158,4)"/>
             <text x="0.2500%" y="1231.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(239,76,39)"/>
+            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(240,38,10)"/>
             <text x="0.2500%" y="1215.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(229,198,12)"/>
+            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(251,25,10)"/>
             <text x="0.2500%" y="1199.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(220,160,11)"/>
+            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(237,101,4)"/>
             <text x="0.2500%" y="1183.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(220,111,53)"/>
+            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(238,4,42)"/>
             <text x="0.2500%" y="1167.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(206,178,29)"/>
+            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(227,122,1)"/>
             <text x="0.2500%" y="1151.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(239,76,39)"/>
+            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(240,38,10)"/>
             <text x="0.2500%" y="1135.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(229,198,12)"/>
+            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(251,25,10)"/>
             <text x="0.2500%" y="1119.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(220,160,11)"/>
+            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(237,101,4)"/>
             <text x="0.2500%" y="1103.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(220,111,53)"/>
+            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(238,4,42)"/>
             <text x="0.2500%" y="1087.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(206,178,29)"/>
+            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(227,122,1)"/>
             <text x="0.2500%" y="1071.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7951.1136212450.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(240,80,28)"/>
+            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(254,143,13)"/>
             <text x="0.2500%" y="1055.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(223,190,6)"/>
+            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(208,19,27)"/>
             <text x="0.2500%" y="1039.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(211,45,41)"/>
+            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(233,70,0)"/>
             <text x="0.2500%" y="1023.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(215,29,35)"/>
+            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(236,59,24)"/>
             <text x="0.2500%" y="1007.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(252,190,17)"/>
+            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(223,66,45)"/>
             <text x="0.2500%" y="991.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(233,79,35)"/>
+            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(243,196,30)"/>
             <text x="0.2500%" y="975.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7967.812636372.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(229,91,48)"/>
+            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(227,102,52)"/>
             <text x="0.2500%" y="959.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(250,134,24)"/>
+            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(230,199,40)"/>
             <text x="0.2500%" y="943.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(217,216,9)"/>
+            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(221,201,36)"/>
             <text x="0.2500%" y="927.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(231,74,39)"/>
+            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(236,47,44)"/>
             <text x="0.2500%" y="911.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(240,207,29)"/>
+            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(243,93,16)"/>
             <text x="0.2500%" y="895.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(237,134,35)"/>
+            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(217,116,36)"/>
             <text x="0.2500%" y="879.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(245,149,30)"/>
+            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(236,2,28)"/>
             <text x="0.2500%" y="863.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(212,203,8)"/>
+            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(243,224,27)"/>
             <text x="0.2500%" y="847.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(212,203,8)"/>
+            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(243,224,27)"/>
             <text x="0.2500%" y="831.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf$.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(242,152,44)"/>
+            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(254,181,25)"/>
             <text x="0.2500%" y="815.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(233,99,40)"/>
+            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(245,169,50)"/>
             <text x="0.2500%" y="799.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(246,111,11)"/>
+            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(251,209,25)"/>
             <text x="0.2500%" y="783.50">org.sca..</text>
         </g>
         <g>
             <title>scala.runtime.java8.JFunction0$mcV$sp.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(246,12,5)"/>
+            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(230,162,33)"/>
             <text x="0.2500%" y="767.50">scala.r..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8582.1627656208.apply$mcV$sp (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(254,229,0)"/>
+            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(214,141,28)"/>
             <text x="2.3543%" y="751.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$136 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(222,155,20)"/>
+            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(205,138,48)"/>
             <text x="2.3543%" y="735.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(252,47,46)"/>
+            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(253,41,30)"/>
             <text x="2.3543%" y="719.50">com..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(214,41,30)"/>
+            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(209,7,17)"/>
             <text x="2.3543%" y="703.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(227,222,18)"/>
+            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(251,90,35)"/>
             <text x="2.3543%" y="687.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(235,88,33)"/>
+            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(230,226,1)"/>
             <text x="2.3543%" y="671.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(243,78,7)"/>
+            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(237,131,42)"/>
             <text x="2.3543%" y="655.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(219,50,13)"/>
+            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(218,195,8)"/>
             <text x="2.3543%" y="639.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(247,202,37)"/>
+            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(215,129,4)"/>
             <text x="2.3543%" y="623.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(251,172,43)"/>
+            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(236,107,6)"/>
             <text x="2.3543%" y="607.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(246,68,6)"/>
+            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(235,109,2)"/>
             <text x="2.3543%" y="591.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(216,70,17)"/>
+            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(211,182,17)"/>
             <text x="2.3543%" y="575.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(215,141,13)"/>
+            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(206,82,40)"/>
             <text x="2.3543%" y="559.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(233,29,52)"/>
+            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(210,133,6)"/>
             <text x="2.3543%" y="543.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(206,61,49)"/>
+            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(242,43,9)"/>
             <text x="2.3543%" y="527.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(253,187,28)"/>
+            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(209,84,2)"/>
             <text x="2.3543%" y="511.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(247,145,48)"/>
+            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(242,213,11)"/>
             <text x="2.3543%" y="495.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(215,131,2)"/>
+            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(238,128,48)"/>
             <text x="2.3543%" y="479.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(215,141,13)"/>
+            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(206,82,40)"/>
             <text x="2.3543%" y="463.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(233,29,52)"/>
+            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(210,133,6)"/>
             <text x="2.3543%" y="447.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(206,61,49)"/>
+            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(242,43,9)"/>
             <text x="2.3543%" y="431.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(253,187,28)"/>
+            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(209,84,2)"/>
             <text x="2.3543%" y="415.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(247,145,48)"/>
+            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(242,213,11)"/>
             <text x="2.3543%" y="399.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(215,131,2)"/>
+            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(238,128,48)"/>
             <text x="2.3543%" y="383.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(216,3,21)"/>
+            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(245,127,31)"/>
             <text x="2.3543%" y="367.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(233,47,47)"/>
+            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(219,196,36)"/>
             <text x="2.3543%" y="351.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(216,134,5)"/>
+            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(229,97,43)"/>
             <text x="2.3543%" y="335.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(240,37,30)"/>
+            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(221,31,3)"/>
             <text x="2.3543%" y="319.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(251,33,48)"/>
+            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(249,11,24)"/>
             <text x="2.3543%" y="303.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(226,75,42)"/>
+            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(244,27,39)"/>
             <text x="2.3543%" y="287.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(246,74,53)"/>
+            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(230,215,6)"/>
             <text x="2.3543%" y="271.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(240,194,24)"/>
+            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(230,138,10)"/>
             <text x="2.3543%" y="255.50">org..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$10462.775835262.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(221,80,42)"/>
+            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(246,145,6)"/>
             <text x="2.3543%" y="239.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(238,6,17)"/>
+            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(229,34,53)"/>
             <text x="2.3543%" y="223.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(240,119,52)"/>
+            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(232,159,5)"/>
             <text x="2.3543%" y="207.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$6 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(225,162,37)"/>
+            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(243,180,4)"/>
             <text x="2.3543%" y="191.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64UrlAsBytes (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(250,228,46)"/>
+            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(246,227,44)"/>
             <text x="3.9401%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(220,67,53)"/>
+            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(207,90,20)"/>
             <text x="3.9401%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(227,5,50)"/>
+            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(210,125,16)"/>
             <text x="3.9401%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(221,97,42)"/>
+            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(233,62,6)"/>
             <text x="3.9401%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(243,168,19)"/>
+            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(225,86,26)"/>
             <text x="3.9401%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(231,157,5)"/>
+            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(222,126,39)"/>
             <text x="3.9401%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(231,137,49)"/>
+            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(221,167,16)"/>
             <text x="3.9401%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(218,82,49)"/>
+            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(219,118,3)"/>
             <text x="3.9401%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(242,134,29)"/>
+            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(209,20,33)"/>
             <text x="3.9401%" y="47.50">s..</text>
         </g>
         <g>
             <title>DrainStacksCompactionTask::do_it(GCTaskManager*, unsigned int) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(245,120,40)"/>
+            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(237,143,36)"/>
             <text x="5.8615%" y="1855.50">Dra..</text>
         </g>
         <g>
             <title>ParCompactionManager::drain_region_stacks() (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(237,89,35)"/>
+            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(229,105,39)"/>
             <text x="5.8615%" y="1839.50">Par..</text>
         </g>
         <g>
             <title>PSParallelCompact::fill_region(ParCompactionManager*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(250,179,33)"/>
+            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(226,29,51)"/>
             <text x="5.8615%" y="1823.50">PSP..</text>
         </g>
         <g>
             <title>ParMarkBitMap::iterate(ParMarkBitMapClosure*, unsigned long, unsigned long) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(237,61,30)"/>
+            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(248,3,31)"/>
             <text x="5.8615%" y="1807.50">Par..</text>
         </g>
         <g>
             <title>MoveAndUpdateClosure::do_addr(HeapWord*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(234,30,14)"/>
+            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(233,47,42)"/>
             <text x="5.8615%" y="1791.50">Mov..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_update_pointers(ParCompactionManager*, oopDesc*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(232,22,14)"/>
+            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(246,150,31)"/>
             <text x="5.8615%" y="1775.50">Ins..</text>
         </g>
         <g>
             <title>ParallelCompactData::calc_new_pointer(HeapWord*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(238,193,27)"/>
+            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(215,137,51)"/>
             <text x="5.8615%" y="1759.50">Par..</text>
         </g>
         <g>
             <title>ParMarkBitMap::live_words_in_range(HeapWord*, oopDesc*) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(250,86,15)"/>
+            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(219,75,10)"/>
             <text x="5.8615%" y="1743.50">Par..</text>
         </g>
         <g>
             <title>OldToYoungRootsTask::do_it(GCTaskManager*, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(214,136,8)"/>
+            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(214,226,20)"/>
             <text x="9.0637%" y="1855.50">OldToYoungRootsTask::do..</text>
         </g>
         <g>
             <title>CardTableExtension::scavenge_contents_parallel(ObjectStartArray*, MutableSpace*, HeapWord*, PSPromotionManager*, unsigned int, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(211,203,21)"/>
+            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(245,219,38)"/>
             <text x="9.0637%" y="1839.50">CardTableExtension::sca..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(245,191,22)"/>
+            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(210,180,3)"/>
             <text x="9.0637%" y="1823.50">PSPromotionManager::dra..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (358 samples, 10.92%)</title>
-            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(221,195,19)"/>
+            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(208,32,17)"/>
             <text x="13.0893%" y="1807.50">oopDesc* PSPromo..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (161 samples, 4.91%)</title>
-            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(244,132,41)"/>
+            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(236,84,53)"/>
             <text x="19.0972%" y="1791.50">Instan..</text>
         </g>
         <g>
             <title>GCTaskThread::run() (793 samples, 24.18%)</title>
-            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(226,134,54)"/>
+            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(253,62,51)"/>
             <text x="5.8615%" y="1871.50">GCTaskThread::run()</text>
         </g>
         <g>
             <title>StealTask::do_it(GCTaskManager*, unsigned int) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(237,158,39)"/>
+            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(235,150,46)"/>
             <text x="24.0072%" y="1855.50">StealTas..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(245,191,22)"/>
+            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(210,180,3)"/>
             <text x="24.0072%" y="1839.50">PSPromot..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (138 samples, 4.21%)</title>
-            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(221,195,19)"/>
+            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(208,32,17)"/>
             <text x="25.8371%" y="1823.50">oopDe..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (80 samples, 2.44%)</title>
-            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(244,132,41)"/>
+            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(236,84,53)"/>
             <text x="27.6059%" y="1807.50">In..</text>
         </g>
         <g>
             <title>Matcher::match() (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(232,51,22)"/>
+            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(208,184,3)"/>
             <text x="30.0457%" y="1759.50">Mat..</text>
         </g>
         <g>
             <title>Matcher::xform(Node*, int) (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(230,135,16)"/>
+            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(225,78,35)"/>
             <text x="30.0457%" y="1743.50">Mat..</text>
         </g>
         <g>
             <title>Arena::contains(void const*) const (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(242,109,32)"/>
+            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(226,52,47)"/>
             <text x="30.0457%" y="1727.50">Are..</text>
         </g>
         <g>
             <title>PhaseAggressiveCoalesce::insert_copies(Matcher&amp;) (86 samples, 2.62%)</title>
-            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(227,210,14)"/>
+            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(223,43,19)"/>
             <text x="33.3699%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::Split(unsigned int, ResourceArea*) (213 samples, 6.50%)</title>
-            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(206,223,27)"/>
+            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(217,100,4)"/>
             <text x="35.9926%" y="1743.50">PhaseChai..</text>
         </g>
         <g>
             <title>PhaseChaitin::build_ifg_physical(ResourceArea*) (305 samples, 9.30%)</title>
-            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(252,213,42)"/>
+            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(218,88,3)"/>
             <text x="42.4885%" y="1743.50">PhaseChaitin:..</text>
         </g>
         <g>
             <title>PhaseChaitin::interfere_with_live(unsigned int, IndexSet*) (183 samples, 5.58%)</title>
-            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(215,104,50)"/>
+            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(234,199,18)"/>
             <text x="46.2091%" y="1727.50">PhaseCh..</text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (66 samples, 2.01%)</title>
-            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(205,126,12)"/>
+            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(248,164,17)"/>
             <text x="49.7773%" y="1711.50">I..</text>
         </g>
         <g>
             <title>PhaseChaitin::gather_lrg_masks(bool) (95 samples, 2.90%)</title>
-            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(244,41,19)"/>
+            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(245,154,29)"/>
             <text x="51.7901%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::post_allocate_copy_removal() (139 samples, 4.24%)</title>
-            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(250,84,22)"/>
+            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(247,171,28)"/>
             <text x="54.6873%" y="1743.50">Phase..</text>
         </g>
         <g>
             <title>PhaseChaitin::elide_copy(Node*, int, Block*, Node_List&amp;, Node_List&amp;, bool) (76 samples, 2.32%)</title>
-            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(252,96,32)"/>
+            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(227,155,51)"/>
             <text x="56.6086%" y="1727.50">P..</text>
         </g>
         <g>
             <title>PhaseCoalesce::coalesce_driver() (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(232,213,50)"/>
+            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(241,11,19)"/>
             <text x="58.9264%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::coalesce(Block*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(247,177,1)"/>
+            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(242,54,29)"/>
             <text x="58.9264%" y="1727.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::update_ifg(unsigned int, unsigned int, IndexSet*, IndexSet*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(244,186,46)"/>
+            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(230,69,32)"/>
             <text x="58.9264%" y="1711.50">Ph..</text>
         </g>
         <g>
             <title>PhaseIFG::Compute_Effective_Degree() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(254,25,30)"/>
+            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(239,40,36)"/>
             <text x="61.7322%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(205,126,12)"/>
+            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(248,164,17)"/>
             <text x="61.7322%" y="1727.50"></text>
         </g>
         <g>
             <title>PhaseIFG::SquareUp() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(248,147,33)"/>
+            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(241,50,36)"/>
             <text x="63.3485%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(205,126,12)"/>
+            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(248,164,17)"/>
             <text x="63.3485%" y="1727.50"></text>
         </g>
         <g>
             <title>Compile::Code_Gen() (1,250 samples, 38.12%)</title>
-            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(241,3,42)"/>
+            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(215,70,26)"/>
             <text x="30.0457%" y="1775.50">Compile::Code_Gen()</text>
         </g>
         <g>
             <title>PhaseChaitin::Register_Allocate() (1,141 samples, 34.80%)</title>
-            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(250,196,4)"/>
+            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(206,38,41)"/>
             <text x="33.3699%" y="1759.50">PhaseChaitin::Register_Allocate()</text>
         </g>
         <g>
             <title>PhaseLive::compute(unsigned int) (110 samples, 3.35%)</title>
-            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(230,72,12)"/>
+            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(216,48,14)"/>
             <text x="64.8124%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::Dominators() (67 samples, 2.04%)</title>
-            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(213,90,37)"/>
+            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(231,72,8)"/>
             <text x="68.1670%" y="1743.50">P..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_early(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (108 samples, 3.29%)</title>
-            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(228,141,12)"/>
+            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(217,222,49)"/>
             <text x="70.2104%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (655 samples, 19.98%)</title>
-            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(237,43,45)"/>
+            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(222,177,5)"/>
             <text x="73.5040%" y="1743.50">PhaseIdealLoop::build_loop_late..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late_post(Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(244,33,18)"/>
+            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(251,195,42)"/>
             <text x="76.5233%" y="1727.50">PhaseIdealLoop::build_loop..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::get_late_ctrl(Node*, Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(246,49,7)"/>
+            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(244,37,15)"/>
             <text x="76.5233%" y="1711.50">PhaseIdealLoop::get_late_c..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::is_dominator(Node*, Node*) [clone .part.114] (496 samples, 15.13%)</title>
-            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(223,100,18)"/>
+            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(238,175,34)"/>
             <text x="78.3531%" y="1695.50">PhaseIdealLoop::is_domi..</text>
         </g>
         <g>
             <title>C2Compiler::compile_method(ciEnv*, ciMethod*, int) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(222,77,30)"/>
+            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(209,82,44)"/>
             <text x="30.0457%" y="1807.50">C2Compiler::compile_method(ciEnv*, ciMethod*, int)</text>
         </g>
         <g>
             <title>Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(243,65,17)"/>
+            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(205,46,27)"/>
             <text x="30.0457%" y="1791.50">Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool)</text>
         </g>
         <g>
             <title>Compile::Optimize() (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(213,36,46)"/>
+            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(208,27,18)"/>
             <text x="68.1670%" y="1775.50">Compile::Optimize()</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_and_optimize(bool, bool) (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(251,67,4)"/>
+            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(215,90,13)"/>
             <text x="68.1670%" y="1759.50">PhaseIdealLoop::build_and_optimize(bool, bo..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_tree() (50 samples, 1.52%)</title>
-            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(248,188,3)"/>
+            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(216,216,34)"/>
             <text x="93.4796%" y="1743.50"></text>
         </g>
         <g>
             <title>all (3,279 samples, 100%)</title>
-            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(233,26,26)"/>
+            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(223,171,53)"/>
             <text x="0.2500%" y="1919.50"></text>
         </g>
         <g>
             <title>start_thread (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(217,160,42)"/>
+            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(236,13,27)"/>
             <text x="5.8615%" y="1903.50">start_thread</text>
         </g>
         <g>
             <title>java_start(Thread*) (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(245,125,2)"/>
+            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(234,20,29)"/>
             <text x="5.8615%" y="1887.50">java_start(Thread*)</text>
         </g>
         <g>
             <title>JavaThread::run() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(233,194,19)"/>
+            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(231,69,22)"/>
             <text x="30.0457%" y="1871.50">JavaThread::run()</text>
         </g>
         <g>
             <title>JavaThread::thread_main_inner() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(206,140,30)"/>
+            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(244,147,15)"/>
             <text x="30.0457%" y="1855.50">JavaThread::thread_main_inner()</text>
         </g>
         <g>
             <title>CompileBroker::compiler_thread_loop() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(229,3,40)"/>
+            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(238,143,19)"/>
             <text x="30.0457%" y="1839.50">CompileBroker::compiler_thread_loop()</text>
         </g>
         <g>
             <title>CompileBroker::invoke_compiler_on_method(CompileTask*) (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(249,200,16)"/>
+            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(230,212,46)"/>
             <text x="30.0457%" y="1823.50">CompileBroker::invoke_compiler_on_method(CompileTask*)</text>
         </g>
         <g>
             <title>Compiler::compile_method(ciEnv*, ciMethod*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(221,6,40)"/>
+            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(246,125,10)"/>
             <text x="95.0045%" y="1807.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::Compilation(AbstractCompiler*, ciEnv*, ciMethod*, int, BufferBlob*) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(217,156,29)"/>
+            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(217,31,10)"/>
             <text x="95.0045%" y="1791.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::compile_method() (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(222,173,40)"/>
+            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(229,97,22)"/>
             <text x="95.0045%" y="1775.50">Compil..</text>
         </g>
         <g>
             <title>ciEnv::register_method(ciMethod*, int, CodeOffsets*, int, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int, bool, bool, RTMState) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(241,63,33)"/>
+            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(210,186,49)"/>
             <text x="95.0045%" y="1759.50">ciEnv:..</text>
         </g>
         <g>
             <title>nmethod::new_nmethod(methodHandle, int, int, CodeOffsets*, int, DebugInformationRecorder*, Dependencies*, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(225,85,51)"/>
+            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(230,137,28)"/>
             <text x="95.0045%" y="1743.50">nmetho..</text>
         </g>
         <g>
             <title>CodeCache::allocate(int, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(224,19,23)"/>
+            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(231,48,37)"/>
             <text x="95.0045%" y="1727.50">CodeCa..</text>
         </g>
         <g>
             <title>CodeHeap::allocate(unsigned long, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(227,66,23)"/>
+            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(235,39,24)"/>
             <text x="95.0045%" y="1711.50">CodeHe..</text>
         </g>
     </svg>

--- a/tests/data/flamegraph/colors/deterministic.svg
+++ b/tests/data/flamegraph/colors/deterministic.svg
@@ -37,1177 +37,1177 @@ var truncate_text_right = false;]]>
     <svg id="frames" x="10" width="1180">
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8575.1705890900.apply$mcV$sp (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(225,215,45)"/>
+            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(206,222,32)"/>
             <text x="0.2500%" y="751.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$124 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(212,220,53)"/>
+            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(249,136,40)"/>
             <text x="0.2500%" y="735.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(253,41,30)"/>
+            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(253,133,5)"/>
             <text x="0.2500%" y="719.50">c..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(209,7,17)"/>
+            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(206,35,1)"/>
             <text x="0.2500%" y="703.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(251,90,35)"/>
+            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(207,114,11)"/>
             <text x="0.2500%" y="687.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(230,226,1)"/>
+            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(230,125,38)"/>
             <text x="0.2500%" y="671.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(237,131,42)"/>
+            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(232,82,51)"/>
             <text x="0.2500%" y="655.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(218,195,8)"/>
+            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(211,143,21)"/>
             <text x="0.2500%" y="639.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(215,129,4)"/>
+            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(251,68,36)"/>
             <text x="0.2500%" y="623.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(236,107,6)"/>
+            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(224,164,5)"/>
             <text x="0.2500%" y="607.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(235,109,2)"/>
+            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(216,162,50)"/>
             <text x="0.2500%" y="591.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(211,182,17)"/>
+            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(237,111,29)"/>
             <text x="0.2500%" y="575.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(206,82,40)"/>
+            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(223,229,23)"/>
             <text x="0.2500%" y="559.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(210,133,6)"/>
+            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(228,72,20)"/>
             <text x="0.2500%" y="543.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(242,43,9)"/>
+            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(216,100,26)"/>
             <text x="0.2500%" y="527.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(209,84,2)"/>
+            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(244,208,0)"/>
             <text x="0.2500%" y="511.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(242,213,11)"/>
+            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(222,173,3)"/>
             <text x="0.2500%" y="495.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(238,128,48)"/>
+            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(223,4,31)"/>
             <text x="0.2500%" y="479.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(206,82,40)"/>
+            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(223,229,23)"/>
             <text x="0.2500%" y="463.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(210,133,6)"/>
+            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(228,72,20)"/>
             <text x="0.2500%" y="447.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(242,43,9)"/>
+            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(216,100,26)"/>
             <text x="0.2500%" y="431.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(209,84,2)"/>
+            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(244,208,0)"/>
             <text x="0.2500%" y="415.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(242,213,11)"/>
+            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(222,173,3)"/>
             <text x="0.2500%" y="399.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(238,128,48)"/>
+            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(223,4,31)"/>
             <text x="0.2500%" y="383.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(245,127,31)"/>
+            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(229,115,11)"/>
             <text x="0.2500%" y="367.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(219,196,36)"/>
+            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(253,61,33)"/>
             <text x="0.2500%" y="351.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(229,97,43)"/>
+            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(254,43,51)"/>
             <text x="0.2500%" y="335.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(221,31,3)"/>
+            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(244,179,22)"/>
             <text x="0.2500%" y="319.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(249,11,24)"/>
+            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(250,149,39)"/>
             <text x="0.2500%" y="303.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(244,27,39)"/>
+            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(220,99,47)"/>
             <text x="0.2500%" y="287.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(230,215,6)"/>
+            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(242,124,44)"/>
             <text x="0.2500%" y="271.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(230,138,10)"/>
+            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(218,211,42)"/>
             <text x="0.2500%" y="255.50">o..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$9984.1092558103.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(220,216,1)"/>
+            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(224,170,49)"/>
             <text x="0.2500%" y="239.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(205,16,18)"/>
+            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(206,229,53)"/>
             <text x="0.2500%" y="223.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(210,13,27)"/>
+            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(223,49,28)"/>
             <text x="0.2500%" y="207.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$5 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(237,67,26)"/>
+            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(232,52,45)"/>
             <text x="0.2500%" y="191.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase16AsBytes (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(236,126,9)"/>
+            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(253,49,53)"/>
             <text x="0.2500%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase16 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(221,35,51)"/>
+            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(214,170,28)"/>
             <text x="0.2500%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(210,125,16)"/>
+            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(222,210,40)"/>
             <text x="0.2500%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(233,62,6)"/>
+            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(252,52,14)"/>
             <text x="0.2500%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(225,86,26)"/>
+            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(217,94,8)"/>
             <text x="0.2500%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(222,126,39)"/>
+            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(246,142,3)"/>
             <text x="0.2500%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(221,167,16)"/>
+            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(222,148,33)"/>
             <text x="0.2500%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(219,118,3)"/>
+            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(220,209,27)"/>
             <text x="0.2500%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(209,20,33)"/>
+            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(218,188,13)"/>
             <text x="0.2500%" y="47.50">s..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64AsBytes (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(209,105,20)"/>
+            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(216,53,25)"/>
             <text x="2.3543%" y="175.50"></text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(207,90,20)"/>
+            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(221,96,6)"/>
             <text x="2.3543%" y="159.50"></text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(210,125,16)"/>
+            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(222,210,40)"/>
             <text x="2.3543%" y="143.50"></text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(233,62,6)"/>
+            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(252,52,14)"/>
             <text x="2.3543%" y="127.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(225,86,26)"/>
+            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(217,94,8)"/>
             <text x="2.3543%" y="111.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(222,126,39)"/>
+            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(246,142,3)"/>
             <text x="2.3543%" y="95.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(221,167,16)"/>
+            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(222,148,33)"/>
             <text x="2.3543%" y="79.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(219,118,3)"/>
+            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(220,209,27)"/>
             <text x="2.3543%" y="63.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(209,20,33)"/>
+            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(218,188,13)"/>
             <text x="2.3543%" y="47.50"></text>
         </g>
         <g>
             <title>java.lang.Thread.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(213,174,21)"/>
+            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(245,195,47)"/>
             <text x="0.2500%" y="1903.50">java.la..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor$Worker.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(209,144,39)"/>
+            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(220,141,10)"/>
             <text x="0.2500%" y="1887.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor.runWorker (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(242,72,13)"/>
+            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(243,187,24)"/>
             <text x="0.2500%" y="1871.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(215,40,35)"/>
+            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(243,85,6)"/>
             <text x="0.2500%" y="1855.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.Executors$RunnableAdapter.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(218,19,14)"/>
+            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(230,187,34)"/>
             <text x="0.2500%" y="1839.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(215,40,35)"/>
+            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(243,85,6)"/>
             <text x="0.2500%" y="1823.50">java.ut..</text>
         </g>
         <g>
             <title>sbt.CompletionService$$anon$2.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(226,31,49)"/>
+            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(253,22,2)"/>
             <text x="0.2500%" y="1807.50">sbt.Com..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4$$Lambda$2176.1600330912.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(222,111,4)"/>
+            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(208,44,16)"/>
             <text x="0.2500%" y="1791.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(207,114,41)"/>
+            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(254,81,44)"/>
             <text x="0.2500%" y="1775.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2169.2034046523.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(235,94,28)"/>
+            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(207,144,39)"/>
             <text x="0.2500%" y="1759.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(242,157,34)"/>
+            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(227,207,4)"/>
             <text x="0.2500%" y="1743.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(242,36,44)"/>
+            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(234,185,42)"/>
             <text x="0.2500%" y="1727.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.internal.util.ErrorHandling$.wideConvert (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(233,30,10)"/>
+            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(254,220,49)"/>
             <text x="0.2500%" y="1711.50">sbt.int..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2178.2095669414.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(207,99,19)"/>
+            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(239,51,13)"/>
             <text x="0.2500%" y="1695.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(214,107,28)"/>
+            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(233,166,7)"/>
             <text x="0.2500%" y="1679.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$4.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(205,49,51)"/>
+            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(236,79,54)"/>
             <text x="0.2500%" y="1663.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3$$Lambda$2167.231900526.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(218,54,43)"/>
+            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(216,222,14)"/>
             <text x="0.2500%" y="1647.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3.$anonfun$apply$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(247,141,38)"/>
+            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(243,64,13)"/>
             <text x="0.2500%" y="1631.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.Tests$$$Lambda$7842.1208470949.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(207,11,20)"/>
+            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(222,55,27)"/>
             <text x="0.2500%" y="1615.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.Tests$.$anonfun$toTask$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(213,7,24)"/>
+            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(253,20,15)"/>
             <text x="0.2500%" y="1599.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFunction.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(218,154,23)"/>
+            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(230,78,7)"/>
             <text x="0.2500%" y="1583.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(219,19,36)"/>
+            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(212,121,54)"/>
             <text x="0.2500%" y="1567.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(219,19,36)"/>
+            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(212,121,54)"/>
             <text x="0.2500%" y="1551.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$.sbt$TestFramework$$withContextLoader (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(249,109,23)"/>
+            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(222,49,54)"/>
             <text x="0.2500%" y="1535.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1$$Lambda$7850.1117892339.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(208,221,41)"/>
+            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(244,213,18)"/>
             <text x="0.2500%" y="1519.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(211,124,16)"/>
+            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(249,152,46)"/>
             <text x="0.2500%" y="1503.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(230,148,3)"/>
+            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(214,76,39)"/>
             <text x="0.2500%" y="1487.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(244,13,21)"/>
+            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(252,117,7)"/>
             <text x="0.2500%" y="1471.50">sbt.Tes..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework$ScalaTestTask.execute (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(240,188,27)"/>
+            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(225,142,45)"/>
             <text x="0.2500%" y="1455.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(216,179,6)"/>
+            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(234,158,3)"/>
             <text x="0.2500%" y="1439.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(224,34,33)"/>
+            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(229,205,54)"/>
             <text x="0.2500%" y="1423.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(215,190,11)"/>
+            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(246,13,8)"/>
             <text x="0.2500%" y="1407.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(205,7,7)"/>
+            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(222,140,39)"/>
             <text x="0.2500%" y="1391.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(205,185,22)"/>
+            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(240,69,6)"/>
             <text x="0.2500%" y="1375.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7943.1056778999.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(229,206,35)"/>
+            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(227,155,0)"/>
             <text x="0.2500%" y="1359.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(239,159,17)"/>
+            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(241,66,50)"/>
             <text x="0.2500%" y="1343.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(207,118,29)"/>
+            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(209,81,4)"/>
             <text x="0.2500%" y="1327.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(247,0,17)"/>
+            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(234,4,53)"/>
             <text x="0.2500%" y="1311.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(232,81,42)"/>
+            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(227,201,30)"/>
             <text x="0.2500%" y="1295.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(209,38,47)"/>
+            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(247,32,54)"/>
             <text x="0.2500%" y="1279.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(205,212,45)"/>
+            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(215,10,6)"/>
             <text x="0.2500%" y="1263.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(230,139,47)"/>
+            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(212,205,44)"/>
             <text x="0.2500%" y="1247.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(242,158,4)"/>
+            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(239,157,10)"/>
             <text x="0.2500%" y="1231.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(240,38,10)"/>
+            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(225,7,20)"/>
             <text x="0.2500%" y="1215.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(251,25,10)"/>
+            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(214,109,20)"/>
             <text x="0.2500%" y="1199.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(237,101,4)"/>
+            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(225,122,14)"/>
             <text x="0.2500%" y="1183.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(238,4,42)"/>
+            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(244,156,51)"/>
             <text x="0.2500%" y="1167.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(227,122,1)"/>
+            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(227,93,40)"/>
             <text x="0.2500%" y="1151.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(240,38,10)"/>
+            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(225,7,20)"/>
             <text x="0.2500%" y="1135.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(251,25,10)"/>
+            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(214,109,20)"/>
             <text x="0.2500%" y="1119.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(237,101,4)"/>
+            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(225,122,14)"/>
             <text x="0.2500%" y="1103.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(238,4,42)"/>
+            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(244,156,51)"/>
             <text x="0.2500%" y="1087.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(227,122,1)"/>
+            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(227,93,40)"/>
             <text x="0.2500%" y="1071.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7951.1136212450.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(254,143,13)"/>
+            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(227,189,26)"/>
             <text x="0.2500%" y="1055.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(208,19,27)"/>
+            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(242,228,43)"/>
             <text x="0.2500%" y="1039.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(233,70,0)"/>
+            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(250,188,20)"/>
             <text x="0.2500%" y="1023.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(236,59,24)"/>
+            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(249,212,40)"/>
             <text x="0.2500%" y="1007.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(223,66,45)"/>
+            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(248,0,20)"/>
             <text x="0.2500%" y="991.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(243,196,30)"/>
+            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(221,107,50)"/>
             <text x="0.2500%" y="975.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7967.812636372.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(227,102,52)"/>
+            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(241,133,47)"/>
             <text x="0.2500%" y="959.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(230,199,40)"/>
+            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(251,154,23)"/>
             <text x="0.2500%" y="943.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(221,201,36)"/>
+            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(240,34,35)"/>
             <text x="0.2500%" y="927.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(236,47,44)"/>
+            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(222,172,43)"/>
             <text x="0.2500%" y="911.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(243,93,16)"/>
+            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(227,44,53)"/>
             <text x="0.2500%" y="895.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(217,116,36)"/>
+            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(228,197,45)"/>
             <text x="0.2500%" y="879.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(236,2,28)"/>
+            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(252,185,4)"/>
             <text x="0.2500%" y="863.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(243,224,27)"/>
+            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(244,167,50)"/>
             <text x="0.2500%" y="847.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(243,224,27)"/>
+            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(244,167,50)"/>
             <text x="0.2500%" y="831.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf$.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(254,181,25)"/>
+            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(247,203,41)"/>
             <text x="0.2500%" y="815.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(245,169,50)"/>
+            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(251,68,18)"/>
             <text x="0.2500%" y="799.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(251,209,25)"/>
+            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(242,166,18)"/>
             <text x="0.2500%" y="783.50">org.sca..</text>
         </g>
         <g>
             <title>scala.runtime.java8.JFunction0$mcV$sp.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(230,162,33)"/>
+            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(222,151,22)"/>
             <text x="0.2500%" y="767.50">scala.r..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8582.1627656208.apply$mcV$sp (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(214,141,28)"/>
+            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(213,153,48)"/>
             <text x="2.3543%" y="751.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$136 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(205,138,48)"/>
+            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(245,55,0)"/>
             <text x="2.3543%" y="735.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(253,41,30)"/>
+            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(253,133,5)"/>
             <text x="2.3543%" y="719.50">com..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(209,7,17)"/>
+            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(206,35,1)"/>
             <text x="2.3543%" y="703.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(251,90,35)"/>
+            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(207,114,11)"/>
             <text x="2.3543%" y="687.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(230,226,1)"/>
+            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(230,125,38)"/>
             <text x="2.3543%" y="671.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(237,131,42)"/>
+            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(232,82,51)"/>
             <text x="2.3543%" y="655.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(218,195,8)"/>
+            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(211,143,21)"/>
             <text x="2.3543%" y="639.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(215,129,4)"/>
+            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(251,68,36)"/>
             <text x="2.3543%" y="623.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(236,107,6)"/>
+            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(224,164,5)"/>
             <text x="2.3543%" y="607.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(235,109,2)"/>
+            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(216,162,50)"/>
             <text x="2.3543%" y="591.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(211,182,17)"/>
+            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(237,111,29)"/>
             <text x="2.3543%" y="575.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(206,82,40)"/>
+            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(223,229,23)"/>
             <text x="2.3543%" y="559.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(210,133,6)"/>
+            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(228,72,20)"/>
             <text x="2.3543%" y="543.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(242,43,9)"/>
+            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(216,100,26)"/>
             <text x="2.3543%" y="527.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(209,84,2)"/>
+            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(244,208,0)"/>
             <text x="2.3543%" y="511.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(242,213,11)"/>
+            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(222,173,3)"/>
             <text x="2.3543%" y="495.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(238,128,48)"/>
+            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(223,4,31)"/>
             <text x="2.3543%" y="479.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(206,82,40)"/>
+            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(223,229,23)"/>
             <text x="2.3543%" y="463.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(210,133,6)"/>
+            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(228,72,20)"/>
             <text x="2.3543%" y="447.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(242,43,9)"/>
+            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(216,100,26)"/>
             <text x="2.3543%" y="431.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(209,84,2)"/>
+            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(244,208,0)"/>
             <text x="2.3543%" y="415.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(242,213,11)"/>
+            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(222,173,3)"/>
             <text x="2.3543%" y="399.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(238,128,48)"/>
+            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(223,4,31)"/>
             <text x="2.3543%" y="383.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(245,127,31)"/>
+            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(229,115,11)"/>
             <text x="2.3543%" y="367.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(219,196,36)"/>
+            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(253,61,33)"/>
             <text x="2.3543%" y="351.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(229,97,43)"/>
+            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(254,43,51)"/>
             <text x="2.3543%" y="335.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(221,31,3)"/>
+            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(244,179,22)"/>
             <text x="2.3543%" y="319.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(249,11,24)"/>
+            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(250,149,39)"/>
             <text x="2.3543%" y="303.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(244,27,39)"/>
+            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(220,99,47)"/>
             <text x="2.3543%" y="287.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(230,215,6)"/>
+            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(242,124,44)"/>
             <text x="2.3543%" y="271.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(230,138,10)"/>
+            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(218,211,42)"/>
             <text x="2.3543%" y="255.50">org..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$10462.775835262.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(246,145,6)"/>
+            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(222,0,34)"/>
             <text x="2.3543%" y="239.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(229,34,53)"/>
+            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(205,52,26)"/>
             <text x="2.3543%" y="223.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(232,159,5)"/>
+            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(238,90,54)"/>
             <text x="2.3543%" y="207.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$6 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(243,180,4)"/>
+            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(224,181,19)"/>
             <text x="2.3543%" y="191.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64UrlAsBytes (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(246,227,44)"/>
+            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(251,220,46)"/>
             <text x="3.9401%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(207,90,20)"/>
+            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(221,96,6)"/>
             <text x="3.9401%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(210,125,16)"/>
+            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(222,210,40)"/>
             <text x="3.9401%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(233,62,6)"/>
+            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(252,52,14)"/>
             <text x="3.9401%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(225,86,26)"/>
+            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(217,94,8)"/>
             <text x="3.9401%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(222,126,39)"/>
+            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(246,142,3)"/>
             <text x="3.9401%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(221,167,16)"/>
+            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(222,148,33)"/>
             <text x="3.9401%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(219,118,3)"/>
+            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(220,209,27)"/>
             <text x="3.9401%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(209,20,33)"/>
+            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(218,188,13)"/>
             <text x="3.9401%" y="47.50">s..</text>
         </g>
         <g>
             <title>DrainStacksCompactionTask::do_it(GCTaskManager*, unsigned int) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(237,143,36)"/>
+            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(243,192,29)"/>
             <text x="5.8615%" y="1855.50">Dra..</text>
         </g>
         <g>
             <title>ParCompactionManager::drain_region_stacks() (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(229,105,39)"/>
+            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(230,86,36)"/>
             <text x="5.8615%" y="1839.50">Par..</text>
         </g>
         <g>
             <title>PSParallelCompact::fill_region(ParCompactionManager*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(226,29,51)"/>
+            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(224,149,19)"/>
             <text x="5.8615%" y="1823.50">PSP..</text>
         </g>
         <g>
             <title>ParMarkBitMap::iterate(ParMarkBitMapClosure*, unsigned long, unsigned long) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(248,3,31)"/>
+            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(210,84,36)"/>
             <text x="5.8615%" y="1807.50">Par..</text>
         </g>
         <g>
             <title>MoveAndUpdateClosure::do_addr(HeapWord*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(233,47,42)"/>
+            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(220,195,22)"/>
             <text x="5.8615%" y="1791.50">Mov..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_update_pointers(ParCompactionManager*, oopDesc*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(246,150,31)"/>
+            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(240,223,12)"/>
             <text x="5.8615%" y="1775.50">Ins..</text>
         </g>
         <g>
             <title>ParallelCompactData::calc_new_pointer(HeapWord*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(215,137,51)"/>
+            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(219,194,31)"/>
             <text x="5.8615%" y="1759.50">Par..</text>
         </g>
         <g>
             <title>ParMarkBitMap::live_words_in_range(HeapWord*, oopDesc*) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(219,75,10)"/>
+            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(231,171,24)"/>
             <text x="5.8615%" y="1743.50">Par..</text>
         </g>
         <g>
             <title>OldToYoungRootsTask::do_it(GCTaskManager*, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(214,226,20)"/>
+            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(214,20,38)"/>
             <text x="9.0637%" y="1855.50">OldToYoungRootsTask::do..</text>
         </g>
         <g>
             <title>CardTableExtension::scavenge_contents_parallel(ObjectStartArray*, MutableSpace*, HeapWord*, PSPromotionManager*, unsigned int, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(245,219,38)"/>
+            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(240,21,34)"/>
             <text x="9.0637%" y="1839.50">CardTableExtension::sca..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(210,180,3)"/>
+            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(239,23,12)"/>
             <text x="9.0637%" y="1823.50">PSPromotionManager::dra..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (358 samples, 10.92%)</title>
-            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(208,32,17)"/>
+            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(216,114,8)"/>
             <text x="13.0893%" y="1807.50">oopDesc* PSPromo..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (161 samples, 4.91%)</title>
-            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(236,84,53)"/>
+            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(235,89,37)"/>
             <text x="19.0972%" y="1791.50">Instan..</text>
         </g>
         <g>
             <title>GCTaskThread::run() (793 samples, 24.18%)</title>
-            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(253,62,51)"/>
+            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(215,164,35)"/>
             <text x="5.8615%" y="1871.50">GCTaskThread::run()</text>
         </g>
         <g>
             <title>StealTask::do_it(GCTaskManager*, unsigned int) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(235,150,46)"/>
+            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(216,82,33)"/>
             <text x="24.0072%" y="1855.50">StealTas..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(210,180,3)"/>
+            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(239,23,12)"/>
             <text x="24.0072%" y="1839.50">PSPromot..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (138 samples, 4.21%)</title>
-            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(208,32,17)"/>
+            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(216,114,8)"/>
             <text x="25.8371%" y="1823.50">oopDe..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (80 samples, 2.44%)</title>
-            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(236,84,53)"/>
+            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(235,89,37)"/>
             <text x="27.6059%" y="1807.50">In..</text>
         </g>
         <g>
             <title>Matcher::match() (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(208,184,3)"/>
+            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(240,165,10)"/>
             <text x="30.0457%" y="1759.50">Mat..</text>
         </g>
         <g>
             <title>Matcher::xform(Node*, int) (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(225,78,35)"/>
+            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(235,133,24)"/>
             <text x="30.0457%" y="1743.50">Mat..</text>
         </g>
         <g>
             <title>Arena::contains(void const*) const (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(226,52,47)"/>
+            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(212,83,7)"/>
             <text x="30.0457%" y="1727.50">Are..</text>
         </g>
         <g>
             <title>PhaseAggressiveCoalesce::insert_copies(Matcher&amp;) (86 samples, 2.62%)</title>
-            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(223,43,19)"/>
+            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(212,94,38)"/>
             <text x="33.3699%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::Split(unsigned int, ResourceArea*) (213 samples, 6.50%)</title>
-            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(217,100,4)"/>
+            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(249,182,10)"/>
             <text x="35.9926%" y="1743.50">PhaseChai..</text>
         </g>
         <g>
             <title>PhaseChaitin::build_ifg_physical(ResourceArea*) (305 samples, 9.30%)</title>
-            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(218,88,3)"/>
+            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(236,47,17)"/>
             <text x="42.4885%" y="1743.50">PhaseChaitin:..</text>
         </g>
         <g>
             <title>PhaseChaitin::interfere_with_live(unsigned int, IndexSet*) (183 samples, 5.58%)</title>
-            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(234,199,18)"/>
+            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(234,97,9)"/>
             <text x="46.2091%" y="1727.50">PhaseCh..</text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (66 samples, 2.01%)</title>
-            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(248,164,17)"/>
+            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(217,50,39)"/>
             <text x="49.7773%" y="1711.50">I..</text>
         </g>
         <g>
             <title>PhaseChaitin::gather_lrg_masks(bool) (95 samples, 2.90%)</title>
-            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(245,154,29)"/>
+            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(240,206,32)"/>
             <text x="51.7901%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::post_allocate_copy_removal() (139 samples, 4.24%)</title>
-            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(247,171,28)"/>
+            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(247,5,35)"/>
             <text x="54.6873%" y="1743.50">Phase..</text>
         </g>
         <g>
             <title>PhaseChaitin::elide_copy(Node*, int, Block*, Node_List&amp;, Node_List&amp;, bool) (76 samples, 2.32%)</title>
-            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(227,155,51)"/>
+            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(223,198,13)"/>
             <text x="56.6086%" y="1727.50">P..</text>
         </g>
         <g>
             <title>PhaseCoalesce::coalesce_driver() (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(241,11,19)"/>
+            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(250,15,35)"/>
             <text x="58.9264%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::coalesce(Block*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(242,54,29)"/>
+            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(249,62,31)"/>
             <text x="58.9264%" y="1727.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::update_ifg(unsigned int, unsigned int, IndexSet*, IndexSet*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(230,69,32)"/>
+            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(249,223,36)"/>
             <text x="58.9264%" y="1711.50">Ph..</text>
         </g>
         <g>
             <title>PhaseIFG::Compute_Effective_Degree() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(239,40,36)"/>
+            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(245,20,0)"/>
             <text x="61.7322%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(248,164,17)"/>
+            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(217,50,39)"/>
             <text x="61.7322%" y="1727.50"></text>
         </g>
         <g>
             <title>PhaseIFG::SquareUp() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(241,50,36)"/>
+            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(229,161,37)"/>
             <text x="63.3485%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(248,164,17)"/>
+            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(217,50,39)"/>
             <text x="63.3485%" y="1727.50"></text>
         </g>
         <g>
             <title>Compile::Code_Gen() (1,250 samples, 38.12%)</title>
-            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(215,70,26)"/>
+            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(222,38,0)"/>
             <text x="30.0457%" y="1775.50">Compile::Code_Gen()</text>
         </g>
         <g>
             <title>PhaseChaitin::Register_Allocate() (1,141 samples, 34.80%)</title>
-            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(206,38,41)"/>
+            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(240,24,42)"/>
             <text x="33.3699%" y="1759.50">PhaseChaitin::Register_Allocate()</text>
         </g>
         <g>
             <title>PhaseLive::compute(unsigned int) (110 samples, 3.35%)</title>
-            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(216,48,14)"/>
+            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(217,70,12)"/>
             <text x="64.8124%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::Dominators() (67 samples, 2.04%)</title>
-            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(231,72,8)"/>
+            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(237,29,44)"/>
             <text x="68.1670%" y="1743.50">P..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_early(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (108 samples, 3.29%)</title>
-            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(217,222,49)"/>
+            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(242,135,14)"/>
             <text x="70.2104%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (655 samples, 19.98%)</title>
-            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(222,177,5)"/>
+            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(216,152,37)"/>
             <text x="73.5040%" y="1743.50">PhaseIdealLoop::build_loop_late..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late_post(Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(251,195,42)"/>
+            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(211,5,52)"/>
             <text x="76.5233%" y="1727.50">PhaseIdealLoop::build_loop..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::get_late_ctrl(Node*, Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(244,37,15)"/>
+            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(240,32,13)"/>
             <text x="76.5233%" y="1711.50">PhaseIdealLoop::get_late_c..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::is_dominator(Node*, Node*) [clone .part.114] (496 samples, 15.13%)</title>
-            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(238,175,34)"/>
+            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(244,164,26)"/>
             <text x="78.3531%" y="1695.50">PhaseIdealLoop::is_domi..</text>
         </g>
         <g>
             <title>C2Compiler::compile_method(ciEnv*, ciMethod*, int) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(209,82,44)"/>
+            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(241,205,18)"/>
             <text x="30.0457%" y="1807.50">C2Compiler::compile_method(ciEnv*, ciMethod*, int)</text>
         </g>
         <g>
             <title>Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(205,46,27)"/>
+            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(208,157,13)"/>
             <text x="30.0457%" y="1791.50">Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool)</text>
         </g>
         <g>
             <title>Compile::Optimize() (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(208,27,18)"/>
+            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(244,150,9)"/>
             <text x="68.1670%" y="1775.50">Compile::Optimize()</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_and_optimize(bool, bool) (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(215,90,13)"/>
+            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(217,126,21)"/>
             <text x="68.1670%" y="1759.50">PhaseIdealLoop::build_and_optimize(bool, bo..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_tree() (50 samples, 1.52%)</title>
-            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(216,216,34)"/>
+            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(210,192,44)"/>
             <text x="93.4796%" y="1743.50"></text>
         </g>
         <g>
             <title>all (3,279 samples, 100%)</title>
-            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(223,171,53)"/>
+            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(249,83,8)"/>
             <text x="0.2500%" y="1919.50"></text>
         </g>
         <g>
             <title>start_thread (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(236,13,27)"/>
+            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(237,152,37)"/>
             <text x="5.8615%" y="1903.50">start_thread</text>
         </g>
         <g>
             <title>java_start(Thread*) (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(234,20,29)"/>
+            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(235,227,30)"/>
             <text x="5.8615%" y="1887.50">java_start(Thread*)</text>
         </g>
         <g>
             <title>JavaThread::run() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(231,69,22)"/>
+            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(217,144,1)"/>
             <text x="30.0457%" y="1871.50">JavaThread::run()</text>
         </g>
         <g>
             <title>JavaThread::thread_main_inner() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(244,147,15)"/>
+            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(206,123,8)"/>
             <text x="30.0457%" y="1855.50">JavaThread::thread_main_inner()</text>
         </g>
         <g>
             <title>CompileBroker::compiler_thread_loop() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(238,143,19)"/>
+            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(219,200,13)"/>
             <text x="30.0457%" y="1839.50">CompileBroker::compiler_thread_loop()</text>
         </g>
         <g>
             <title>CompileBroker::invoke_compiler_on_method(CompileTask*) (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(230,212,46)"/>
+            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(231,98,12)"/>
             <text x="30.0457%" y="1823.50">CompileBroker::invoke_compiler_on_method(CompileTask*)</text>
         </g>
         <g>
             <title>Compiler::compile_method(ciEnv*, ciMethod*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(246,125,10)"/>
+            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(220,153,24)"/>
             <text x="95.0045%" y="1807.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::Compilation(AbstractCompiler*, ciEnv*, ciMethod*, int, BufferBlob*) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(217,31,10)"/>
+            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(217,22,46)"/>
             <text x="95.0045%" y="1791.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::compile_method() (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(229,97,22)"/>
+            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(230,165,36)"/>
             <text x="95.0045%" y="1775.50">Compil..</text>
         </g>
         <g>
             <title>ciEnv::register_method(ciMethod*, int, CodeOffsets*, int, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int, bool, bool, RTMState) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(210,186,49)"/>
+            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(253,30,24)"/>
             <text x="95.0045%" y="1759.50">ciEnv:..</text>
         </g>
         <g>
             <title>nmethod::new_nmethod(methodHandle, int, int, CodeOffsets*, int, DebugInformationRecorder*, Dependencies*, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(230,137,28)"/>
+            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(215,128,4)"/>
             <text x="95.0045%" y="1743.50">nmetho..</text>
         </g>
         <g>
             <title>CodeCache::allocate(int, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(231,48,37)"/>
+            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(233,180,33)"/>
             <text x="95.0045%" y="1727.50">CodeCa..</text>
         </g>
         <g>
             <title>CodeHeap::allocate(unsigned long, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(235,39,24)"/>
+            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(205,74,20)"/>
             <text x="95.0045%" y="1711.50">CodeHe..</text>
         </g>
     </svg>

--- a/tests/data/flamegraph/colors/deterministic.svg
+++ b/tests/data/flamegraph/colors/deterministic.svg
@@ -1,0 +1,1214 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="1958" onload="init(evt)" viewBox="0 0 1200 1958" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:"Verdana"; font-size:12px; fill:rgb(0,0,0); }
+#title { text-anchor:middle; font-size:17px; }
+#search { opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript">
+        <![CDATA[var nametype = 'Function:';
+var fontsize = 12;
+var fontwidth = 0.59;
+var xpad = 10;
+var inverted = false;
+var searchcolor = 'rgb(230,0,230)';
+var fluiddrawing = true;
+var truncate_text_right = false;]]>
+    </script>
+    <rect x="0" y="0" width="100%" height="1958" fill="url(#background)"/>
+    <text id="title" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" x="10" y="1941.00"> </text>
+    <text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" x="1090" y="24.00">Search</text>
+    <text id="matched" x="1090" y="1941.00"> </text>
+    <svg id="frames" x="10" width="1180">
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8575.1705890900.apply$mcV$sp (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(217,180,16)"/>
+            <text x="0.2500%" y="751.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$124 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(214,105,7)"/>
+            <text x="0.2500%" y="735.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(243,58,48)"/>
+            <text x="0.2500%" y="719.50">c..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(218,159,15)"/>
+            <text x="0.2500%" y="703.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(242,28,13)"/>
+            <text x="0.2500%" y="687.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(231,14,51)"/>
+            <text x="0.2500%" y="671.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.check (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(226,67,53)"/>
+            <text x="0.2500%" y="655.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Platform$.runWorkers (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(245,213,12)"/>
+            <text x="0.2500%" y="639.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(220,53,33)"/>
+            <text x="0.2500%" y="623.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.$anonfun$check$1$adapted (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(234,35,37)"/>
+            <text x="0.2500%" y="607.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.$anonfun$check$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(207,177,51)"/>
+            <text x="0.2500%" y="591.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.workerFun$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(243,109,49)"/>
+            <text x="0.2500%" y="575.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(254,13,38)"/>
+            <text x="0.2500%" y="559.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(221,169,0)"/>
+            <text x="0.2500%" y="543.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(207,112,50)"/>
+            <text x="0.2500%" y="527.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(253,153,52)"/>
+            <text x="0.2500%" y="511.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(219,11,8)"/>
+            <text x="0.2500%" y="495.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(253,172,21)"/>
+            <text x="0.2500%" y="479.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(254,13,38)"/>
+            <text x="0.2500%" y="463.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(221,169,0)"/>
+            <text x="0.2500%" y="447.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(207,112,50)"/>
+            <text x="0.2500%" y="431.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(253,153,52)"/>
+            <text x="0.2500%" y="415.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(219,11,8)"/>
+            <text x="0.2500%" y="399.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(253,172,21)"/>
+            <text x="0.2500%" y="383.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.secure (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(205,178,7)"/>
+            <text x="0.2500%" y="367.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(234,163,16)"/>
+            <text x="0.2500%" y="351.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(243,125,35)"/>
+            <text x="0.2500%" y="335.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(213,108,49)"/>
+            <text x="0.2500%" y="319.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAll$3 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(233,226,44)"/>
+            <text x="0.2500%" y="303.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(207,65,52)"/>
+            <text x="0.2500%" y="287.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(235,49,34)"/>
+            <text x="0.2500%" y="271.50">o..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(252,140,16)"/>
+            <text x="0.2500%" y="255.50">o..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$9984.1092558103.apply (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(218,30,4)"/>
+            <text x="0.2500%" y="239.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128$adapted (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(216,63,17)"/>
+            <text x="0.2500%" y="223.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(211,136,33)"/>
+            <text x="0.2500%" y="207.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$5 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(235,203,34)"/>
+            <text x="0.2500%" y="191.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase16AsBytes (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(245,119,8)"/>
+            <text x="0.2500%" y="175.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase16 (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(217,184,50)"/>
+            <text x="0.2500%" y="159.50">c..</text>
+        </g>
+        <g>
+            <title>scoverage.Invoker$.invoked (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(240,151,3)"/>
+            <text x="0.2500%" y="143.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.AbstractMap.contains (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(209,216,47)"/>
+            <text x="0.2500%" y="127.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.MapOps.contains$ (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(242,162,46)"/>
+            <text x="0.2500%" y="111.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.MapOps.contains (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(207,229,35)"/>
+            <text x="0.2500%" y="95.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.TrieMap.get (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(226,6,29)"/>
+            <text x="0.2500%" y="79.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.TrieMap.lookuphc (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(213,12,48)"/>
+            <text x="0.2500%" y="63.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.INode.rec_lookup (69 samples, 2.10%)</title>
+            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(206,146,5)"/>
+            <text x="0.2500%" y="47.50">s..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64AsBytes (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(216,26,49)"/>
+            <text x="2.3543%" y="175.50"></text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(225,32,26)"/>
+            <text x="2.3543%" y="159.50"></text>
+        </g>
+        <g>
+            <title>scoverage.Invoker$.invoked (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(240,151,3)"/>
+            <text x="2.3543%" y="143.50"></text>
+        </g>
+        <g>
+            <title>scala.collection.AbstractMap.contains (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(209,216,47)"/>
+            <text x="2.3543%" y="127.50"></text>
+        </g>
+        <g>
+            <title>scala.collection.MapOps.contains$ (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(242,162,46)"/>
+            <text x="2.3543%" y="111.50"></text>
+        </g>
+        <g>
+            <title>scala.collection.MapOps.contains (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(207,229,35)"/>
+            <text x="2.3543%" y="95.50"></text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.TrieMap.get (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(226,6,29)"/>
+            <text x="2.3543%" y="79.50"></text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.TrieMap.lookuphc (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(213,12,48)"/>
+            <text x="2.3543%" y="63.50"></text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.INode.rec_lookup (52 samples, 1.59%)</title>
+            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(206,146,5)"/>
+            <text x="2.3543%" y="47.50"></text>
+        </g>
+        <g>
+            <title>java.lang.Thread.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(238,208,10)"/>
+            <text x="0.2500%" y="1903.50">java.la..</text>
+        </g>
+        <g>
+            <title>java.util.concurrent.ThreadPoolExecutor$Worker.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(208,4,23)"/>
+            <text x="0.2500%" y="1887.50">java.ut..</text>
+        </g>
+        <g>
+            <title>java.util.concurrent.ThreadPoolExecutor.runWorker (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(250,132,8)"/>
+            <text x="0.2500%" y="1871.50">java.ut..</text>
+        </g>
+        <g>
+            <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(223,81,51)"/>
+            <text x="0.2500%" y="1855.50">java.ut..</text>
+        </g>
+        <g>
+            <title>java.util.concurrent.Executors$RunnableAdapter.call (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(234,190,25)"/>
+            <text x="0.2500%" y="1839.50">java.ut..</text>
+        </g>
+        <g>
+            <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(223,81,51)"/>
+            <text x="0.2500%" y="1823.50">java.ut..</text>
+        </g>
+        <g>
+            <title>sbt.CompletionService$$anon$2.call (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(208,32,53)"/>
+            <text x="0.2500%" y="1807.50">sbt.Com..</text>
+        </g>
+        <g>
+            <title>sbt.ConcurrentRestrictions$$anon$4$$Lambda$2176.1600330912.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(209,198,8)"/>
+            <text x="0.2500%" y="1791.50">sbt.Con..</text>
+        </g>
+        <g>
+            <title>sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(251,94,54)"/>
+            <text x="0.2500%" y="1775.50">sbt.Con..</text>
+        </g>
+        <g>
+            <title>sbt.Execute$$Lambda$2169.2034046523.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(221,166,36)"/>
+            <text x="0.2500%" y="1759.50">sbt.Exe..</text>
+        </g>
+        <g>
+            <title>sbt.Execute.$anonfun$submit$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(226,121,6)"/>
+            <text x="0.2500%" y="1743.50">sbt.Exe..</text>
+        </g>
+        <g>
+            <title>sbt.Execute.work (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(221,149,28)"/>
+            <text x="0.2500%" y="1727.50">sbt.Exe..</text>
+        </g>
+        <g>
+            <title>sbt.internal.util.ErrorHandling$.wideConvert (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(209,183,35)"/>
+            <text x="0.2500%" y="1711.50">sbt.int..</text>
+        </g>
+        <g>
+            <title>sbt.Execute$$Lambda$2178.2095669414.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(253,97,17)"/>
+            <text x="0.2500%" y="1695.50">sbt.Exe..</text>
+        </g>
+        <g>
+            <title>sbt.Execute.$anonfun$submit$2 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(215,10,25)"/>
+            <text x="0.2500%" y="1679.50">sbt.Exe..</text>
+        </g>
+        <g>
+            <title>sbt.std.Transform$$anon$4.work (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(251,146,20)"/>
+            <text x="0.2500%" y="1663.50">sbt.std..</text>
+        </g>
+        <g>
+            <title>sbt.std.Transform$$anon$3$$Lambda$2167.231900526.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(241,37,33)"/>
+            <text x="0.2500%" y="1647.50">sbt.std..</text>
+        </g>
+        <g>
+            <title>sbt.std.Transform$$anon$3.$anonfun$apply$2 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(238,61,38)"/>
+            <text x="0.2500%" y="1631.50">sbt.std..</text>
+        </g>
+        <g>
+            <title>sbt.Tests$$$Lambda$7842.1208470949.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(253,27,42)"/>
+            <text x="0.2500%" y="1615.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.Tests$.$anonfun$toTask$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(232,109,15)"/>
+            <text x="0.2500%" y="1599.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestFunction.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(224,104,27)"/>
+            <text x="0.2500%" y="1583.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(249,158,37)"/>
+            <text x="0.2500%" y="1567.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(249,158,37)"/>
+            <text x="0.2500%" y="1551.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestFramework$.sbt$TestFramework$$withContextLoader (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(240,26,42)"/>
+            <text x="0.2500%" y="1535.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1$$Lambda$7850.1117892339.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(225,159,48)"/>
+            <text x="0.2500%" y="1519.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(247,193,12)"/>
+            <text x="0.2500%" y="1503.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestRunner.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(239,17,37)"/>
+            <text x="0.2500%" y="1487.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>sbt.TestRunner.runTest$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(221,20,9)"/>
+            <text x="0.2500%" y="1471.50">sbt.Tes..</text>
+        </g>
+        <g>
+            <title>org.scalatest.tools.Framework$ScalaTestTask.execute (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(228,128,10)"/>
+            <text x="0.2500%" y="1455.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(230,16,5)"/>
+            <text x="0.2500%" y="1439.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpec.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(213,25,28)"/>
+            <text x="0.2500%" y="1423.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.run$ (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(229,127,36)"/>
+            <text x="0.2500%" y="1407.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(205,111,22)"/>
+            <text x="0.2500%" y="1391.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.runImpl (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(208,13,8)"/>
+            <text x="0.2500%" y="1375.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7943.1056778999.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(211,95,3)"/>
+            <text x="0.2500%" y="1359.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(207,69,22)"/>
+            <text x="0.2500%" y="1343.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(254,26,17)"/>
+            <text x="0.2500%" y="1327.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.Suite.run$ (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(215,135,51)"/>
+            <text x="0.2500%" y="1311.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.Suite.run (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(242,139,18)"/>
+            <text x="0.2500%" y="1295.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpec.runTests (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(238,150,40)"/>
+            <text x="0.2500%" y="1279.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.runTests$ (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(232,216,2)"/>
+            <text x="0.2500%" y="1263.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.runTests (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(237,18,51)"/>
+            <text x="0.2500%" y="1247.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.runTestsImpl (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(207,138,26)"/>
+            <text x="0.2500%" y="1231.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(233,85,12)"/>
+            <text x="0.2500%" y="1215.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(213,228,39)"/>
+            <text x="0.2500%" y="1199.50">org.sca..</text>
+        </g>
+        <g>
+            <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(223,170,26)"/>
+            <text x="0.2500%" y="1183.50">scala.c..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(251,61,26)"/>
+            <text x="0.2500%" y="1167.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(235,103,25)"/>
+            <text x="0.2500%" y="1151.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(233,85,12)"/>
+            <text x="0.2500%" y="1135.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(213,228,39)"/>
+            <text x="0.2500%" y="1119.50">org.sca..</text>
+        </g>
+        <g>
+            <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(223,170,26)"/>
+            <text x="0.2500%" y="1103.50">scala.c..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(251,61,26)"/>
+            <text x="0.2500%" y="1087.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(235,103,25)"/>
+            <text x="0.2500%" y="1071.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7951.1136212450.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(236,212,28)"/>
+            <text x="0.2500%" y="1055.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(215,133,34)"/>
+            <text x="0.2500%" y="1039.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpec.runTest (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(205,172,5)"/>
+            <text x="0.2500%" y="1023.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.runTest$ (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(254,100,28)"/>
+            <text x="0.2500%" y="1007.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.runTest (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(228,79,26)"/>
+            <text x="0.2500%" y="991.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.SuperEngine.runTestImpl (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(207,197,29)"/>
+            <text x="0.2500%" y="975.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7967.812636372.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(236,147,30)"/>
+            <text x="0.2500%" y="959.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(237,154,52)"/>
+            <text x="0.2500%" y="943.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1 (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(237,159,42)"/>
+            <text x="0.2500%" y="927.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpec.withFixture (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(242,132,0)"/>
+            <text x="0.2500%" y="911.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.TestSuite.withFixture$ (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(221,7,39)"/>
+            <text x="0.2500%" y="895.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.TestSuite.withFixture (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(216,109,36)"/>
+            <text x="0.2500%" y="879.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(241,223,27)"/>
+            <text x="0.2500%" y="863.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(236,121,41)"/>
+            <text x="0.2500%" y="847.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(236,121,41)"/>
+            <text x="0.2500%" y="831.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.OutcomeOf$.outcomeOf (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(242,38,9)"/>
+            <text x="0.2500%" y="815.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.OutcomeOf.outcomeOf$ (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(252,119,36)"/>
+            <text x="0.2500%" y="799.50">org.sca..</text>
+        </g>
+        <g>
+            <title>org.scalatest.OutcomeOf.outcomeOf (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(209,116,12)"/>
+            <text x="0.2500%" y="783.50">org.sca..</text>
+        </g>
+        <g>
+            <title>scala.runtime.java8.JFunction0$mcV$sp.apply (184 samples, 5.61%)</title>
+            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(211,0,16)"/>
+            <text x="0.2500%" y="767.50">scala.r..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8582.1627656208.apply$mcV$sp (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(238,119,10)"/>
+            <text x="2.3543%" y="751.50">com..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$136 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(207,109,34)"/>
+            <text x="2.3543%" y="735.50">com..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(243,58,48)"/>
+            <text x="2.3543%" y="719.50">com..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(218,159,15)"/>
+            <text x="2.3543%" y="703.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(242,28,13)"/>
+            <text x="2.3543%" y="687.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(231,14,51)"/>
+            <text x="2.3543%" y="671.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.check (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(226,67,53)"/>
+            <text x="2.3543%" y="655.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Platform$.runWorkers (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(245,213,12)"/>
+            <text x="2.3543%" y="639.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(220,53,33)"/>
+            <text x="2.3543%" y="623.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.$anonfun$check$1$adapted (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(234,35,37)"/>
+            <text x="2.3543%" y="607.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.$anonfun$check$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(207,177,51)"/>
+            <text x="2.3543%" y="591.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Test$.workerFun$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(243,109,49)"/>
+            <text x="2.3543%" y="575.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(254,13,38)"/>
+            <text x="2.3543%" y="559.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(221,169,0)"/>
+            <text x="2.3543%" y="543.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(207,112,50)"/>
+            <text x="2.3543%" y="527.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(253,153,52)"/>
+            <text x="2.3543%" y="511.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(219,11,8)"/>
+            <text x="2.3543%" y="495.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(253,172,21)"/>
+            <text x="2.3543%" y="479.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(254,13,38)"/>
+            <text x="2.3543%" y="463.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(221,169,0)"/>
+            <text x="2.3543%" y="447.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(207,112,50)"/>
+            <text x="2.3543%" y="431.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(253,153,52)"/>
+            <text x="2.3543%" y="415.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(219,11,8)"/>
+            <text x="2.3543%" y="399.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(253,172,21)"/>
+            <text x="2.3543%" y="383.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.secure (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(205,178,7)"/>
+            <text x="2.3543%" y="367.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(234,163,16)"/>
+            <text x="2.3543%" y="351.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(243,125,35)"/>
+            <text x="2.3543%" y="335.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(213,108,49)"/>
+            <text x="2.3543%" y="319.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalacheck.Prop$.$anonfun$forAll$3 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(233,226,44)"/>
+            <text x="2.3543%" y="303.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(207,65,52)"/>
+            <text x="2.3543%" y="287.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(235,49,34)"/>
+            <text x="2.3543%" y="271.50">org..</text>
+        </g>
+        <g>
+            <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(252,140,16)"/>
+            <text x="2.3543%" y="255.50">org..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$10462.775835262.apply (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(253,166,1)"/>
+            <text x="2.3543%" y="239.50">com..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137$adapted (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(251,48,4)"/>
+            <text x="2.3543%" y="223.50">com..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(247,155,35)"/>
+            <text x="2.3543%" y="207.50">com..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$6 (115 samples, 3.51%)</title>
+            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(206,90,0)"/>
+            <text x="2.3543%" y="191.50">com..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64UrlAsBytes (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(226,59,6)"/>
+            <text x="3.9401%" y="175.50">c..</text>
+        </g>
+        <g>
+            <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(225,32,26)"/>
+            <text x="3.9401%" y="159.50">c..</text>
+        </g>
+        <g>
+            <title>scoverage.Invoker$.invoked (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(240,151,3)"/>
+            <text x="3.9401%" y="143.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.AbstractMap.contains (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(209,216,47)"/>
+            <text x="3.9401%" y="127.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.MapOps.contains$ (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(242,162,46)"/>
+            <text x="3.9401%" y="111.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.MapOps.contains (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(207,229,35)"/>
+            <text x="3.9401%" y="95.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.TrieMap.get (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(226,6,29)"/>
+            <text x="3.9401%" y="79.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.TrieMap.lookuphc (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(213,12,48)"/>
+            <text x="3.9401%" y="63.50">s..</text>
+        </g>
+        <g>
+            <title>scala.collection.concurrent.INode.rec_lookup (63 samples, 1.92%)</title>
+            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(206,146,5)"/>
+            <text x="3.9401%" y="47.50">s..</text>
+        </g>
+        <g>
+            <title>DrainStacksCompactionTask::do_it(GCTaskManager*, unsigned int) (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(235,63,36)"/>
+            <text x="5.8615%" y="1855.50">Dra..</text>
+        </g>
+        <g>
+            <title>ParCompactionManager::drain_region_stacks() (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(233,203,47)"/>
+            <text x="5.8615%" y="1839.50">Par..</text>
+        </g>
+        <g>
+            <title>PSParallelCompact::fill_region(ParCompactionManager*, unsigned long) (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(249,0,7)"/>
+            <text x="5.8615%" y="1823.50">PSP..</text>
+        </g>
+        <g>
+            <title>ParMarkBitMap::iterate(ParMarkBitMapClosure*, unsigned long, unsigned long) const (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(209,5,12)"/>
+            <text x="5.8615%" y="1807.50">Par..</text>
+        </g>
+        <g>
+            <title>MoveAndUpdateClosure::do_addr(HeapWord*, unsigned long) (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(244,227,14)"/>
+            <text x="5.8615%" y="1791.50">Mov..</text>
+        </g>
+        <g>
+            <title>InstanceKlass::oop_update_pointers(ParCompactionManager*, oopDesc*) (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(215,142,7)"/>
+            <text x="5.8615%" y="1775.50">Ins..</text>
+        </g>
+        <g>
+            <title>ParallelCompactData::calc_new_pointer(HeapWord*) (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(239,40,11)"/>
+            <text x="5.8615%" y="1759.50">Par..</text>
+        </g>
+        <g>
+            <title>ParMarkBitMap::live_words_in_range(HeapWord*, oopDesc*) const (105 samples, 3.20%)</title>
+            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(220,137,24)"/>
+            <text x="5.8615%" y="1743.50">Par..</text>
+        </g>
+        <g>
+            <title>OldToYoungRootsTask::do_it(GCTaskManager*, unsigned int) (490 samples, 14.94%)</title>
+            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(250,216,25)"/>
+            <text x="9.0637%" y="1855.50">OldToYoungRootsTask::do..</text>
+        </g>
+        <g>
+            <title>CardTableExtension::scavenge_contents_parallel(ObjectStartArray*, MutableSpace*, HeapWord*, PSPromotionManager*, unsigned int, unsigned int) (490 samples, 14.94%)</title>
+            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(247,188,46)"/>
+            <text x="9.0637%" y="1839.50">CardTableExtension::sca..</text>
+        </g>
+        <g>
+            <title>PSPromotionManager::drain_stacks_depth(bool) (490 samples, 14.94%)</title>
+            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(249,81,13)"/>
+            <text x="9.0637%" y="1823.50">PSPromotionManager::dra..</text>
+        </g>
+        <g>
+            <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (358 samples, 10.92%)</title>
+            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(210,190,36)"/>
+            <text x="13.0893%" y="1807.50">oopDesc* PSPromo..</text>
+        </g>
+        <g>
+            <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (161 samples, 4.91%)</title>
+            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(216,227,32)"/>
+            <text x="19.0972%" y="1791.50">Instan..</text>
+        </g>
+        <g>
+            <title>GCTaskThread::run() (793 samples, 24.18%)</title>
+            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(223,24,24)"/>
+            <text x="5.8615%" y="1871.50">GCTaskThread::run()</text>
+        </g>
+        <g>
+            <title>StealTask::do_it(GCTaskManager*, unsigned int) (198 samples, 6.04%)</title>
+            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(245,93,3)"/>
+            <text x="24.0072%" y="1855.50">StealTas..</text>
+        </g>
+        <g>
+            <title>PSPromotionManager::drain_stacks_depth(bool) (198 samples, 6.04%)</title>
+            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(249,81,13)"/>
+            <text x="24.0072%" y="1839.50">PSPromot..</text>
+        </g>
+        <g>
+            <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (138 samples, 4.21%)</title>
+            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(210,190,36)"/>
+            <text x="25.8371%" y="1823.50">oopDe..</text>
+        </g>
+        <g>
+            <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (80 samples, 2.44%)</title>
+            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(216,227,32)"/>
+            <text x="27.6059%" y="1807.50">In..</text>
+        </g>
+        <g>
+            <title>Matcher::match() (109 samples, 3.32%)</title>
+            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(252,31,9)"/>
+            <text x="30.0457%" y="1759.50">Mat..</text>
+        </g>
+        <g>
+            <title>Matcher::xform(Node*, int) (109 samples, 3.32%)</title>
+            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(232,214,39)"/>
+            <text x="30.0457%" y="1743.50">Mat..</text>
+        </g>
+        <g>
+            <title>Arena::contains(void const*) const (109 samples, 3.32%)</title>
+            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(228,221,38)"/>
+            <text x="30.0457%" y="1727.50">Are..</text>
+        </g>
+        <g>
+            <title>PhaseAggressiveCoalesce::insert_copies(Matcher&amp;) (86 samples, 2.62%)</title>
+            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(238,108,41)"/>
+            <text x="33.3699%" y="1743.50">Ph..</text>
+        </g>
+        <g>
+            <title>PhaseChaitin::Split(unsigned int, ResourceArea*) (213 samples, 6.50%)</title>
+            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(248,202,16)"/>
+            <text x="35.9926%" y="1743.50">PhaseChai..</text>
+        </g>
+        <g>
+            <title>PhaseChaitin::build_ifg_physical(ResourceArea*) (305 samples, 9.30%)</title>
+            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(224,204,35)"/>
+            <text x="42.4885%" y="1743.50">PhaseChaitin:..</text>
+        </g>
+        <g>
+            <title>PhaseChaitin::interfere_with_live(unsigned int, IndexSet*) (183 samples, 5.58%)</title>
+            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(231,171,31)"/>
+            <text x="46.2091%" y="1727.50">PhaseCh..</text>
+        </g>
+        <g>
+            <title>IndexSetIterator::advance_and_next() (66 samples, 2.01%)</title>
+            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(221,170,35)"/>
+            <text x="49.7773%" y="1711.50">I..</text>
+        </g>
+        <g>
+            <title>PhaseChaitin::gather_lrg_masks(bool) (95 samples, 2.90%)</title>
+            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(211,73,26)"/>
+            <text x="51.7901%" y="1743.50">Ph..</text>
+        </g>
+        <g>
+            <title>PhaseChaitin::post_allocate_copy_removal() (139 samples, 4.24%)</title>
+            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(234,98,13)"/>
+            <text x="54.6873%" y="1743.50">Phase..</text>
+        </g>
+        <g>
+            <title>PhaseChaitin::elide_copy(Node*, int, Block*, Node_List&amp;, Node_List&amp;, bool) (76 samples, 2.32%)</title>
+            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(252,216,19)"/>
+            <text x="56.6086%" y="1727.50">P..</text>
+        </g>
+        <g>
+            <title>PhaseCoalesce::coalesce_driver() (92 samples, 2.81%)</title>
+            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(226,120,16)"/>
+            <text x="58.9264%" y="1743.50">Ph..</text>
+        </g>
+        <g>
+            <title>PhaseConservativeCoalesce::coalesce(Block*) (92 samples, 2.81%)</title>
+            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(229,38,26)"/>
+            <text x="58.9264%" y="1727.50">Ph..</text>
+        </g>
+        <g>
+            <title>PhaseConservativeCoalesce::update_ifg(unsigned int, unsigned int, IndexSet*, IndexSet*) (92 samples, 2.81%)</title>
+            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(243,40,43)"/>
+            <text x="58.9264%" y="1711.50">Ph..</text>
+        </g>
+        <g>
+            <title>PhaseIFG::Compute_Effective_Degree() (53 samples, 1.62%)</title>
+            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(227,72,12)"/>
+            <text x="61.7322%" y="1743.50"></text>
+        </g>
+        <g>
+            <title>IndexSetIterator::advance_and_next() (53 samples, 1.62%)</title>
+            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(221,170,35)"/>
+            <text x="61.7322%" y="1727.50"></text>
+        </g>
+        <g>
+            <title>PhaseIFG::SquareUp() (48 samples, 1.46%)</title>
+            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(231,0,44)"/>
+            <text x="63.3485%" y="1743.50"></text>
+        </g>
+        <g>
+            <title>IndexSetIterator::advance_and_next() (48 samples, 1.46%)</title>
+            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(221,170,35)"/>
+            <text x="63.3485%" y="1727.50"></text>
+        </g>
+        <g>
+            <title>Compile::Code_Gen() (1,250 samples, 38.12%)</title>
+            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(231,42,32)"/>
+            <text x="30.0457%" y="1775.50">Compile::Code_Gen()</text>
+        </g>
+        <g>
+            <title>PhaseChaitin::Register_Allocate() (1,141 samples, 34.80%)</title>
+            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(228,102,7)"/>
+            <text x="33.3699%" y="1759.50">PhaseChaitin::Register_Allocate()</text>
+        </g>
+        <g>
+            <title>PhaseLive::compute(unsigned int) (110 samples, 3.35%)</title>
+            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(205,142,50)"/>
+            <text x="64.8124%" y="1743.50">Pha..</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::Dominators() (67 samples, 2.04%)</title>
+            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(252,13,18)"/>
+            <text x="68.1670%" y="1743.50">P..</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::build_loop_early(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (108 samples, 3.29%)</title>
+            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(209,71,12)"/>
+            <text x="70.2104%" y="1743.50">Pha..</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::build_loop_late(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (655 samples, 19.98%)</title>
+            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(247,33,39)"/>
+            <text x="73.5040%" y="1743.50">PhaseIdealLoop::build_loop_late..</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::build_loop_late_post(Node*) (556 samples, 16.96%)</title>
+            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(231,163,35)"/>
+            <text x="76.5233%" y="1727.50">PhaseIdealLoop::build_loop..</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::get_late_ctrl(Node*, Node*) (556 samples, 16.96%)</title>
+            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(228,63,35)"/>
+            <text x="76.5233%" y="1711.50">PhaseIdealLoop::get_late_c..</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::is_dominator(Node*, Node*) [clone .part.114] (496 samples, 15.13%)</title>
+            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(214,176,27)"/>
+            <text x="78.3531%" y="1695.50">PhaseIdealLoop::is_domi..</text>
+        </g>
+        <g>
+            <title>C2Compiler::compile_method(ciEnv*, ciMethod*, int) (2,130 samples, 64.96%)</title>
+            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(227,78,15)"/>
+            <text x="30.0457%" y="1807.50">C2Compiler::compile_method(ciEnv*, ciMethod*, int)</text>
+        </g>
+        <g>
+            <title>Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool) (2,130 samples, 64.96%)</title>
+            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(248,99,0)"/>
+            <text x="30.0457%" y="1791.50">Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool)</text>
+        </g>
+        <g>
+            <title>Compile::Optimize() (880 samples, 26.84%)</title>
+            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(251,158,5)"/>
+            <text x="68.1670%" y="1775.50">Compile::Optimize()</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::build_and_optimize(bool, bool) (880 samples, 26.84%)</title>
+            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(243,158,30)"/>
+            <text x="68.1670%" y="1759.50">PhaseIdealLoop::build_and_optimize(bool, bo..</text>
+        </g>
+        <g>
+            <title>PhaseIdealLoop::build_loop_tree() (50 samples, 1.52%)</title>
+            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(243,110,36)"/>
+            <text x="93.4796%" y="1743.50"></text>
+        </g>
+        <g>
+            <title>all (3,279 samples, 100%)</title>
+            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(205,60,50)"/>
+            <text x="0.2500%" y="1919.50"></text>
+        </g>
+        <g>
+            <title>start_thread (3,095 samples, 94.39%)</title>
+            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(222,211,8)"/>
+            <text x="5.8615%" y="1903.50">start_thread</text>
+        </g>
+        <g>
+            <title>java_start(Thread*) (3,095 samples, 94.39%)</title>
+            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(234,209,47)"/>
+            <text x="5.8615%" y="1887.50">java_start(Thread*)</text>
+        </g>
+        <g>
+            <title>JavaThread::run() (2,302 samples, 70.20%)</title>
+            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(217,5,39)"/>
+            <text x="30.0457%" y="1871.50">JavaThread::run()</text>
+        </g>
+        <g>
+            <title>JavaThread::thread_main_inner() (2,302 samples, 70.20%)</title>
+            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(248,132,33)"/>
+            <text x="30.0457%" y="1855.50">JavaThread::thread_main_inner()</text>
+        </g>
+        <g>
+            <title>CompileBroker::compiler_thread_loop() (2,302 samples, 70.20%)</title>
+            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(208,137,39)"/>
+            <text x="30.0457%" y="1839.50">CompileBroker::compiler_thread_loop()</text>
+        </g>
+        <g>
+            <title>CompileBroker::invoke_compiler_on_method(CompileTask*) (2,302 samples, 70.20%)</title>
+            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(252,177,19)"/>
+            <text x="30.0457%" y="1823.50">CompileBroker::invoke_compiler_on_method(CompileTask*)</text>
+        </g>
+        <g>
+            <title>Compiler::compile_method(ciEnv*, ciMethod*, int) (172 samples, 5.25%)</title>
+            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(207,120,21)"/>
+            <text x="95.0045%" y="1807.50">Compil..</text>
+        </g>
+        <g>
+            <title>Compilation::Compilation(AbstractCompiler*, ciEnv*, ciMethod*, int, BufferBlob*) (172 samples, 5.25%)</title>
+            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(211,122,18)"/>
+            <text x="95.0045%" y="1791.50">Compil..</text>
+        </g>
+        <g>
+            <title>Compilation::compile_method() (172 samples, 5.25%)</title>
+            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(205,178,15)"/>
+            <text x="95.0045%" y="1775.50">Compil..</text>
+        </g>
+        <g>
+            <title>ciEnv::register_method(ciMethod*, int, CodeOffsets*, int, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int, bool, bool, RTMState) (172 samples, 5.25%)</title>
+            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(246,91,28)"/>
+            <text x="95.0045%" y="1759.50">ciEnv:..</text>
+        </g>
+        <g>
+            <title>nmethod::new_nmethod(methodHandle, int, int, CodeOffsets*, int, DebugInformationRecorder*, Dependencies*, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int) (172 samples, 5.25%)</title>
+            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(248,160,22)"/>
+            <text x="95.0045%" y="1743.50">nmetho..</text>
+        </g>
+        <g>
+            <title>CodeCache::allocate(int, bool) (172 samples, 5.25%)</title>
+            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(254,124,47)"/>
+            <text x="95.0045%" y="1727.50">CodeCa..</text>
+        </g>
+        <g>
+            <title>CodeHeap::allocate(unsigned long, bool) (172 samples, 5.25%)</title>
+            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(250,130,33)"/>
+            <text x="95.0045%" y="1711.50">CodeHe..</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/data/flamegraph/colors/deterministic.svg
+++ b/tests/data/flamegraph/colors/deterministic.svg
@@ -37,1177 +37,1177 @@ var truncate_text_right = false;]]>
     <svg id="frames" x="10" width="1180">
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8575.1705890900.apply$mcV$sp (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(216,139,44)"/>
+            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(220,102,51)"/>
             <text x="0.2500%" y="751.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$124 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(208,118,47)"/>
+            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(252,157,54)"/>
             <text x="0.2500%" y="735.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(238,100,11)"/>
+            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(252,47,46)"/>
             <text x="0.2500%" y="719.50">c..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(245,146,32)"/>
+            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(214,41,30)"/>
             <text x="0.2500%" y="703.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(210,86,34)"/>
+            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(227,222,18)"/>
             <text x="0.2500%" y="687.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(228,136,22)"/>
+            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(235,88,33)"/>
             <text x="0.2500%" y="671.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(209,72,20)"/>
+            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(243,78,7)"/>
             <text x="0.2500%" y="655.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(208,140,43)"/>
+            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(219,50,13)"/>
             <text x="0.2500%" y="639.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(225,123,12)"/>
+            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(247,202,37)"/>
             <text x="0.2500%" y="623.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(228,200,34)"/>
+            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(251,172,43)"/>
             <text x="0.2500%" y="607.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(253,112,7)"/>
+            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(246,68,6)"/>
             <text x="0.2500%" y="591.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(252,191,27)"/>
+            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(216,70,17)"/>
             <text x="0.2500%" y="575.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(223,159,50)"/>
+            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(215,141,13)"/>
             <text x="0.2500%" y="559.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(224,99,1)"/>
+            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(233,29,52)"/>
             <text x="0.2500%" y="543.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(239,47,0)"/>
+            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(206,61,49)"/>
             <text x="0.2500%" y="527.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(205,87,27)"/>
+            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(253,187,28)"/>
             <text x="0.2500%" y="511.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(253,39,14)"/>
+            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(247,145,48)"/>
             <text x="0.2500%" y="495.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(251,122,49)"/>
+            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(215,131,2)"/>
             <text x="0.2500%" y="479.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(223,159,50)"/>
+            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(215,141,13)"/>
             <text x="0.2500%" y="463.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(224,99,1)"/>
+            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(233,29,52)"/>
             <text x="0.2500%" y="447.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(239,47,0)"/>
+            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(206,61,49)"/>
             <text x="0.2500%" y="431.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(205,87,27)"/>
+            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(253,187,28)"/>
             <text x="0.2500%" y="415.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(253,39,14)"/>
+            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(247,145,48)"/>
             <text x="0.2500%" y="399.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(251,122,49)"/>
+            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(215,131,2)"/>
             <text x="0.2500%" y="383.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(230,62,39)"/>
+            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(216,3,21)"/>
             <text x="0.2500%" y="367.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(244,215,5)"/>
+            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(233,47,47)"/>
             <text x="0.2500%" y="351.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(254,200,37)"/>
+            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(216,134,5)"/>
             <text x="0.2500%" y="335.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(251,21,16)"/>
+            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(240,37,30)"/>
             <text x="0.2500%" y="319.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(247,172,3)"/>
+            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(251,33,48)"/>
             <text x="0.2500%" y="303.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(217,86,50)"/>
+            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(226,75,42)"/>
             <text x="0.2500%" y="287.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(224,212,1)"/>
+            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(246,74,53)"/>
             <text x="0.2500%" y="271.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(207,95,52)"/>
+            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(240,194,24)"/>
             <text x="0.2500%" y="255.50">o..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$9984.1092558103.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(216,198,29)"/>
+            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(222,39,47)"/>
             <text x="0.2500%" y="239.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(251,209,53)"/>
+            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(219,158,2)"/>
             <text x="0.2500%" y="223.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(254,161,13)"/>
+            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(227,60,42)"/>
             <text x="0.2500%" y="207.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$5 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(226,200,1)"/>
+            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(230,55,48)"/>
             <text x="0.2500%" y="191.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase16AsBytes (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(246,86,33)"/>
+            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(224,155,39)"/>
             <text x="0.2500%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase16 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(222,220,16)"/>
+            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(224,196,28)"/>
             <text x="0.2500%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(210,41,15)"/>
+            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(227,5,50)"/>
             <text x="0.2500%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(243,78,18)"/>
+            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(221,97,42)"/>
             <text x="0.2500%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(245,73,0)"/>
+            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(243,168,19)"/>
             <text x="0.2500%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(247,119,30)"/>
+            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(231,157,5)"/>
             <text x="0.2500%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(217,67,14)"/>
+            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(231,137,49)"/>
             <text x="0.2500%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(206,173,14)"/>
+            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(218,82,49)"/>
             <text x="0.2500%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(211,144,16)"/>
+            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(242,134,29)"/>
             <text x="0.2500%" y="47.50">s..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64AsBytes (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(230,210,9)"/>
+            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(223,109,7)"/>
             <text x="2.3543%" y="175.50"></text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(205,119,1)"/>
+            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(220,67,53)"/>
             <text x="2.3543%" y="159.50"></text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(210,41,15)"/>
+            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(227,5,50)"/>
             <text x="2.3543%" y="143.50"></text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(243,78,18)"/>
+            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(221,97,42)"/>
             <text x="2.3543%" y="127.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(245,73,0)"/>
+            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(243,168,19)"/>
             <text x="2.3543%" y="111.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(247,119,30)"/>
+            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(231,157,5)"/>
             <text x="2.3543%" y="95.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(217,67,14)"/>
+            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(231,137,49)"/>
             <text x="2.3543%" y="79.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(206,173,14)"/>
+            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(218,82,49)"/>
             <text x="2.3543%" y="63.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(211,144,16)"/>
+            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(242,134,29)"/>
             <text x="2.3543%" y="47.50"></text>
         </g>
         <g>
             <title>java.lang.Thread.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(207,36,7)"/>
+            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(210,79,46)"/>
             <text x="0.2500%" y="1903.50">java.la..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor$Worker.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(223,162,54)"/>
+            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(219,191,46)"/>
             <text x="0.2500%" y="1887.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor.runWorker (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(211,40,6)"/>
+            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(244,50,22)"/>
             <text x="0.2500%" y="1871.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(214,180,2)"/>
+            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(227,24,21)"/>
             <text x="0.2500%" y="1855.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.Executors$RunnableAdapter.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(205,2,33)"/>
+            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(213,3,17)"/>
             <text x="0.2500%" y="1839.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(214,180,2)"/>
+            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(227,24,21)"/>
             <text x="0.2500%" y="1823.50">java.ut..</text>
         </g>
         <g>
             <title>sbt.CompletionService$$anon$2.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(230,211,29)"/>
+            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(241,45,17)"/>
             <text x="0.2500%" y="1807.50">sbt.Com..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4$$Lambda$2176.1600330912.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(239,107,2)"/>
+            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(229,111,36)"/>
             <text x="0.2500%" y="1791.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(214,197,10)"/>
+            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(249,213,27)"/>
             <text x="0.2500%" y="1775.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2169.2034046523.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(221,169,52)"/>
+            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(247,77,17)"/>
             <text x="0.2500%" y="1759.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(251,69,10)"/>
+            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(222,188,33)"/>
             <text x="0.2500%" y="1743.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(250,139,44)"/>
+            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(210,59,43)"/>
             <text x="0.2500%" y="1727.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.internal.util.ErrorHandling$.wideConvert (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(249,89,0)"/>
+            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(220,65,2)"/>
             <text x="0.2500%" y="1711.50">sbt.int..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2178.2095669414.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(211,179,5)"/>
+            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(237,77,4)"/>
             <text x="0.2500%" y="1695.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(252,215,32)"/>
+            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(228,225,21)"/>
             <text x="0.2500%" y="1679.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$4.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(224,63,2)"/>
+            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(226,122,31)"/>
             <text x="0.2500%" y="1663.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3$$Lambda$2167.231900526.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(251,71,18)"/>
+            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(206,55,4)"/>
             <text x="0.2500%" y="1647.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3.$anonfun$apply$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(237,7,4)"/>
+            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(244,37,11)"/>
             <text x="0.2500%" y="1631.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.Tests$$$Lambda$7842.1208470949.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(238,140,25)"/>
+            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(233,51,37)"/>
             <text x="0.2500%" y="1615.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.Tests$.$anonfun$toTask$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(208,156,12)"/>
+            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(210,126,29)"/>
             <text x="0.2500%" y="1599.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFunction.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(216,28,9)"/>
+            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(252,157,48)"/>
             <text x="0.2500%" y="1583.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(207,195,52)"/>
+            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(251,34,11)"/>
             <text x="0.2500%" y="1567.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(207,195,52)"/>
+            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(251,34,11)"/>
             <text x="0.2500%" y="1551.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$.sbt$TestFramework$$withContextLoader (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(244,127,10)"/>
+            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(228,164,52)"/>
             <text x="0.2500%" y="1535.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1$$Lambda$7850.1117892339.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(253,29,31)"/>
+            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(222,204,47)"/>
             <text x="0.2500%" y="1519.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(252,171,1)"/>
+            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(250,71,9)"/>
             <text x="0.2500%" y="1503.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(239,195,25)"/>
+            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(227,90,30)"/>
             <text x="0.2500%" y="1487.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(219,54,9)"/>
+            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(231,59,29)"/>
             <text x="0.2500%" y="1471.50">sbt.Tes..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework$ScalaTestTask.execute (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(227,63,22)"/>
+            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(241,135,42)"/>
             <text x="0.2500%" y="1455.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(245,169,11)"/>
+            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(220,149,36)"/>
             <text x="0.2500%" y="1439.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(213,17,29)"/>
+            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(239,142,14)"/>
             <text x="0.2500%" y="1423.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(218,110,25)"/>
+            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(253,183,53)"/>
             <text x="0.2500%" y="1407.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(226,127,32)"/>
+            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(208,161,30)"/>
             <text x="0.2500%" y="1391.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(253,219,24)"/>
+            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(250,2,18)"/>
             <text x="0.2500%" y="1375.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7943.1056778999.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(241,126,4)"/>
+            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(234,62,31)"/>
             <text x="0.2500%" y="1359.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(222,73,20)"/>
+            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(240,58,13)"/>
             <text x="0.2500%" y="1343.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(251,134,16)"/>
+            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(234,42,46)"/>
             <text x="0.2500%" y="1327.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(211,214,31)"/>
+            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(211,114,32)"/>
             <text x="0.2500%" y="1311.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(230,118,27)"/>
+            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(222,31,9)"/>
             <text x="0.2500%" y="1295.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(225,221,2)"/>
+            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(249,222,8)"/>
             <text x="0.2500%" y="1279.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(231,228,18)"/>
+            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(225,134,17)"/>
             <text x="0.2500%" y="1263.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(211,120,10)"/>
+            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(211,171,24)"/>
             <text x="0.2500%" y="1247.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(226,36,30)"/>
+            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(226,168,40)"/>
             <text x="0.2500%" y="1231.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(217,103,44)"/>
+            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(239,76,39)"/>
             <text x="0.2500%" y="1215.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(225,108,7)"/>
+            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(229,198,12)"/>
             <text x="0.2500%" y="1199.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(252,56,2)"/>
+            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(220,160,11)"/>
             <text x="0.2500%" y="1183.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(246,32,19)"/>
+            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(220,111,53)"/>
             <text x="0.2500%" y="1167.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(240,171,25)"/>
+            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(206,178,29)"/>
             <text x="0.2500%" y="1151.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(217,103,44)"/>
+            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(239,76,39)"/>
             <text x="0.2500%" y="1135.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(225,108,7)"/>
+            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(229,198,12)"/>
             <text x="0.2500%" y="1119.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(252,56,2)"/>
+            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(220,160,11)"/>
             <text x="0.2500%" y="1103.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(246,32,19)"/>
+            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(220,111,53)"/>
             <text x="0.2500%" y="1087.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(240,171,25)"/>
+            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(206,178,29)"/>
             <text x="0.2500%" y="1071.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7951.1136212450.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(231,208,46)"/>
+            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(240,80,28)"/>
             <text x="0.2500%" y="1055.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(239,165,33)"/>
+            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(223,190,6)"/>
             <text x="0.2500%" y="1039.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(254,219,1)"/>
+            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(211,45,41)"/>
             <text x="0.2500%" y="1023.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(222,96,38)"/>
+            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(215,29,35)"/>
             <text x="0.2500%" y="1007.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(232,170,15)"/>
+            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(252,190,17)"/>
             <text x="0.2500%" y="991.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(244,171,52)"/>
+            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(233,79,35)"/>
             <text x="0.2500%" y="975.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7967.812636372.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(222,202,30)"/>
+            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(229,91,48)"/>
             <text x="0.2500%" y="959.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(248,103,47)"/>
+            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(250,134,24)"/>
             <text x="0.2500%" y="943.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(226,212,18)"/>
+            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(217,216,9)"/>
             <text x="0.2500%" y="927.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(235,209,15)"/>
+            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(231,74,39)"/>
             <text x="0.2500%" y="911.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(243,17,14)"/>
+            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(240,207,29)"/>
             <text x="0.2500%" y="895.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(210,44,24)"/>
+            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(237,134,35)"/>
             <text x="0.2500%" y="879.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(252,74,14)"/>
+            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(245,149,30)"/>
             <text x="0.2500%" y="863.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(243,186,28)"/>
+            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(212,203,8)"/>
             <text x="0.2500%" y="847.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(243,186,28)"/>
+            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(212,203,8)"/>
             <text x="0.2500%" y="831.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf$.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(247,12,7)"/>
+            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(242,152,44)"/>
             <text x="0.2500%" y="815.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(243,57,1)"/>
+            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(233,99,40)"/>
             <text x="0.2500%" y="799.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(254,73,19)"/>
+            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(246,111,11)"/>
             <text x="0.2500%" y="783.50">org.sca..</text>
         </g>
         <g>
             <title>scala.runtime.java8.JFunction0$mcV$sp.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(237,207,29)"/>
+            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(246,12,5)"/>
             <text x="0.2500%" y="767.50">scala.r..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8582.1627656208.apply$mcV$sp (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(220,142,41)"/>
+            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(254,229,0)"/>
             <text x="2.3543%" y="751.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$136 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(233,143,28)"/>
+            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(222,155,20)"/>
             <text x="2.3543%" y="735.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(238,100,11)"/>
+            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(252,47,46)"/>
             <text x="2.3543%" y="719.50">com..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(245,146,32)"/>
+            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(214,41,30)"/>
             <text x="2.3543%" y="703.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(210,86,34)"/>
+            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(227,222,18)"/>
             <text x="2.3543%" y="687.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(228,136,22)"/>
+            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(235,88,33)"/>
             <text x="2.3543%" y="671.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(209,72,20)"/>
+            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(243,78,7)"/>
             <text x="2.3543%" y="655.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(208,140,43)"/>
+            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(219,50,13)"/>
             <text x="2.3543%" y="639.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(225,123,12)"/>
+            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(247,202,37)"/>
             <text x="2.3543%" y="623.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(228,200,34)"/>
+            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(251,172,43)"/>
             <text x="2.3543%" y="607.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(253,112,7)"/>
+            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(246,68,6)"/>
             <text x="2.3543%" y="591.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(252,191,27)"/>
+            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(216,70,17)"/>
             <text x="2.3543%" y="575.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(223,159,50)"/>
+            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(215,141,13)"/>
             <text x="2.3543%" y="559.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(224,99,1)"/>
+            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(233,29,52)"/>
             <text x="2.3543%" y="543.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(239,47,0)"/>
+            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(206,61,49)"/>
             <text x="2.3543%" y="527.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(205,87,27)"/>
+            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(253,187,28)"/>
             <text x="2.3543%" y="511.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(253,39,14)"/>
+            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(247,145,48)"/>
             <text x="2.3543%" y="495.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(251,122,49)"/>
+            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(215,131,2)"/>
             <text x="2.3543%" y="479.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(223,159,50)"/>
+            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(215,141,13)"/>
             <text x="2.3543%" y="463.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(224,99,1)"/>
+            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(233,29,52)"/>
             <text x="2.3543%" y="447.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(239,47,0)"/>
+            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(206,61,49)"/>
             <text x="2.3543%" y="431.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(205,87,27)"/>
+            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(253,187,28)"/>
             <text x="2.3543%" y="415.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(253,39,14)"/>
+            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(247,145,48)"/>
             <text x="2.3543%" y="399.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(251,122,49)"/>
+            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(215,131,2)"/>
             <text x="2.3543%" y="383.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(230,62,39)"/>
+            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(216,3,21)"/>
             <text x="2.3543%" y="367.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(244,215,5)"/>
+            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(233,47,47)"/>
             <text x="2.3543%" y="351.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(254,200,37)"/>
+            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(216,134,5)"/>
             <text x="2.3543%" y="335.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(251,21,16)"/>
+            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(240,37,30)"/>
             <text x="2.3543%" y="319.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(247,172,3)"/>
+            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(251,33,48)"/>
             <text x="2.3543%" y="303.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(217,86,50)"/>
+            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(226,75,42)"/>
             <text x="2.3543%" y="287.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(224,212,1)"/>
+            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(246,74,53)"/>
             <text x="2.3543%" y="271.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(207,95,52)"/>
+            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(240,194,24)"/>
             <text x="2.3543%" y="255.50">org..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$10462.775835262.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(213,122,15)"/>
+            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(221,80,42)"/>
             <text x="2.3543%" y="239.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(253,123,0)"/>
+            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(238,6,17)"/>
             <text x="2.3543%" y="223.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(206,211,26)"/>
+            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(240,119,52)"/>
             <text x="2.3543%" y="207.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$6 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(214,54,20)"/>
+            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(225,162,37)"/>
             <text x="2.3543%" y="191.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64UrlAsBytes (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(211,224,6)"/>
+            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(250,228,46)"/>
             <text x="3.9401%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(205,119,1)"/>
+            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(220,67,53)"/>
             <text x="3.9401%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(210,41,15)"/>
+            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(227,5,50)"/>
             <text x="3.9401%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(243,78,18)"/>
+            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(221,97,42)"/>
             <text x="3.9401%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(245,73,0)"/>
+            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(243,168,19)"/>
             <text x="3.9401%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(247,119,30)"/>
+            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(231,157,5)"/>
             <text x="3.9401%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(217,67,14)"/>
+            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(231,137,49)"/>
             <text x="3.9401%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(206,173,14)"/>
+            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(218,82,49)"/>
             <text x="3.9401%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(211,144,16)"/>
+            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(242,134,29)"/>
             <text x="3.9401%" y="47.50">s..</text>
         </g>
         <g>
             <title>DrainStacksCompactionTask::do_it(GCTaskManager*, unsigned int) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(243,108,47)"/>
+            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(245,120,40)"/>
             <text x="5.8615%" y="1855.50">Dra..</text>
         </g>
         <g>
             <title>ParCompactionManager::drain_region_stacks() (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(245,222,35)"/>
+            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(237,89,35)"/>
             <text x="5.8615%" y="1839.50">Par..</text>
         </g>
         <g>
             <title>PSParallelCompact::fill_region(ParCompactionManager*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(226,40,48)"/>
+            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(250,179,33)"/>
             <text x="5.8615%" y="1823.50">PSP..</text>
         </g>
         <g>
             <title>ParMarkBitMap::iterate(ParMarkBitMapClosure*, unsigned long, unsigned long) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(241,23,39)"/>
+            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(237,61,30)"/>
             <text x="5.8615%" y="1807.50">Par..</text>
         </g>
         <g>
             <title>MoveAndUpdateClosure::do_addr(HeapWord*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(238,19,34)"/>
+            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(234,30,14)"/>
             <text x="5.8615%" y="1791.50">Mov..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_update_pointers(ParCompactionManager*, oopDesc*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(240,201,37)"/>
+            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(232,22,14)"/>
             <text x="5.8615%" y="1775.50">Ins..</text>
         </g>
         <g>
             <title>ParallelCompactData::calc_new_pointer(HeapWord*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(208,135,43)"/>
+            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(238,193,27)"/>
             <text x="5.8615%" y="1759.50">Par..</text>
         </g>
         <g>
             <title>ParMarkBitMap::live_words_in_range(HeapWord*, oopDesc*) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(237,94,7)"/>
+            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(250,86,15)"/>
             <text x="5.8615%" y="1743.50">Par..</text>
         </g>
         <g>
             <title>OldToYoungRootsTask::do_it(GCTaskManager*, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(210,203,30)"/>
+            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(214,136,8)"/>
             <text x="9.0637%" y="1855.50">OldToYoungRootsTask::do..</text>
         </g>
         <g>
             <title>CardTableExtension::scavenge_contents_parallel(ObjectStartArray*, MutableSpace*, HeapWord*, PSPromotionManager*, unsigned int, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(242,67,6)"/>
+            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(211,203,21)"/>
             <text x="9.0637%" y="1839.50">CardTableExtension::sca..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(217,115,45)"/>
+            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(245,191,22)"/>
             <text x="9.0637%" y="1823.50">PSPromotionManager::dra..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (358 samples, 10.92%)</title>
-            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(213,207,15)"/>
+            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(221,195,19)"/>
             <text x="13.0893%" y="1807.50">oopDesc* PSPromo..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (161 samples, 4.91%)</title>
-            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(227,147,36)"/>
+            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(244,132,41)"/>
             <text x="19.0972%" y="1791.50">Instan..</text>
         </g>
         <g>
             <title>GCTaskThread::run() (793 samples, 24.18%)</title>
-            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(231,28,50)"/>
+            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(226,134,54)"/>
             <text x="5.8615%" y="1871.50">GCTaskThread::run()</text>
         </g>
         <g>
             <title>StealTask::do_it(GCTaskManager*, unsigned int) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(206,1,42)"/>
+            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(237,158,39)"/>
             <text x="24.0072%" y="1855.50">StealTas..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(217,115,45)"/>
+            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(245,191,22)"/>
             <text x="24.0072%" y="1839.50">PSPromot..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (138 samples, 4.21%)</title>
-            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(213,207,15)"/>
+            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(221,195,19)"/>
             <text x="25.8371%" y="1823.50">oopDe..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (80 samples, 2.44%)</title>
-            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(227,147,36)"/>
+            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(244,132,41)"/>
             <text x="27.6059%" y="1807.50">In..</text>
         </g>
         <g>
             <title>Matcher::match() (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(217,202,13)"/>
+            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(232,51,22)"/>
             <text x="30.0457%" y="1759.50">Mat..</text>
         </g>
         <g>
             <title>Matcher::xform(Node*, int) (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(240,117,3)"/>
+            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(230,135,16)"/>
             <text x="30.0457%" y="1743.50">Mat..</text>
         </g>
         <g>
             <title>Arena::contains(void const*) const (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(217,65,52)"/>
+            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(242,109,32)"/>
             <text x="30.0457%" y="1727.50">Are..</text>
         </g>
         <g>
             <title>PhaseAggressiveCoalesce::insert_copies(Matcher&amp;) (86 samples, 2.62%)</title>
-            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(226,178,38)"/>
+            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(227,210,14)"/>
             <text x="33.3699%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::Split(unsigned int, ResourceArea*) (213 samples, 6.50%)</title>
-            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(215,15,31)"/>
+            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(206,223,27)"/>
             <text x="35.9926%" y="1743.50">PhaseChai..</text>
         </g>
         <g>
             <title>PhaseChaitin::build_ifg_physical(ResourceArea*) (305 samples, 9.30%)</title>
-            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(244,55,30)"/>
+            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(252,213,42)"/>
             <text x="42.4885%" y="1743.50">PhaseChaitin:..</text>
         </g>
         <g>
             <title>PhaseChaitin::interfere_with_live(unsigned int, IndexSet*) (183 samples, 5.58%)</title>
-            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(216,166,34)"/>
+            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(215,104,50)"/>
             <text x="46.2091%" y="1727.50">PhaseCh..</text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (66 samples, 2.01%)</title>
-            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(249,209,24)"/>
+            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(205,126,12)"/>
             <text x="49.7773%" y="1711.50">I..</text>
         </g>
         <g>
             <title>PhaseChaitin::gather_lrg_masks(bool) (95 samples, 2.90%)</title>
-            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(246,12,7)"/>
+            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(244,41,19)"/>
             <text x="51.7901%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::post_allocate_copy_removal() (139 samples, 4.24%)</title>
-            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(217,130,4)"/>
+            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(250,84,22)"/>
             <text x="54.6873%" y="1743.50">Phase..</text>
         </g>
         <g>
             <title>PhaseChaitin::elide_copy(Node*, int, Block*, Node_List&amp;, Node_List&amp;, bool) (76 samples, 2.32%)</title>
-            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(214,211,49)"/>
+            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(252,96,32)"/>
             <text x="56.6086%" y="1727.50">P..</text>
         </g>
         <g>
             <title>PhaseCoalesce::coalesce_driver() (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(241,86,53)"/>
+            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(232,213,50)"/>
             <text x="58.9264%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::coalesce(Block*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(207,4,10)"/>
+            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(247,177,1)"/>
             <text x="58.9264%" y="1727.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::update_ifg(unsigned int, unsigned int, IndexSet*, IndexSet*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(213,97,14)"/>
+            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(244,186,46)"/>
             <text x="58.9264%" y="1711.50">Ph..</text>
         </g>
         <g>
             <title>PhaseIFG::Compute_Effective_Degree() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(214,75,10)"/>
+            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(254,25,30)"/>
             <text x="61.7322%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(249,209,24)"/>
+            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(205,126,12)"/>
             <text x="61.7322%" y="1727.50"></text>
         </g>
         <g>
             <title>PhaseIFG::SquareUp() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(239,205,33)"/>
+            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(248,147,33)"/>
             <text x="63.3485%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(249,209,24)"/>
+            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(205,126,12)"/>
             <text x="63.3485%" y="1727.50"></text>
         </g>
         <g>
             <title>Compile::Code_Gen() (1,250 samples, 38.12%)</title>
-            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(228,110,35)"/>
+            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(241,3,42)"/>
             <text x="30.0457%" y="1775.50">Compile::Code_Gen()</text>
         </g>
         <g>
             <title>PhaseChaitin::Register_Allocate() (1,141 samples, 34.80%)</title>
-            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(247,199,21)"/>
+            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(250,196,4)"/>
             <text x="33.3699%" y="1759.50">PhaseChaitin::Register_Allocate()</text>
         </g>
         <g>
             <title>PhaseLive::compute(unsigned int) (110 samples, 3.35%)</title>
-            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(240,153,27)"/>
+            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(230,72,12)"/>
             <text x="64.8124%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::Dominators() (67 samples, 2.04%)</title>
-            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(243,52,49)"/>
+            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(213,90,37)"/>
             <text x="68.1670%" y="1743.50">P..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_early(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (108 samples, 3.29%)</title>
-            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(225,11,36)"/>
+            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(228,141,12)"/>
             <text x="70.2104%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (655 samples, 19.98%)</title>
-            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(211,17,31)"/>
+            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(237,43,45)"/>
             <text x="73.5040%" y="1743.50">PhaseIdealLoop::build_loop_late..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late_post(Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(254,211,2)"/>
+            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(244,33,18)"/>
             <text x="76.5233%" y="1727.50">PhaseIdealLoop::build_loop..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::get_late_ctrl(Node*, Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(254,120,21)"/>
+            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(246,49,7)"/>
             <text x="76.5233%" y="1711.50">PhaseIdealLoop::get_late_c..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::is_dominator(Node*, Node*) [clone .part.114] (496 samples, 15.13%)</title>
-            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(252,13,5)"/>
+            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(223,100,18)"/>
             <text x="78.3531%" y="1695.50">PhaseIdealLoop::is_domi..</text>
         </g>
         <g>
             <title>C2Compiler::compile_method(ciEnv*, ciMethod*, int) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(206,153,36)"/>
+            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(222,77,30)"/>
             <text x="30.0457%" y="1807.50">C2Compiler::compile_method(ciEnv*, ciMethod*, int)</text>
         </g>
         <g>
             <title>Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(245,191,32)"/>
+            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(243,65,17)"/>
             <text x="30.0457%" y="1791.50">Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool)</text>
         </g>
         <g>
             <title>Compile::Optimize() (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(245,198,26)"/>
+            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(213,36,46)"/>
             <text x="68.1670%" y="1775.50">Compile::Optimize()</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_and_optimize(bool, bool) (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(208,203,49)"/>
+            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(251,67,4)"/>
             <text x="68.1670%" y="1759.50">PhaseIdealLoop::build_and_optimize(bool, bo..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_tree() (50 samples, 1.52%)</title>
-            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(225,146,27)"/>
+            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(248,188,3)"/>
             <text x="93.4796%" y="1743.50"></text>
         </g>
         <g>
             <title>all (3,279 samples, 100%)</title>
-            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(243,189,40)"/>
+            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(233,26,26)"/>
             <text x="0.2500%" y="1919.50"></text>
         </g>
         <g>
             <title>start_thread (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(238,100,18)"/>
+            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(217,160,42)"/>
             <text x="5.8615%" y="1903.50">start_thread</text>
         </g>
         <g>
             <title>java_start(Thread*) (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(221,121,10)"/>
+            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(245,125,2)"/>
             <text x="5.8615%" y="1887.50">java_start(Thread*)</text>
         </g>
         <g>
             <title>JavaThread::run() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(249,16,53)"/>
+            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(233,194,19)"/>
             <text x="30.0457%" y="1871.50">JavaThread::run()</text>
         </g>
         <g>
             <title>JavaThread::thread_main_inner() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(236,159,26)"/>
+            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(206,140,30)"/>
             <text x="30.0457%" y="1855.50">JavaThread::thread_main_inner()</text>
         </g>
         <g>
             <title>CompileBroker::compiler_thread_loop() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(222,140,17)"/>
+            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(229,3,40)"/>
             <text x="30.0457%" y="1839.50">CompileBroker::compiler_thread_loop()</text>
         </g>
         <g>
             <title>CompileBroker::invoke_compiler_on_method(CompileTask*) (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(221,42,51)"/>
+            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(249,200,16)"/>
             <text x="30.0457%" y="1823.50">CompileBroker::invoke_compiler_on_method(CompileTask*)</text>
         </g>
         <g>
             <title>Compiler::compile_method(ciEnv*, ciMethod*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(214,170,37)"/>
+            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(221,6,40)"/>
             <text x="95.0045%" y="1807.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::Compilation(AbstractCompiler*, ciEnv*, ciMethod*, int, BufferBlob*) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(246,70,37)"/>
+            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(217,156,29)"/>
             <text x="95.0045%" y="1791.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::compile_method() (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(238,19,23)"/>
+            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(222,173,40)"/>
             <text x="95.0045%" y="1775.50">Compil..</text>
         </g>
         <g>
             <title>ciEnv::register_method(ciMethod*, int, CodeOffsets*, int, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int, bool, bool, RTMState) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(245,198,37)"/>
+            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(241,63,33)"/>
             <text x="95.0045%" y="1759.50">ciEnv:..</text>
         </g>
         <g>
             <title>nmethod::new_nmethod(methodHandle, int, int, CodeOffsets*, int, DebugInformationRecorder*, Dependencies*, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(235,72,33)"/>
+            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(225,85,51)"/>
             <text x="95.0045%" y="1743.50">nmetho..</text>
         </g>
         <g>
             <title>CodeCache::allocate(int, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(236,221,22)"/>
+            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(224,19,23)"/>
             <text x="95.0045%" y="1727.50">CodeCa..</text>
         </g>
         <g>
             <title>CodeHeap::allocate(unsigned long, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(211,143,19)"/>
+            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(227,66,23)"/>
             <text x="95.0045%" y="1711.50">CodeHe..</text>
         </g>
     </svg>

--- a/tests/data/flamegraph/colors/deterministic.svg
+++ b/tests/data/flamegraph/colors/deterministic.svg
@@ -37,1177 +37,1177 @@ var truncate_text_right = false;]]>
     <svg id="frames" x="10" width="1180">
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8575.1705890900.apply$mcV$sp (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(217,180,16)"/>
+            <rect x="0.0000%" y="741" width="2.1043%" height="15" fill="rgb(216,139,44)"/>
             <text x="0.2500%" y="751.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$124 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(214,105,7)"/>
+            <rect x="0.0000%" y="725" width="2.1043%" height="15" fill="rgb(208,118,47)"/>
             <text x="0.2500%" y="735.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(243,58,48)"/>
+            <rect x="0.0000%" y="709" width="2.1043%" height="15" fill="rgb(238,100,11)"/>
             <text x="0.2500%" y="719.50">c..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(218,159,15)"/>
+            <rect x="0.0000%" y="693" width="2.1043%" height="15" fill="rgb(245,146,32)"/>
             <text x="0.2500%" y="703.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(242,28,13)"/>
+            <rect x="0.0000%" y="677" width="2.1043%" height="15" fill="rgb(210,86,34)"/>
             <text x="0.2500%" y="687.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(231,14,51)"/>
+            <rect x="0.0000%" y="661" width="2.1043%" height="15" fill="rgb(228,136,22)"/>
             <text x="0.2500%" y="671.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(226,67,53)"/>
+            <rect x="0.0000%" y="645" width="2.1043%" height="15" fill="rgb(209,72,20)"/>
             <text x="0.2500%" y="655.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(245,213,12)"/>
+            <rect x="0.0000%" y="629" width="2.1043%" height="15" fill="rgb(208,140,43)"/>
             <text x="0.2500%" y="639.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(220,53,33)"/>
+            <rect x="0.0000%" y="613" width="2.1043%" height="15" fill="rgb(225,123,12)"/>
             <text x="0.2500%" y="623.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(234,35,37)"/>
+            <rect x="0.0000%" y="597" width="2.1043%" height="15" fill="rgb(228,200,34)"/>
             <text x="0.2500%" y="607.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(207,177,51)"/>
+            <rect x="0.0000%" y="581" width="2.1043%" height="15" fill="rgb(253,112,7)"/>
             <text x="0.2500%" y="591.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(243,109,49)"/>
+            <rect x="0.0000%" y="565" width="2.1043%" height="15" fill="rgb(252,191,27)"/>
             <text x="0.2500%" y="575.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(254,13,38)"/>
+            <rect x="0.0000%" y="549" width="2.1043%" height="15" fill="rgb(223,159,50)"/>
             <text x="0.2500%" y="559.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(221,169,0)"/>
+            <rect x="0.0000%" y="533" width="2.1043%" height="15" fill="rgb(224,99,1)"/>
             <text x="0.2500%" y="543.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(207,112,50)"/>
+            <rect x="0.0000%" y="517" width="2.1043%" height="15" fill="rgb(239,47,0)"/>
             <text x="0.2500%" y="527.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(253,153,52)"/>
+            <rect x="0.0000%" y="501" width="2.1043%" height="15" fill="rgb(205,87,27)"/>
             <text x="0.2500%" y="511.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(219,11,8)"/>
+            <rect x="0.0000%" y="485" width="2.1043%" height="15" fill="rgb(253,39,14)"/>
             <text x="0.2500%" y="495.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(253,172,21)"/>
+            <rect x="0.0000%" y="469" width="2.1043%" height="15" fill="rgb(251,122,49)"/>
             <text x="0.2500%" y="479.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(254,13,38)"/>
+            <rect x="0.0000%" y="453" width="2.1043%" height="15" fill="rgb(223,159,50)"/>
             <text x="0.2500%" y="463.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(221,169,0)"/>
+            <rect x="0.0000%" y="437" width="2.1043%" height="15" fill="rgb(224,99,1)"/>
             <text x="0.2500%" y="447.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(207,112,50)"/>
+            <rect x="0.0000%" y="421" width="2.1043%" height="15" fill="rgb(239,47,0)"/>
             <text x="0.2500%" y="431.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(253,153,52)"/>
+            <rect x="0.0000%" y="405" width="2.1043%" height="15" fill="rgb(205,87,27)"/>
             <text x="0.2500%" y="415.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(219,11,8)"/>
+            <rect x="0.0000%" y="389" width="2.1043%" height="15" fill="rgb(253,39,14)"/>
             <text x="0.2500%" y="399.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(253,172,21)"/>
+            <rect x="0.0000%" y="373" width="2.1043%" height="15" fill="rgb(251,122,49)"/>
             <text x="0.2500%" y="383.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(205,178,7)"/>
+            <rect x="0.0000%" y="357" width="2.1043%" height="15" fill="rgb(230,62,39)"/>
             <text x="0.2500%" y="367.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(234,163,16)"/>
+            <rect x="0.0000%" y="341" width="2.1043%" height="15" fill="rgb(244,215,5)"/>
             <text x="0.2500%" y="351.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(243,125,35)"/>
+            <rect x="0.0000%" y="325" width="2.1043%" height="15" fill="rgb(254,200,37)"/>
             <text x="0.2500%" y="335.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(213,108,49)"/>
+            <rect x="0.0000%" y="309" width="2.1043%" height="15" fill="rgb(251,21,16)"/>
             <text x="0.2500%" y="319.50">o..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(233,226,44)"/>
+            <rect x="0.0000%" y="293" width="2.1043%" height="15" fill="rgb(247,172,3)"/>
             <text x="0.2500%" y="303.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(207,65,52)"/>
+            <rect x="0.0000%" y="277" width="2.1043%" height="15" fill="rgb(217,86,50)"/>
             <text x="0.2500%" y="287.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(235,49,34)"/>
+            <rect x="0.0000%" y="261" width="2.1043%" height="15" fill="rgb(224,212,1)"/>
             <text x="0.2500%" y="271.50">o..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(252,140,16)"/>
+            <rect x="0.0000%" y="245" width="2.1043%" height="15" fill="rgb(207,95,52)"/>
             <text x="0.2500%" y="255.50">o..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$9984.1092558103.apply (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(218,30,4)"/>
+            <rect x="0.0000%" y="229" width="2.1043%" height="15" fill="rgb(216,198,29)"/>
             <text x="0.2500%" y="239.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128$adapted (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(216,63,17)"/>
+            <rect x="0.0000%" y="213" width="2.1043%" height="15" fill="rgb(251,209,53)"/>
             <text x="0.2500%" y="223.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$128 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(211,136,33)"/>
+            <rect x="0.0000%" y="197" width="2.1043%" height="15" fill="rgb(254,161,13)"/>
             <text x="0.2500%" y="207.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$5 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(235,203,34)"/>
+            <rect x="0.0000%" y="181" width="2.1043%" height="15" fill="rgb(226,200,1)"/>
             <text x="0.2500%" y="191.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase16AsBytes (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(245,119,8)"/>
+            <rect x="0.0000%" y="165" width="2.1043%" height="15" fill="rgb(246,86,33)"/>
             <text x="0.2500%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase16 (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(217,184,50)"/>
+            <rect x="0.0000%" y="149" width="2.1043%" height="15" fill="rgb(222,220,16)"/>
             <text x="0.2500%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(240,151,3)"/>
+            <rect x="0.0000%" y="133" width="2.1043%" height="15" fill="rgb(210,41,15)"/>
             <text x="0.2500%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(209,216,47)"/>
+            <rect x="0.0000%" y="117" width="2.1043%" height="15" fill="rgb(243,78,18)"/>
             <text x="0.2500%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(242,162,46)"/>
+            <rect x="0.0000%" y="101" width="2.1043%" height="15" fill="rgb(245,73,0)"/>
             <text x="0.2500%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(207,229,35)"/>
+            <rect x="0.0000%" y="85" width="2.1043%" height="15" fill="rgb(247,119,30)"/>
             <text x="0.2500%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(226,6,29)"/>
+            <rect x="0.0000%" y="69" width="2.1043%" height="15" fill="rgb(217,67,14)"/>
             <text x="0.2500%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(213,12,48)"/>
+            <rect x="0.0000%" y="53" width="2.1043%" height="15" fill="rgb(206,173,14)"/>
             <text x="0.2500%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (69 samples, 2.10%)</title>
-            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(206,146,5)"/>
+            <rect x="0.0000%" y="37" width="2.1043%" height="15" fill="rgb(211,144,16)"/>
             <text x="0.2500%" y="47.50">s..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64AsBytes (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(216,26,49)"/>
+            <rect x="2.1043%" y="165" width="1.5858%" height="15" fill="rgb(230,210,9)"/>
             <text x="2.3543%" y="175.50"></text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(225,32,26)"/>
+            <rect x="2.1043%" y="149" width="1.5858%" height="15" fill="rgb(205,119,1)"/>
             <text x="2.3543%" y="159.50"></text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(240,151,3)"/>
+            <rect x="2.1043%" y="133" width="1.5858%" height="15" fill="rgb(210,41,15)"/>
             <text x="2.3543%" y="143.50"></text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(209,216,47)"/>
+            <rect x="2.1043%" y="117" width="1.5858%" height="15" fill="rgb(243,78,18)"/>
             <text x="2.3543%" y="127.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(242,162,46)"/>
+            <rect x="2.1043%" y="101" width="1.5858%" height="15" fill="rgb(245,73,0)"/>
             <text x="2.3543%" y="111.50"></text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(207,229,35)"/>
+            <rect x="2.1043%" y="85" width="1.5858%" height="15" fill="rgb(247,119,30)"/>
             <text x="2.3543%" y="95.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(226,6,29)"/>
+            <rect x="2.1043%" y="69" width="1.5858%" height="15" fill="rgb(217,67,14)"/>
             <text x="2.3543%" y="79.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(213,12,48)"/>
+            <rect x="2.1043%" y="53" width="1.5858%" height="15" fill="rgb(206,173,14)"/>
             <text x="2.3543%" y="63.50"></text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (52 samples, 1.59%)</title>
-            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(206,146,5)"/>
+            <rect x="2.1043%" y="37" width="1.5858%" height="15" fill="rgb(211,144,16)"/>
             <text x="2.3543%" y="47.50"></text>
         </g>
         <g>
             <title>java.lang.Thread.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(238,208,10)"/>
+            <rect x="0.0000%" y="1893" width="5.6115%" height="15" fill="rgb(207,36,7)"/>
             <text x="0.2500%" y="1903.50">java.la..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor$Worker.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(208,4,23)"/>
+            <rect x="0.0000%" y="1877" width="5.6115%" height="15" fill="rgb(223,162,54)"/>
             <text x="0.2500%" y="1887.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.ThreadPoolExecutor.runWorker (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(250,132,8)"/>
+            <rect x="0.0000%" y="1861" width="5.6115%" height="15" fill="rgb(211,40,6)"/>
             <text x="0.2500%" y="1871.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(223,81,51)"/>
+            <rect x="0.0000%" y="1845" width="5.6115%" height="15" fill="rgb(214,180,2)"/>
             <text x="0.2500%" y="1855.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.Executors$RunnableAdapter.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(234,190,25)"/>
+            <rect x="0.0000%" y="1829" width="5.6115%" height="15" fill="rgb(205,2,33)"/>
             <text x="0.2500%" y="1839.50">java.ut..</text>
         </g>
         <g>
             <title>java.util.concurrent.FutureTask.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(223,81,51)"/>
+            <rect x="0.0000%" y="1813" width="5.6115%" height="15" fill="rgb(214,180,2)"/>
             <text x="0.2500%" y="1823.50">java.ut..</text>
         </g>
         <g>
             <title>sbt.CompletionService$$anon$2.call (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(208,32,53)"/>
+            <rect x="0.0000%" y="1797" width="5.6115%" height="15" fill="rgb(230,211,29)"/>
             <text x="0.2500%" y="1807.50">sbt.Com..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4$$Lambda$2176.1600330912.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(209,198,8)"/>
+            <rect x="0.0000%" y="1781" width="5.6115%" height="15" fill="rgb(239,107,2)"/>
             <text x="0.2500%" y="1791.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(251,94,54)"/>
+            <rect x="0.0000%" y="1765" width="5.6115%" height="15" fill="rgb(214,197,10)"/>
             <text x="0.2500%" y="1775.50">sbt.Con..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2169.2034046523.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(221,166,36)"/>
+            <rect x="0.0000%" y="1749" width="5.6115%" height="15" fill="rgb(221,169,52)"/>
             <text x="0.2500%" y="1759.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(226,121,6)"/>
+            <rect x="0.0000%" y="1733" width="5.6115%" height="15" fill="rgb(251,69,10)"/>
             <text x="0.2500%" y="1743.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(221,149,28)"/>
+            <rect x="0.0000%" y="1717" width="5.6115%" height="15" fill="rgb(250,139,44)"/>
             <text x="0.2500%" y="1727.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.internal.util.ErrorHandling$.wideConvert (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(209,183,35)"/>
+            <rect x="0.0000%" y="1701" width="5.6115%" height="15" fill="rgb(249,89,0)"/>
             <text x="0.2500%" y="1711.50">sbt.int..</text>
         </g>
         <g>
             <title>sbt.Execute$$Lambda$2178.2095669414.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(253,97,17)"/>
+            <rect x="0.0000%" y="1685" width="5.6115%" height="15" fill="rgb(211,179,5)"/>
             <text x="0.2500%" y="1695.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.Execute.$anonfun$submit$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(215,10,25)"/>
+            <rect x="0.0000%" y="1669" width="5.6115%" height="15" fill="rgb(252,215,32)"/>
             <text x="0.2500%" y="1679.50">sbt.Exe..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$4.work (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(251,146,20)"/>
+            <rect x="0.0000%" y="1653" width="5.6115%" height="15" fill="rgb(224,63,2)"/>
             <text x="0.2500%" y="1663.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3$$Lambda$2167.231900526.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(241,37,33)"/>
+            <rect x="0.0000%" y="1637" width="5.6115%" height="15" fill="rgb(251,71,18)"/>
             <text x="0.2500%" y="1647.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.std.Transform$$anon$3.$anonfun$apply$2 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(238,61,38)"/>
+            <rect x="0.0000%" y="1621" width="5.6115%" height="15" fill="rgb(237,7,4)"/>
             <text x="0.2500%" y="1631.50">sbt.std..</text>
         </g>
         <g>
             <title>sbt.Tests$$$Lambda$7842.1208470949.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(253,27,42)"/>
+            <rect x="0.0000%" y="1605" width="5.6115%" height="15" fill="rgb(238,140,25)"/>
             <text x="0.2500%" y="1615.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.Tests$.$anonfun$toTask$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(232,109,15)"/>
+            <rect x="0.0000%" y="1589" width="5.6115%" height="15" fill="rgb(208,156,12)"/>
             <text x="0.2500%" y="1599.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFunction.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(224,104,27)"/>
+            <rect x="0.0000%" y="1573" width="5.6115%" height="15" fill="rgb(216,28,9)"/>
             <text x="0.2500%" y="1583.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(249,158,37)"/>
+            <rect x="0.0000%" y="1557" width="5.6115%" height="15" fill="rgb(207,195,52)"/>
             <text x="0.2500%" y="1567.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(249,158,37)"/>
+            <rect x="0.0000%" y="1541" width="5.6115%" height="15" fill="rgb(207,195,52)"/>
             <text x="0.2500%" y="1551.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$.sbt$TestFramework$$withContextLoader (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(240,26,42)"/>
+            <rect x="0.0000%" y="1525" width="5.6115%" height="15" fill="rgb(244,127,10)"/>
             <text x="0.2500%" y="1535.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1$$Lambda$7850.1117892339.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(225,159,48)"/>
+            <rect x="0.0000%" y="1509" width="5.6115%" height="15" fill="rgb(253,29,31)"/>
             <text x="0.2500%" y="1519.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(247,193,12)"/>
+            <rect x="0.0000%" y="1493" width="5.6115%" height="15" fill="rgb(252,171,1)"/>
             <text x="0.2500%" y="1503.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(239,17,37)"/>
+            <rect x="0.0000%" y="1477" width="5.6115%" height="15" fill="rgb(239,195,25)"/>
             <text x="0.2500%" y="1487.50">sbt.Tes..</text>
         </g>
         <g>
             <title>sbt.TestRunner.runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(221,20,9)"/>
+            <rect x="0.0000%" y="1461" width="5.6115%" height="15" fill="rgb(219,54,9)"/>
             <text x="0.2500%" y="1471.50">sbt.Tes..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework$ScalaTestTask.execute (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(228,128,10)"/>
+            <rect x="0.0000%" y="1445" width="5.6115%" height="15" fill="rgb(227,63,22)"/>
             <text x="0.2500%" y="1455.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(230,16,5)"/>
+            <rect x="0.0000%" y="1429" width="5.6115%" height="15" fill="rgb(245,169,11)"/>
             <text x="0.2500%" y="1439.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(213,25,28)"/>
+            <rect x="0.0000%" y="1413" width="5.6115%" height="15" fill="rgb(213,17,29)"/>
             <text x="0.2500%" y="1423.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(229,127,36)"/>
+            <rect x="0.0000%" y="1397" width="5.6115%" height="15" fill="rgb(218,110,25)"/>
             <text x="0.2500%" y="1407.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(205,111,22)"/>
+            <rect x="0.0000%" y="1381" width="5.6115%" height="15" fill="rgb(226,127,32)"/>
             <text x="0.2500%" y="1391.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(208,13,8)"/>
+            <rect x="0.0000%" y="1365" width="5.6115%" height="15" fill="rgb(253,219,24)"/>
             <text x="0.2500%" y="1375.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7943.1056778999.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(211,95,3)"/>
+            <rect x="0.0000%" y="1349" width="5.6115%" height="15" fill="rgb(241,126,4)"/>
             <text x="0.2500%" y="1359.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(207,69,22)"/>
+            <rect x="0.0000%" y="1333" width="5.6115%" height="15" fill="rgb(222,73,20)"/>
             <text x="0.2500%" y="1343.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(254,26,17)"/>
+            <rect x="0.0000%" y="1317" width="5.6115%" height="15" fill="rgb(251,134,16)"/>
             <text x="0.2500%" y="1327.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(215,135,51)"/>
+            <rect x="0.0000%" y="1301" width="5.6115%" height="15" fill="rgb(211,214,31)"/>
             <text x="0.2500%" y="1311.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Suite.run (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(242,139,18)"/>
+            <rect x="0.0000%" y="1285" width="5.6115%" height="15" fill="rgb(230,118,27)"/>
             <text x="0.2500%" y="1295.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(238,150,40)"/>
+            <rect x="0.0000%" y="1269" width="5.6115%" height="15" fill="rgb(225,221,2)"/>
             <text x="0.2500%" y="1279.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(232,216,2)"/>
+            <rect x="0.0000%" y="1253" width="5.6115%" height="15" fill="rgb(231,228,18)"/>
             <text x="0.2500%" y="1263.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTests (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(237,18,51)"/>
+            <rect x="0.0000%" y="1237" width="5.6115%" height="15" fill="rgb(211,120,10)"/>
             <text x="0.2500%" y="1247.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(207,138,26)"/>
+            <rect x="0.0000%" y="1221" width="5.6115%" height="15" fill="rgb(226,36,30)"/>
             <text x="0.2500%" y="1231.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(233,85,12)"/>
+            <rect x="0.0000%" y="1205" width="5.6115%" height="15" fill="rgb(217,103,44)"/>
             <text x="0.2500%" y="1215.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(213,228,39)"/>
+            <rect x="0.0000%" y="1189" width="5.6115%" height="15" fill="rgb(225,108,7)"/>
             <text x="0.2500%" y="1199.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(223,170,26)"/>
+            <rect x="0.0000%" y="1173" width="5.6115%" height="15" fill="rgb(252,56,2)"/>
             <text x="0.2500%" y="1183.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(251,61,26)"/>
+            <rect x="0.0000%" y="1157" width="5.6115%" height="15" fill="rgb(246,32,19)"/>
             <text x="0.2500%" y="1167.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(235,103,25)"/>
+            <rect x="0.0000%" y="1141" width="5.6115%" height="15" fill="rgb(240,171,25)"/>
             <text x="0.2500%" y="1151.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestsInBranch (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(233,85,12)"/>
+            <rect x="0.0000%" y="1125" width="5.6115%" height="15" fill="rgb(217,103,44)"/>
             <text x="0.2500%" y="1135.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.traverseSubNodes$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(213,228,39)"/>
+            <rect x="0.0000%" y="1109" width="5.6115%" height="15" fill="rgb(225,108,7)"/>
             <text x="0.2500%" y="1119.50">org.sca..</text>
         </g>
         <g>
             <title>scala.collection.immutable.List.foreach (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(223,170,26)"/>
+            <rect x="0.0000%" y="1093" width="5.6115%" height="15" fill="rgb(252,56,2)"/>
             <text x="0.2500%" y="1103.50">scala.c..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine$$Lambda$7952.1547585176.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(251,61,26)"/>
+            <rect x="0.0000%" y="1077" width="5.6115%" height="15" fill="rgb(246,32,19)"/>
             <text x="0.2500%" y="1087.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(235,103,25)"/>
+            <rect x="0.0000%" y="1061" width="5.6115%" height="15" fill="rgb(240,171,25)"/>
             <text x="0.2500%" y="1071.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7951.1136212450.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(236,212,28)"/>
+            <rect x="0.0000%" y="1045" width="5.6115%" height="15" fill="rgb(231,208,46)"/>
             <text x="0.2500%" y="1055.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(215,133,34)"/>
+            <rect x="0.0000%" y="1029" width="5.6115%" height="15" fill="rgb(239,165,33)"/>
             <text x="0.2500%" y="1039.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(205,172,5)"/>
+            <rect x="0.0000%" y="1013" width="5.6115%" height="15" fill="rgb(254,219,1)"/>
             <text x="0.2500%" y="1023.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(254,100,28)"/>
+            <rect x="0.0000%" y="997" width="5.6115%" height="15" fill="rgb(222,96,38)"/>
             <text x="0.2500%" y="1007.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.runTest (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(228,79,26)"/>
+            <rect x="0.0000%" y="981" width="5.6115%" height="15" fill="rgb(232,170,15)"/>
             <text x="0.2500%" y="991.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.SuperEngine.runTestImpl (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(207,197,29)"/>
+            <rect x="0.0000%" y="965" width="5.6115%" height="15" fill="rgb(244,171,52)"/>
             <text x="0.2500%" y="975.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$Lambda$7967.812636372.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(236,147,30)"/>
+            <rect x="0.0000%" y="949" width="5.6115%" height="15" fill="rgb(222,202,30)"/>
             <text x="0.2500%" y="959.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(237,154,52)"/>
+            <rect x="0.0000%" y="933" width="5.6115%" height="15" fill="rgb(248,103,47)"/>
             <text x="0.2500%" y="943.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1 (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(237,159,42)"/>
+            <rect x="0.0000%" y="917" width="5.6115%" height="15" fill="rgb(226,212,18)"/>
             <text x="0.2500%" y="927.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpec.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(242,132,0)"/>
+            <rect x="0.0000%" y="901" width="5.6115%" height="15" fill="rgb(235,209,15)"/>
             <text x="0.2500%" y="911.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(221,7,39)"/>
+            <rect x="0.0000%" y="885" width="5.6115%" height="15" fill="rgb(243,17,14)"/>
             <text x="0.2500%" y="895.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.TestSuite.withFixture (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(216,109,36)"/>
+            <rect x="0.0000%" y="869" width="5.6115%" height="15" fill="rgb(210,44,24)"/>
             <text x="0.2500%" y="879.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(241,223,27)"/>
+            <rect x="0.0000%" y="853" width="5.6115%" height="15" fill="rgb(252,74,14)"/>
             <text x="0.2500%" y="863.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(236,121,41)"/>
+            <rect x="0.0000%" y="837" width="5.6115%" height="15" fill="rgb(243,186,28)"/>
             <text x="0.2500%" y="847.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.Transformer.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(236,121,41)"/>
+            <rect x="0.0000%" y="821" width="5.6115%" height="15" fill="rgb(243,186,28)"/>
             <text x="0.2500%" y="831.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf$.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(242,38,9)"/>
+            <rect x="0.0000%" y="805" width="5.6115%" height="15" fill="rgb(247,12,7)"/>
             <text x="0.2500%" y="815.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf$ (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(252,119,36)"/>
+            <rect x="0.0000%" y="789" width="5.6115%" height="15" fill="rgb(243,57,1)"/>
             <text x="0.2500%" y="799.50">org.sca..</text>
         </g>
         <g>
             <title>org.scalatest.OutcomeOf.outcomeOf (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(209,116,12)"/>
+            <rect x="0.0000%" y="773" width="5.6115%" height="15" fill="rgb(254,73,19)"/>
             <text x="0.2500%" y="783.50">org.sca..</text>
         </g>
         <g>
             <title>scala.runtime.java8.JFunction0$mcV$sp.apply (184 samples, 5.61%)</title>
-            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(211,0,16)"/>
+            <rect x="0.0000%" y="757" width="5.6115%" height="15" fill="rgb(237,207,29)"/>
             <text x="0.2500%" y="767.50">scala.r..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$8582.1627656208.apply$mcV$sp (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(238,119,10)"/>
+            <rect x="2.1043%" y="741" width="3.5072%" height="15" fill="rgb(220,142,41)"/>
             <text x="2.3543%" y="751.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$136 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(207,109,34)"/>
+            <rect x="2.1043%" y="725" width="3.5072%" height="15" fill="rgb(233,143,28)"/>
             <text x="2.3543%" y="735.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(243,58,48)"/>
+            <rect x="2.1043%" y="709" width="3.5072%" height="15" fill="rgb(238,100,11)"/>
             <text x="2.3543%" y="719.50">com..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll$ (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(218,159,15)"/>
+            <rect x="2.1043%" y="693" width="3.5072%" height="15" fill="rgb(245,146,32)"/>
             <text x="2.3543%" y="703.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.forAll (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(242,28,13)"/>
+            <rect x="2.1043%" y="677" width="3.5072%" height="15" fill="rgb(210,86,34)"/>
             <text x="2.3543%" y="687.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.UnitCheckerAsserting$CheckerAssertingImpl.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(231,14,51)"/>
+            <rect x="2.1043%" y="661" width="3.5072%" height="15" fill="rgb(228,136,22)"/>
             <text x="2.3543%" y="671.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.check (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(226,67,53)"/>
+            <rect x="2.1043%" y="645" width="3.5072%" height="15" fill="rgb(209,72,20)"/>
             <text x="2.3543%" y="655.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Platform$.runWorkers (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(245,213,12)"/>
+            <rect x="2.1043%" y="629" width="3.5072%" height="15" fill="rgb(208,140,43)"/>
             <text x="2.3543%" y="639.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$$$Lambda$8420.1048877523.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(220,53,33)"/>
+            <rect x="2.1043%" y="613" width="3.5072%" height="15" fill="rgb(225,123,12)"/>
             <text x="2.3543%" y="623.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(234,35,37)"/>
+            <rect x="2.1043%" y="597" width="3.5072%" height="15" fill="rgb(228,200,34)"/>
             <text x="2.3543%" y="607.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.$anonfun$check$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(207,177,51)"/>
+            <rect x="2.1043%" y="581" width="3.5072%" height="15" fill="rgb(253,112,7)"/>
             <text x="2.3543%" y="591.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Test$.workerFun$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(243,109,49)"/>
+            <rect x="2.1043%" y="565" width="3.5072%" height="15" fill="rgb(252,191,27)"/>
             <text x="2.3543%" y="575.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(254,13,38)"/>
+            <rect x="2.1043%" y="549" width="3.5072%" height="15" fill="rgb(223,159,50)"/>
             <text x="2.3543%" y="559.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(221,169,0)"/>
+            <rect x="2.1043%" y="533" width="3.5072%" height="15" fill="rgb(224,99,1)"/>
             <text x="2.3543%" y="543.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(207,112,50)"/>
+            <rect x="2.1043%" y="517" width="3.5072%" height="15" fill="rgb(239,47,0)"/>
             <text x="2.3543%" y="527.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(253,153,52)"/>
+            <rect x="2.1043%" y="501" width="3.5072%" height="15" fill="rgb(205,87,27)"/>
             <text x="2.3543%" y="511.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(219,11,8)"/>
+            <rect x="2.1043%" y="485" width="3.5072%" height="15" fill="rgb(253,39,14)"/>
             <text x="2.3543%" y="495.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(253,172,21)"/>
+            <rect x="2.1043%" y="469" width="3.5072%" height="15" fill="rgb(251,122,49)"/>
             <text x="2.3543%" y="479.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.PropFromFun.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(254,13,38)"/>
+            <rect x="2.1043%" y="453" width="3.5072%" height="15" fill="rgb(223,159,50)"/>
             <text x="2.3543%" y="463.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8392.1163160283.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(221,169,0)"/>
+            <rect x="2.1043%" y="437" width="3.5072%" height="15" fill="rgb(224,99,1)"/>
             <text x="2.3543%" y="447.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$apply$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(207,112,50)"/>
+            <rect x="2.1043%" y="421" width="3.5072%" height="15" fill="rgb(239,47,0)"/>
             <text x="2.3543%" y="431.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8391.1460249324.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(253,153,52)"/>
+            <rect x="2.1043%" y="405" width="3.5072%" height="15" fill="rgb(205,87,27)"/>
             <text x="2.3543%" y="415.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(219,11,8)"/>
+            <rect x="2.1043%" y="389" width="3.5072%" height="15" fill="rgb(253,39,14)"/>
             <text x="2.3543%" y="399.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.result$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(253,172,21)"/>
+            <rect x="2.1043%" y="373" width="3.5072%" height="15" fill="rgb(251,122,49)"/>
             <text x="2.3543%" y="383.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.secure (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(205,178,7)"/>
+            <rect x="2.1043%" y="357" width="3.5072%" height="15" fill="rgb(230,62,39)"/>
             <text x="2.3543%" y="367.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$8437.980556189.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(234,163,16)"/>
+            <rect x="2.1043%" y="341" width="3.5072%" height="15" fill="rgb(244,215,5)"/>
             <text x="2.3543%" y="351.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAllShrink$2 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(243,125,35)"/>
+            <rect x="2.1043%" y="325" width="3.5072%" height="15" fill="rgb(254,200,37)"/>
             <text x="2.3543%" y="335.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$$$Lambda$9326.169489320.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(213,108,49)"/>
+            <rect x="2.1043%" y="309" width="3.5072%" height="15" fill="rgb(251,21,16)"/>
             <text x="2.3543%" y="319.50">org..</text>
         </g>
         <g>
             <title>org.scalacheck.Prop$.$anonfun$forAll$3 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(233,226,44)"/>
+            <rect x="2.1043%" y="293" width="3.5072%" height="15" fill="rgb(247,172,3)"/>
             <text x="2.3543%" y="303.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks$$Lambda$9322.742157558.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(207,65,52)"/>
+            <rect x="2.1043%" y="277" width="3.5072%" height="15" fill="rgb(217,86,50)"/>
             <text x="2.3543%" y="287.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.$anonfun$forAll$21 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(235,49,34)"/>
+            <rect x="2.1043%" y="261" width="3.5072%" height="15" fill="rgb(224,212,1)"/>
             <text x="2.3543%" y="271.50">org..</text>
         </g>
         <g>
             <title>org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks.liftedTree13$1 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(252,140,16)"/>
+            <rect x="2.1043%" y="245" width="3.5072%" height="15" fill="rgb(207,95,52)"/>
             <text x="2.3543%" y="255.50">org..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec$$Lambda$10462.775835262.apply (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(253,166,1)"/>
+            <rect x="2.1043%" y="229" width="3.5072%" height="15" fill="rgb(213,122,15)"/>
             <text x="2.3543%" y="239.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137$adapted (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(251,48,4)"/>
+            <rect x="2.1043%" y="213" width="3.5072%" height="15" fill="rgb(253,123,0)"/>
             <text x="2.3543%" y="223.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.$anonfun$new$137 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(247,155,35)"/>
+            <rect x="2.1043%" y="197" width="3.5072%" height="15" fill="rgb(206,211,26)"/>
             <text x="2.3543%" y="207.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderSpec.check$6 (115 samples, 3.51%)</title>
-            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(206,90,0)"/>
+            <rect x="2.1043%" y="181" width="3.5072%" height="15" fill="rgb(214,54,20)"/>
             <text x="2.3543%" y="191.50">com..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.readBase64UrlAsBytes (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(226,59,6)"/>
+            <rect x="3.6901%" y="165" width="1.9213%" height="15" fill="rgb(211,224,6)"/>
             <text x="3.9401%" y="175.50">c..</text>
         </g>
         <g>
             <title>com.github.plokhotnyuk.jsoniter_scala.core.JsonReader.parseBase64 (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(225,32,26)"/>
+            <rect x="3.6901%" y="149" width="1.9213%" height="15" fill="rgb(205,119,1)"/>
             <text x="3.9401%" y="159.50">c..</text>
         </g>
         <g>
             <title>scoverage.Invoker$.invoked (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(240,151,3)"/>
+            <rect x="3.6901%" y="133" width="1.9213%" height="15" fill="rgb(210,41,15)"/>
             <text x="3.9401%" y="143.50">s..</text>
         </g>
         <g>
             <title>scala.collection.AbstractMap.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(209,216,47)"/>
+            <rect x="3.6901%" y="117" width="1.9213%" height="15" fill="rgb(243,78,18)"/>
             <text x="3.9401%" y="127.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains$ (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(242,162,46)"/>
+            <rect x="3.6901%" y="101" width="1.9213%" height="15" fill="rgb(245,73,0)"/>
             <text x="3.9401%" y="111.50">s..</text>
         </g>
         <g>
             <title>scala.collection.MapOps.contains (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(207,229,35)"/>
+            <rect x="3.6901%" y="85" width="1.9213%" height="15" fill="rgb(247,119,30)"/>
             <text x="3.9401%" y="95.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.get (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(226,6,29)"/>
+            <rect x="3.6901%" y="69" width="1.9213%" height="15" fill="rgb(217,67,14)"/>
             <text x="3.9401%" y="79.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.TrieMap.lookuphc (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(213,12,48)"/>
+            <rect x="3.6901%" y="53" width="1.9213%" height="15" fill="rgb(206,173,14)"/>
             <text x="3.9401%" y="63.50">s..</text>
         </g>
         <g>
             <title>scala.collection.concurrent.INode.rec_lookup (63 samples, 1.92%)</title>
-            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(206,146,5)"/>
+            <rect x="3.6901%" y="37" width="1.9213%" height="15" fill="rgb(211,144,16)"/>
             <text x="3.9401%" y="47.50">s..</text>
         </g>
         <g>
             <title>DrainStacksCompactionTask::do_it(GCTaskManager*, unsigned int) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(235,63,36)"/>
+            <rect x="5.6115%" y="1845" width="3.2022%" height="15" fill="rgb(243,108,47)"/>
             <text x="5.8615%" y="1855.50">Dra..</text>
         </g>
         <g>
             <title>ParCompactionManager::drain_region_stacks() (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(233,203,47)"/>
+            <rect x="5.6115%" y="1829" width="3.2022%" height="15" fill="rgb(245,222,35)"/>
             <text x="5.8615%" y="1839.50">Par..</text>
         </g>
         <g>
             <title>PSParallelCompact::fill_region(ParCompactionManager*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(249,0,7)"/>
+            <rect x="5.6115%" y="1813" width="3.2022%" height="15" fill="rgb(226,40,48)"/>
             <text x="5.8615%" y="1823.50">PSP..</text>
         </g>
         <g>
             <title>ParMarkBitMap::iterate(ParMarkBitMapClosure*, unsigned long, unsigned long) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(209,5,12)"/>
+            <rect x="5.6115%" y="1797" width="3.2022%" height="15" fill="rgb(241,23,39)"/>
             <text x="5.8615%" y="1807.50">Par..</text>
         </g>
         <g>
             <title>MoveAndUpdateClosure::do_addr(HeapWord*, unsigned long) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(244,227,14)"/>
+            <rect x="5.6115%" y="1781" width="3.2022%" height="15" fill="rgb(238,19,34)"/>
             <text x="5.8615%" y="1791.50">Mov..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_update_pointers(ParCompactionManager*, oopDesc*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(215,142,7)"/>
+            <rect x="5.6115%" y="1765" width="3.2022%" height="15" fill="rgb(240,201,37)"/>
             <text x="5.8615%" y="1775.50">Ins..</text>
         </g>
         <g>
             <title>ParallelCompactData::calc_new_pointer(HeapWord*) (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(239,40,11)"/>
+            <rect x="5.6115%" y="1749" width="3.2022%" height="15" fill="rgb(208,135,43)"/>
             <text x="5.8615%" y="1759.50">Par..</text>
         </g>
         <g>
             <title>ParMarkBitMap::live_words_in_range(HeapWord*, oopDesc*) const (105 samples, 3.20%)</title>
-            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(220,137,24)"/>
+            <rect x="5.6115%" y="1733" width="3.2022%" height="15" fill="rgb(237,94,7)"/>
             <text x="5.8615%" y="1743.50">Par..</text>
         </g>
         <g>
             <title>OldToYoungRootsTask::do_it(GCTaskManager*, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(250,216,25)"/>
+            <rect x="8.8137%" y="1845" width="14.9436%" height="15" fill="rgb(210,203,30)"/>
             <text x="9.0637%" y="1855.50">OldToYoungRootsTask::do..</text>
         </g>
         <g>
             <title>CardTableExtension::scavenge_contents_parallel(ObjectStartArray*, MutableSpace*, HeapWord*, PSPromotionManager*, unsigned int, unsigned int) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(247,188,46)"/>
+            <rect x="8.8137%" y="1829" width="14.9436%" height="15" fill="rgb(242,67,6)"/>
             <text x="9.0637%" y="1839.50">CardTableExtension::sca..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (490 samples, 14.94%)</title>
-            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(249,81,13)"/>
+            <rect x="8.8137%" y="1813" width="14.9436%" height="15" fill="rgb(217,115,45)"/>
             <text x="9.0637%" y="1823.50">PSPromotionManager::dra..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (358 samples, 10.92%)</title>
-            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(210,190,36)"/>
+            <rect x="12.8393%" y="1797" width="10.9180%" height="15" fill="rgb(213,207,15)"/>
             <text x="13.0893%" y="1807.50">oopDesc* PSPromo..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (161 samples, 4.91%)</title>
-            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(216,227,32)"/>
+            <rect x="18.8472%" y="1781" width="4.9100%" height="15" fill="rgb(227,147,36)"/>
             <text x="19.0972%" y="1791.50">Instan..</text>
         </g>
         <g>
             <title>GCTaskThread::run() (793 samples, 24.18%)</title>
-            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(223,24,24)"/>
+            <rect x="5.6115%" y="1861" width="24.1842%" height="15" fill="rgb(231,28,50)"/>
             <text x="5.8615%" y="1871.50">GCTaskThread::run()</text>
         </g>
         <g>
             <title>StealTask::do_it(GCTaskManager*, unsigned int) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(245,93,3)"/>
+            <rect x="23.7572%" y="1845" width="6.0384%" height="15" fill="rgb(206,1,42)"/>
             <text x="24.0072%" y="1855.50">StealTas..</text>
         </g>
         <g>
             <title>PSPromotionManager::drain_stacks_depth(bool) (198 samples, 6.04%)</title>
-            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(249,81,13)"/>
+            <rect x="23.7572%" y="1829" width="6.0384%" height="15" fill="rgb(217,115,45)"/>
             <text x="24.0072%" y="1839.50">PSPromot..</text>
         </g>
         <g>
             <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt;(oopDesc*) (138 samples, 4.21%)</title>
-            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(210,190,36)"/>
+            <rect x="25.5871%" y="1813" width="4.2086%" height="15" fill="rgb(213,207,15)"/>
             <text x="25.8371%" y="1823.50">oopDe..</text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents(PSPromotionManager*, oopDesc*) (80 samples, 2.44%)</title>
-            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(216,227,32)"/>
+            <rect x="27.3559%" y="1797" width="2.4398%" height="15" fill="rgb(227,147,36)"/>
             <text x="27.6059%" y="1807.50">In..</text>
         </g>
         <g>
             <title>Matcher::match() (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(252,31,9)"/>
+            <rect x="29.7957%" y="1749" width="3.3242%" height="15" fill="rgb(217,202,13)"/>
             <text x="30.0457%" y="1759.50">Mat..</text>
         </g>
         <g>
             <title>Matcher::xform(Node*, int) (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(232,214,39)"/>
+            <rect x="29.7957%" y="1733" width="3.3242%" height="15" fill="rgb(240,117,3)"/>
             <text x="30.0457%" y="1743.50">Mat..</text>
         </g>
         <g>
             <title>Arena::contains(void const*) const (109 samples, 3.32%)</title>
-            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(228,221,38)"/>
+            <rect x="29.7957%" y="1717" width="3.3242%" height="15" fill="rgb(217,65,52)"/>
             <text x="30.0457%" y="1727.50">Are..</text>
         </g>
         <g>
             <title>PhaseAggressiveCoalesce::insert_copies(Matcher&amp;) (86 samples, 2.62%)</title>
-            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(238,108,41)"/>
+            <rect x="33.1199%" y="1733" width="2.6228%" height="15" fill="rgb(226,178,38)"/>
             <text x="33.3699%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::Split(unsigned int, ResourceArea*) (213 samples, 6.50%)</title>
-            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(248,202,16)"/>
+            <rect x="35.7426%" y="1733" width="6.4959%" height="15" fill="rgb(215,15,31)"/>
             <text x="35.9926%" y="1743.50">PhaseChai..</text>
         </g>
         <g>
             <title>PhaseChaitin::build_ifg_physical(ResourceArea*) (305 samples, 9.30%)</title>
-            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(224,204,35)"/>
+            <rect x="42.2385%" y="1733" width="9.3016%" height="15" fill="rgb(244,55,30)"/>
             <text x="42.4885%" y="1743.50">PhaseChaitin:..</text>
         </g>
         <g>
             <title>PhaseChaitin::interfere_with_live(unsigned int, IndexSet*) (183 samples, 5.58%)</title>
-            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(231,171,31)"/>
+            <rect x="45.9591%" y="1717" width="5.5810%" height="15" fill="rgb(216,166,34)"/>
             <text x="46.2091%" y="1727.50">PhaseCh..</text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (66 samples, 2.01%)</title>
-            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(221,170,35)"/>
+            <rect x="49.5273%" y="1701" width="2.0128%" height="15" fill="rgb(249,209,24)"/>
             <text x="49.7773%" y="1711.50">I..</text>
         </g>
         <g>
             <title>PhaseChaitin::gather_lrg_masks(bool) (95 samples, 2.90%)</title>
-            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(211,73,26)"/>
+            <rect x="51.5401%" y="1733" width="2.8972%" height="15" fill="rgb(246,12,7)"/>
             <text x="51.7901%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseChaitin::post_allocate_copy_removal() (139 samples, 4.24%)</title>
-            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(234,98,13)"/>
+            <rect x="54.4373%" y="1733" width="4.2391%" height="15" fill="rgb(217,130,4)"/>
             <text x="54.6873%" y="1743.50">Phase..</text>
         </g>
         <g>
             <title>PhaseChaitin::elide_copy(Node*, int, Block*, Node_List&amp;, Node_List&amp;, bool) (76 samples, 2.32%)</title>
-            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(252,216,19)"/>
+            <rect x="56.3586%" y="1717" width="2.3178%" height="15" fill="rgb(214,211,49)"/>
             <text x="56.6086%" y="1727.50">P..</text>
         </g>
         <g>
             <title>PhaseCoalesce::coalesce_driver() (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(226,120,16)"/>
+            <rect x="58.6764%" y="1733" width="2.8057%" height="15" fill="rgb(241,86,53)"/>
             <text x="58.9264%" y="1743.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::coalesce(Block*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(229,38,26)"/>
+            <rect x="58.6764%" y="1717" width="2.8057%" height="15" fill="rgb(207,4,10)"/>
             <text x="58.9264%" y="1727.50">Ph..</text>
         </g>
         <g>
             <title>PhaseConservativeCoalesce::update_ifg(unsigned int, unsigned int, IndexSet*, IndexSet*) (92 samples, 2.81%)</title>
-            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(243,40,43)"/>
+            <rect x="58.6764%" y="1701" width="2.8057%" height="15" fill="rgb(213,97,14)"/>
             <text x="58.9264%" y="1711.50">Ph..</text>
         </g>
         <g>
             <title>PhaseIFG::Compute_Effective_Degree() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(227,72,12)"/>
+            <rect x="61.4822%" y="1733" width="1.6163%" height="15" fill="rgb(214,75,10)"/>
             <text x="61.7322%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (53 samples, 1.62%)</title>
-            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(221,170,35)"/>
+            <rect x="61.4822%" y="1717" width="1.6163%" height="15" fill="rgb(249,209,24)"/>
             <text x="61.7322%" y="1727.50"></text>
         </g>
         <g>
             <title>PhaseIFG::SquareUp() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(231,0,44)"/>
+            <rect x="63.0985%" y="1733" width="1.4639%" height="15" fill="rgb(239,205,33)"/>
             <text x="63.3485%" y="1743.50"></text>
         </g>
         <g>
             <title>IndexSetIterator::advance_and_next() (48 samples, 1.46%)</title>
-            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(221,170,35)"/>
+            <rect x="63.0985%" y="1717" width="1.4639%" height="15" fill="rgb(249,209,24)"/>
             <text x="63.3485%" y="1727.50"></text>
         </g>
         <g>
             <title>Compile::Code_Gen() (1,250 samples, 38.12%)</title>
-            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(231,42,32)"/>
+            <rect x="29.7957%" y="1765" width="38.1214%" height="15" fill="rgb(228,110,35)"/>
             <text x="30.0457%" y="1775.50">Compile::Code_Gen()</text>
         </g>
         <g>
             <title>PhaseChaitin::Register_Allocate() (1,141 samples, 34.80%)</title>
-            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(228,102,7)"/>
+            <rect x="33.1199%" y="1749" width="34.7972%" height="15" fill="rgb(247,199,21)"/>
             <text x="33.3699%" y="1759.50">PhaseChaitin::Register_Allocate()</text>
         </g>
         <g>
             <title>PhaseLive::compute(unsigned int) (110 samples, 3.35%)</title>
-            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(205,142,50)"/>
+            <rect x="64.5624%" y="1733" width="3.3547%" height="15" fill="rgb(240,153,27)"/>
             <text x="64.8124%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::Dominators() (67 samples, 2.04%)</title>
-            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(252,13,18)"/>
+            <rect x="67.9170%" y="1733" width="2.0433%" height="15" fill="rgb(243,52,49)"/>
             <text x="68.1670%" y="1743.50">P..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_early(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (108 samples, 3.29%)</title>
-            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(209,71,12)"/>
+            <rect x="69.9604%" y="1733" width="3.2937%" height="15" fill="rgb(225,11,36)"/>
             <text x="70.2104%" y="1743.50">Pha..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late(VectorSet&amp;, Node_List&amp;, Node_Stack&amp;) (655 samples, 19.98%)</title>
-            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(247,33,39)"/>
+            <rect x="73.2540%" y="1733" width="19.9756%" height="15" fill="rgb(211,17,31)"/>
             <text x="73.5040%" y="1743.50">PhaseIdealLoop::build_loop_late..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_late_post(Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(231,163,35)"/>
+            <rect x="76.2733%" y="1717" width="16.9564%" height="15" fill="rgb(254,211,2)"/>
             <text x="76.5233%" y="1727.50">PhaseIdealLoop::build_loop..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::get_late_ctrl(Node*, Node*) (556 samples, 16.96%)</title>
-            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(228,63,35)"/>
+            <rect x="76.2733%" y="1701" width="16.9564%" height="15" fill="rgb(254,120,21)"/>
             <text x="76.5233%" y="1711.50">PhaseIdealLoop::get_late_c..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::is_dominator(Node*, Node*) [clone .part.114] (496 samples, 15.13%)</title>
-            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(214,176,27)"/>
+            <rect x="78.1031%" y="1685" width="15.1266%" height="15" fill="rgb(252,13,5)"/>
             <text x="78.3531%" y="1695.50">PhaseIdealLoop::is_domi..</text>
         </g>
         <g>
             <title>C2Compiler::compile_method(ciEnv*, ciMethod*, int) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(227,78,15)"/>
+            <rect x="29.7957%" y="1797" width="64.9588%" height="15" fill="rgb(206,153,36)"/>
             <text x="30.0457%" y="1807.50">C2Compiler::compile_method(ciEnv*, ciMethod*, int)</text>
         </g>
         <g>
             <title>Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool) (2,130 samples, 64.96%)</title>
-            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(248,99,0)"/>
+            <rect x="29.7957%" y="1781" width="64.9588%" height="15" fill="rgb(245,191,32)"/>
             <text x="30.0457%" y="1791.50">Compile::Compile(ciEnv*, C2Compiler*, ciMethod*, int, bool, bool, bool)</text>
         </g>
         <g>
             <title>Compile::Optimize() (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(251,158,5)"/>
+            <rect x="67.9170%" y="1765" width="26.8375%" height="15" fill="rgb(245,198,26)"/>
             <text x="68.1670%" y="1775.50">Compile::Optimize()</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_and_optimize(bool, bool) (880 samples, 26.84%)</title>
-            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(243,158,30)"/>
+            <rect x="67.9170%" y="1749" width="26.8375%" height="15" fill="rgb(208,203,49)"/>
             <text x="68.1670%" y="1759.50">PhaseIdealLoop::build_and_optimize(bool, bo..</text>
         </g>
         <g>
             <title>PhaseIdealLoop::build_loop_tree() (50 samples, 1.52%)</title>
-            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(243,110,36)"/>
+            <rect x="93.2296%" y="1733" width="1.5249%" height="15" fill="rgb(225,146,27)"/>
             <text x="93.4796%" y="1743.50"></text>
         </g>
         <g>
             <title>all (3,279 samples, 100%)</title>
-            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(205,60,50)"/>
+            <rect x="0.0000%" y="1909" width="100.0000%" height="15" fill="rgb(243,189,40)"/>
             <text x="0.2500%" y="1919.50"></text>
         </g>
         <g>
             <title>start_thread (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(222,211,8)"/>
+            <rect x="5.6115%" y="1893" width="94.3885%" height="15" fill="rgb(238,100,18)"/>
             <text x="5.8615%" y="1903.50">start_thread</text>
         </g>
         <g>
             <title>java_start(Thread*) (3,095 samples, 94.39%)</title>
-            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(234,209,47)"/>
+            <rect x="5.6115%" y="1877" width="94.3885%" height="15" fill="rgb(221,121,10)"/>
             <text x="5.8615%" y="1887.50">java_start(Thread*)</text>
         </g>
         <g>
             <title>JavaThread::run() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(217,5,39)"/>
+            <rect x="29.7957%" y="1861" width="70.2043%" height="15" fill="rgb(249,16,53)"/>
             <text x="30.0457%" y="1871.50">JavaThread::run()</text>
         </g>
         <g>
             <title>JavaThread::thread_main_inner() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(248,132,33)"/>
+            <rect x="29.7957%" y="1845" width="70.2043%" height="15" fill="rgb(236,159,26)"/>
             <text x="30.0457%" y="1855.50">JavaThread::thread_main_inner()</text>
         </g>
         <g>
             <title>CompileBroker::compiler_thread_loop() (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(208,137,39)"/>
+            <rect x="29.7957%" y="1829" width="70.2043%" height="15" fill="rgb(222,140,17)"/>
             <text x="30.0457%" y="1839.50">CompileBroker::compiler_thread_loop()</text>
         </g>
         <g>
             <title>CompileBroker::invoke_compiler_on_method(CompileTask*) (2,302 samples, 70.20%)</title>
-            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(252,177,19)"/>
+            <rect x="29.7957%" y="1813" width="70.2043%" height="15" fill="rgb(221,42,51)"/>
             <text x="30.0457%" y="1823.50">CompileBroker::invoke_compiler_on_method(CompileTask*)</text>
         </g>
         <g>
             <title>Compiler::compile_method(ciEnv*, ciMethod*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(207,120,21)"/>
+            <rect x="94.7545%" y="1797" width="5.2455%" height="15" fill="rgb(214,170,37)"/>
             <text x="95.0045%" y="1807.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::Compilation(AbstractCompiler*, ciEnv*, ciMethod*, int, BufferBlob*) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(211,122,18)"/>
+            <rect x="94.7545%" y="1781" width="5.2455%" height="15" fill="rgb(246,70,37)"/>
             <text x="95.0045%" y="1791.50">Compil..</text>
         </g>
         <g>
             <title>Compilation::compile_method() (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(205,178,15)"/>
+            <rect x="94.7545%" y="1765" width="5.2455%" height="15" fill="rgb(238,19,23)"/>
             <text x="95.0045%" y="1775.50">Compil..</text>
         </g>
         <g>
             <title>ciEnv::register_method(ciMethod*, int, CodeOffsets*, int, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int, bool, bool, RTMState) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(246,91,28)"/>
+            <rect x="94.7545%" y="1749" width="5.2455%" height="15" fill="rgb(245,198,37)"/>
             <text x="95.0045%" y="1759.50">ciEnv:..</text>
         </g>
         <g>
             <title>nmethod::new_nmethod(methodHandle, int, int, CodeOffsets*, int, DebugInformationRecorder*, Dependencies*, CodeBuffer*, int, OopMapSet*, ExceptionHandlerTable*, ImplicitExceptionTable*, AbstractCompiler*, int) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(248,160,22)"/>
+            <rect x="94.7545%" y="1733" width="5.2455%" height="15" fill="rgb(235,72,33)"/>
             <text x="95.0045%" y="1743.50">nmetho..</text>
         </g>
         <g>
             <title>CodeCache::allocate(int, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(254,124,47)"/>
+            <rect x="94.7545%" y="1717" width="5.2455%" height="15" fill="rgb(236,221,22)"/>
             <text x="95.0045%" y="1727.50">CodeCa..</text>
         </g>
         <g>
             <title>CodeHeap::allocate(unsigned long, bool) (172 samples, 5.25%)</title>
-            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(250,130,33)"/>
+            <rect x="94.7545%" y="1701" width="5.2455%" height="15" fill="rgb(211,143,19)"/>
             <text x="95.0045%" y="1711.50">CodeHe..</text>
         </g>
     </svg>

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -122,6 +122,17 @@ fn test_flamegraph_logs_with_options<F>(
 }
 
 #[test]
+fn flamegraph_colors_deterministic() {
+    let input_file = "./tests/data/flamegraph/colors/async-profiler-collapsed-part.txt";
+    let expected_result_file = "./tests/data/flamegraph/colors/deterministic.svg";
+
+    let mut options = flamegraph::Options::default();
+    options.deterministic = true;
+
+    test_flamegraph(input_file, expected_result_file, options).unwrap();
+}
+
+#[test]
 fn flamegraph_colors_java() {
     let input_file = "./flamegraph/test/results/perf-java-stacks-01-collapsed-all.txt";
     let expected_result_file = "./tests/data/flamegraph/colors/java.svg";


### PR DESCRIPTION
From the runs I've tried out with this so far it seems like the color selection is a bit biased towards darker shades, which is unfortunate. Not entirely sure what to do about that.