### PR TITLE
Add a generic palette to highlight kernel / jitted code

### DIFF
--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -82,7 +82,7 @@ struct Opt {
         short = "c",
         long = "colors",
         default_value = defaults::COLORS,
-        possible_values = &["aqua","blue","green","hot","io","java","js","mem","orange","perl","purple","red","wakeup","yellow"],
+        possible_values = &["annotated","aqua","blue","green","hot","io","java","js","mem","orange","perl","purple","red","wakeup","yellow"],
         value_name = "STRING"
     )]
     colors: Palette,

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -118,6 +118,8 @@ pub enum BasicPalette {
 /// different function names (kernel functions, JIT functions, etc.).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MultiPalette {
+    /// Use function annotations with no specific language heuristics to color frames.
+    Annotated,
     /// Use Java semantics to color frames.
     Java,
     /// Use JavaScript semantics to color frames.
@@ -193,6 +195,7 @@ impl FromStr for Palette {
             "mem" => Ok(Palette::Basic(BasicPalette::Mem)),
             "io" => Ok(Palette::Basic(BasicPalette::Io)),
             "wakeup" => Ok(Palette::Multi(MultiPalette::Wakeup)),
+            "annotated" => Ok(Palette::Multi(MultiPalette::Annotated)),
             "java" => Ok(Palette::Multi(MultiPalette::Java)),
             "js" => Ok(Palette::Multi(MultiPalette::Js)),
             "perl" => Ok(Palette::Multi(MultiPalette::Perl)),
@@ -304,6 +307,7 @@ macro_rules! color {
 fn rgb_components_for_palette(palette: Palette, name: &str, v1: f32, v2: f32, v3: f32) -> Color {
     let basic_palette = match palette {
         Palette::Basic(basic) => basic,
+        Palette::Multi(MultiPalette::Annotated) => palettes::annotated::resolve(name),
         Palette::Multi(MultiPalette::Java) => palettes::java::resolve(name),
         Palette::Multi(MultiPalette::Perl) => palettes::perl::resolve(name),
         Palette::Multi(MultiPalette::Js) => palettes::js::resolve(name),

--- a/src/flamegraph/color/palettes.rs
+++ b/src/flamegraph/color/palettes.rs
@@ -1,3 +1,29 @@
+pub(super) mod annotated {
+    use crate::flamegraph::color::BasicPalette;
+
+    /// Handle annotations (_[j], _[i], ...; which are
+    /// accurate) in a generic way.
+    pub fn resolve(name: &str) -> BasicPalette {
+        if name.ends_with(']') {
+            if let Some(ai) = name.rfind("_[") {
+                if name[ai..].len() == 4 {
+                    match &name[ai + 2..ai + 3] {
+                        // kernel annotation
+                        "k" => return BasicPalette::Orange,
+                        // inline annotation
+                        "i" => return BasicPalette::Aqua,
+                        // jit annotation
+                        "j" => return BasicPalette::Green,
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        BasicPalette::Red
+    }
+}
+
 pub(super) mod java {
     use crate::flamegraph::color::BasicPalette;
 


### PR DESCRIPTION
The "java" and "js" colour palettes have a very useful feature of being able to highlight which frames are jitted or kernel functions based on the annotations added to the function makes by the stackcollapse programs. Unfortunately they also make a number of assumptions based on the function names which are very specific to those languages, and cause nonsensical results with other runtimes.

This PR adds a new generic "annotated" colour palette that only uses the function name annotations, and can thus be used regardless of the runtime being profiled.