### PR TITLE
Switch test case to not handle arbitrarily large input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Support for invalid utf8 data in collapse. [#196](https://github.com/jonhoo/inferno/pull/196)
 
 ### Removed
 

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -466,7 +466,7 @@ mod tests {
             input.extend_from_slice(valid_stack.as_bytes());
         }
         input.extend_from_slice(invalid_stack.as_bytes());
-        for _ in 0..(1024 * 1024 * 10) {
+        for _ in 0..100 {
             input.extend_from_slice(valid_stack.as_bytes());
         }
 


### PR DESCRIPTION
- This test was exiting early because there was invalid utf8 placed in between these statements, but now that it's being processed this test runs for a while to process `1024*1024*10` elements.

My apologies for not noticing this test was really slow when I added support in #196, I didn't consider this was how the test was setup