### PR TITLE
Faster float formatting

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -844,6 +844,25 @@ fn deannotate(f: &str) -> &str {
     f
 }
 
+fn format_percentage(buffer: &mut StrStack, value: f64) -> usize {
+    if value == 0.0 {
+        return write!(buffer, "0.0000%");
+    }
+    let mut ibuf = itoa::Buffer::new();
+    let formatted = ibuf.format((value * 10_000.0).round() as u64);
+    if value >= 1.0 {
+        let len = formatted.len();
+        write!(
+            buffer,
+            "{}.{}%",
+            &formatted[..len - 4],
+            &formatted[len - 4..]
+        )
+    } else {
+        write!(buffer, "0.{:0>4}%", formatted)
+    }
+}
+
 fn filled_rectangle<W: Write>(
     svg: &mut Writer<W>,
     buffer: &mut StrStack,
@@ -851,9 +870,9 @@ fn filled_rectangle<W: Write>(
     color: Color,
     cache_rect: &mut Event<'_>,
 ) -> quick_xml::Result<()> {
-    let x = write!(buffer, "{:.4}%", rect.x1_pct);
+    let x = format_percentage(buffer, rect.x1_pct);
     let y = write_usize(buffer, rect.y1);
-    let width = write!(buffer, "{:.4}%", rect.width_pct());
+    let width = format_percentage(buffer, rect.width_pct());
     let height = write_usize(buffer, rect.height());
     let color = write!(buffer, "rgb({},{},{})", color.r, color.g, color.b);
 

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -7,7 +7,7 @@ use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::Writer;
 use str_stack::StrStack;
 
-use super::{Direction, Options, TextTruncateDirection};
+use super::{format_percentage, Direction, Options, TextTruncateDirection};
 
 pub(super) enum TextArgument<'a> {
     String(Cow<'a, str>),
@@ -259,9 +259,17 @@ where
 {
     let x = match item.x {
         Dimension::Pixels(x) => write!(buf, "{:.2}", x),
-        Dimension::Percent(x) => write!(buf, "{:.4}%", x),
+        Dimension::Percent(x) => format_percentage(buf, x),
     };
-    let y = write!(buf, "{:.2}", item.y);
+
+    let mut ibuf = itoa::Buffer::new();
+    let formatted = ibuf.format((item.y * 100.0) as u64);
+    let y = if item.y >= 1.0 {
+        let len = formatted.len();
+        write!(buf, "{}.{}", &formatted[..len - 2], &formatted[len - 2..])
+    } else {
+        write!(buf, "0.{:0>2}", formatted)
+    };
 
     let TextItem { text, extra, .. } = item;
 

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -7,7 +7,7 @@ use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::Writer;
 use str_stack::StrStack;
 
-use super::{format_percentage, Direction, Options, TextTruncateDirection};
+use super::{Direction, Options, RoundTo, TextTruncateDirection};
 
 pub(super) enum TextArgument<'a> {
     String(Cow<'a, str>),
@@ -259,17 +259,9 @@ where
 {
     let x = match item.x {
         Dimension::Pixels(x) => write!(buf, "{:.2}", x),
-        Dimension::Percent(x) => format_percentage(buf, x),
+        Dimension::Percent(x) => write!(buf, "{}%", RoundTo(x, 4)),
     };
-
-    let mut ibuf = itoa::Buffer::new();
-    let formatted = ibuf.format((item.y * 100.0) as u64);
-    let y = if item.y >= 1.0 {
-        let len = formatted.len();
-        write!(buf, "{}.{}", &formatted[..len - 2], &formatted[len - 2..])
-    } else {
-        write!(buf, "0.{:0>2}", formatted)
-    };
+    let y = write!(buf, "{}", RoundTo(item.y, 2));
 
     let TextItem { text, extra, .. } = item;
 


### PR DESCRIPTION
I don't have access to whatever folded stacks were in https://github.com/jonhoo/inferno/issues/102, but I've been experimenting with a 116 MB file and `--minwidth=0`. Looks like a 17% improvement with no other options, and 24% with `--reverse`.

Guidance appreciated, not yet sure how to thread this technique into the code in `from_lines`. I feel like a newtype with a customized `Display` impl might be the thing?