### PR TITLE
Support non-utf8 data in collapse by doing lossy conversion

### DIFF
--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -740,18 +740,19 @@ pub(crate) mod testing {
 
         fn count_lines_and_stacks(bytes: &[u8]) -> (usize, usize) {
             let mut reader = io::BufReader::new(bytes);
-            let mut line = String::new();
+            let mut line = Vec::new();
 
             let (mut nlines, mut nstacks) = (0, 0);
             loop {
                 line.clear();
-                let n = reader.read_line(&mut line).unwrap();
+                let n = reader.read_until(0x0A, &mut line).unwrap();
                 if n == 0 {
                     nstacks += 1;
                     break;
                 }
+                let l = String::from_utf8_lossy(&line);
                 nlines += 1;
-                if line.trim().is_empty() {
+                if l.trim().is_empty() {
                     nstacks += 1;
                 }
             }

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -133,10 +133,10 @@ impl CollapsePrivate for Folder {
         let mut found_empty_line = false;
         let mut found_stack_line = false;
         let mut input = input.as_bytes();
-        let mut line = Vec::new();
+        let mut line = String::new();
         loop {
             line.clear();
-            if let Ok(n) = input.read_until(0x0A, &mut line) {
+            if let Ok(n) = input.read_line(&mut line) {
                 if n == 0 {
                     break;
                 }
@@ -144,8 +144,7 @@ impl CollapsePrivate for Folder {
                 return Some(false);
             }
 
-            let s = String::from_utf8_lossy(&line);
-            let line = s.trim();
+            let line = line.trim();
             if line.is_empty() {
                 found_empty_line = true;
             } else if found_empty_line {

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -456,7 +456,7 @@ mod tests {
     }
 
     #[test]
-    fn test_collapse_multi_dtrace_stop_early() {
+    fn test_collapse_multi_dtrace_non_utf8() {
         let invalid_utf8 = unsafe { std::str::from_utf8_unchecked(&[0xf0, 0x28, 0x8c, 0xbc]) };
         let invalid_stack = format!("genunix`cv_broadcast+0x1{}\n1\n\n", invalid_utf8);
         let valid_stack = "genunix`cv_broadcast+0x1\n1\n\n";
@@ -473,20 +473,7 @@ mod tests {
         let mut folder = Folder::default();
         folder.nstacks_per_job = 1;
         folder.opt.nthreads = 12;
-        match <Folder as Collapse>::collapse(&mut folder, &input[..], io::sink()) {
-            Ok(_) => panic!("collapse should have return error, but instead returned Ok."),
-            Err(e) => match e.kind() {
-                io::ErrorKind::InvalidData => assert_eq!(
-                    &format!("{}", e),
-                    "stream did not contain valid UTF-8",
-                    "error message is incorrect.",
-                ),
-                k => panic!(
-                    "collapse should have returned `InvalidData` error but instead returned {:?}",
-                    k
-                ),
-            },
-        }
+        <Folder as Collapse>::collapse(&mut folder, &input[..], io::sink()).unwrap();
     }
 
     #[test]

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -77,15 +77,15 @@ impl CollapsePrivate for Folder {
         R: io::BufRead,
     {
         // Consumer the header...
-        let mut line = String::new();
+        let mut line = Vec::new();
         loop {
             line.clear();
-            if reader.read_line(&mut line)? == 0 {
+            if reader.read_until(0x0A, &mut line)? == 0 {
                 // We reached the end :( this should not happen.
                 warn!("File ended while skipping headers");
                 return Ok(());
             };
-            if line.trim().is_empty() {
+            if String::from_utf8_lossy(&line).trim().is_empty() {
                 return Ok(());
             }
         }
@@ -99,13 +99,14 @@ impl CollapsePrivate for Folder {
     where
         R: io::BufRead,
     {
-        let mut line = String::new();
+        let mut line = Vec::new();
         loop {
             line.clear();
-            if reader.read_line(&mut line)? == 0 {
+            if reader.read_until(0x0A, &mut line)? == 0 {
                 break;
             }
-            let line = line.trim();
+            let s = String::from_utf8_lossy(&line);
+            let line = s.trim();
             if line.is_empty() {
                 continue;
             } else if let Ok(count) = line.parse::<usize>() {
@@ -132,10 +133,10 @@ impl CollapsePrivate for Folder {
         let mut found_empty_line = false;
         let mut found_stack_line = false;
         let mut input = input.as_bytes();
-        let mut line = String::new();
+        let mut line = Vec::new();
         loop {
             line.clear();
-            if let Ok(n) = input.read_line(&mut line) {
+            if let Ok(n) = input.read_until(0x0A, &mut line) {
                 if n == 0 {
                     break;
                 }
@@ -143,7 +144,8 @@ impl CollapsePrivate for Folder {
                 return Some(false);
             }
 
-            let line = line.trim();
+            let s = String::from_utf8_lossy(&line);
+            let line = s.trim();
             if line.is_empty() {
                 found_empty_line = true;
             } else if found_empty_line {

--- a/src/collapse/sample.rs
+++ b/src/collapse/sample.rs
@@ -76,14 +76,15 @@ impl Collapse for Folder {
         W: io::Write,
     {
         // Consume the header...
-        let mut line = String::new();
+        let mut line = Vec::new();
         loop {
             line.clear();
-            if reader.read_line(&mut line)? == 0 {
+            if reader.read_until(0x0A, &mut line)? == 0 {
                 warn!("File ended before start of call graph");
                 return Ok(());
             };
-            if line.starts_with(START_LINE) {
+            let l = String::from_utf8_lossy(&line);
+            if l.starts_with(START_LINE) {
                 break;
             }
         }
@@ -92,10 +93,11 @@ impl Collapse for Folder {
         let mut occurrences = Occurrences::new(1);
         loop {
             line.clear();
-            if reader.read_line(&mut line)? == 0 {
+            if reader.read_until(0x0A, &mut line)? == 0 {
                 return invalid_data_error!("File ended before end of call graph");
             }
-            let line = line.trim_end();
+            let l = String::from_utf8_lossy(&line);
+            let line = l.trim_end();
             if line.is_empty() {
                 continue;
             } else if line.starts_with("    ") {

--- a/src/collapse/vtune.rs
+++ b/src/collapse/vtune.rs
@@ -52,14 +52,15 @@ impl Collapse for Folder {
         W: io::Write,
     {
         // Consume the header...
-        let mut line = String::new();
+        let mut line = Vec::new();
         loop {
             line.clear();
-            if reader.read_line(&mut line)? == 0 {
+            if reader.read_until(0x0A, &mut line)? == 0 {
                 warn!("File ended before header");
                 return Ok(());
             };
-            if line.starts_with(HEADER) {
+            let l = String::from_utf8_lossy(&line);
+            if l.starts_with(HEADER) {
                 break;
             }
         }
@@ -68,10 +69,11 @@ impl Collapse for Folder {
         let mut occurrences = Occurrences::new(1);
         loop {
             line.clear();
-            if reader.read_line(&mut line)? == 0 {
+            if reader.read_until(0x0A, &mut line)? == 0 {
                 break;
             }
-            let line = line.trim_end();
+            let l = String::from_utf8_lossy(&line);
+            let line = l.trim_end();
             if line.is_empty() {
                 continue;
             } else {

--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -90,17 +90,18 @@ where
     R: BufRead,
 {
     let mut total = 0;
-    let mut line = String::new();
+    let mut line = Vec::new();
     let mut stripped_fractional_samples = false;
     loop {
         line.clear();
 
-        if reader.read_line(&mut line)? == 0 {
+        if reader.read_until(0x0A, &mut line)? == 0 {
             break;
         }
 
+        let l = String::from_utf8_lossy(&line);
         if let Some((stack, count)) =
-            parse_line(&line, opt.strip_hex, &mut stripped_fractional_samples)
+            parse_line(&l, opt.strip_hex, &mut stripped_fractional_samples)
         {
             let mut counts = stack_counts.entry(stack).or_default();
             if is_first {
@@ -110,7 +111,7 @@ where
             }
             total += count;
         } else {
-            warn!("Unable to parse line: {}", line);
+            warn!("Unable to parse line: {}", l);
         }
     }
 

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -38,15 +38,16 @@ impl FuncFrameAttrsMap {
     /// tab-separated `name=value` pairs.
     pub fn from_reader<R: BufRead>(mut reader: R) -> io::Result<FuncFrameAttrsMap> {
         let mut funcattr_map = FuncFrameAttrsMap::default();
-        let mut line = String::new();
+        let mut line = Vec::new();
         loop {
             line.clear();
 
-            if reader.read_line(&mut line)? == 0 {
+            if reader.read_until(0x0A, &mut line)? == 0 {
                 break;
             }
 
-            let mut line = line.trim().splitn(2, '\t');
+            let l = String::from_utf8_lossy(&line);
+            let mut line = l.trim().splitn(2, '\t');
             let func = unwrap_or_continue!(line.next());
             if func.is_empty() {
                 continue;


### PR DESCRIPTION
A project I'm benchmarking has non-utf8 data in the dtrace, and it's quite annoying to have to use iconv to sanitize the file before collapsing. I did this for my own needs, and figured I would PR as it might be useful to others as well.

If you are open to this, I should also add this to other parts of the code that do similar things, but I won't do that preemptively unless go ahead is given (not sure if there is a good reason this is not done)