### PR TITLE
Increase default flamegraph fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Support jit annotations in collapse-perf for runtimes using the jitdump format. [#202](https://github.com/jonhoo/inferno/pull/202)
 
 ### Changed
+ - Decreased default minimum width from 0.1% to 0.01%. [#204](https://github.com/jonhoo/inferno/pull/204)
 
 ### Removed
 

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -139,7 +139,7 @@ struct Opt {
     )]
     height: usize,
 
-    /// Omit functions smaller than <FLOAT> pixels
+    /// Omit functions smaller than <FLOAT> percent
     #[structopt(
         long = "minwidth",
         default_value = &defaults::str::MIN_WIDTH,

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -80,7 +80,7 @@ pub mod defaults {
         TITLE: &str = "Flame Graph",
         CHART_TITLE: &str = "Flame Chart",
         FRAME_HEIGHT: usize = 16,
-        MIN_WIDTH: f64 = 0.1,
+        MIN_WIDTH: f64 = 0.01,
         FONT_TYPE: &str = "Verdana",
         FONT_SIZE: usize = 12,
         FONT_WIDTH: f64 = 0.59,

--- a/tests/data/flamegraph/example-perf-stacks/example-perf-stacks.svg
+++ b/tests/data/flamegraph/example-perf-stacks/example-perf-stacks.svg
@@ -36,6 +36,56 @@ var truncate_text_right = false;]]>
     <text id="matched" x="1090" y="1253.00"> </text>
     <svg id="frames" x="10" width="1180">
         <g>
+            <title>gmain (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1205" width="0.0760%" height="15" fill="rgb(243,47,5)"/>
+            <text x="0.2500%" y="1215.50"></text>
+        </g>
+        <g>
+            <title>[unknown] (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1189" width="0.0760%" height="15" fill="rgb(228,31,8)"/>
+            <text x="0.2500%" y="1199.50"></text>
+        </g>
+        <g>
+            <title>inotify_add_watch (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1173" width="0.0760%" height="15" fill="rgb(207,98,12)"/>
+            <text x="0.2500%" y="1183.50"></text>
+        </g>
+        <g>
+            <title>system_call_fastpath (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1157" width="0.0760%" height="15" fill="rgb(210,77,43)"/>
+            <text x="0.2500%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>sys_inotify_add_watch (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1141" width="0.0760%" height="15" fill="rgb(243,143,5)"/>
+            <text x="0.2500%" y="1151.50"></text>
+        </g>
+        <g>
+            <title>user_path_at (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1125" width="0.0760%" height="15" fill="rgb(232,166,45)"/>
+            <text x="0.2500%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>user_path_at_empty (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1109" width="0.0760%" height="15" fill="rgb(233,20,14)"/>
+            <text x="0.2500%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>filename_lookup (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1093" width="0.0760%" height="15" fill="rgb(205,2,0)"/>
+            <text x="0.2500%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>link_path_walk (1 samples, 0.08%)</title>
+            <rect x="0.0000%" y="1077" width="0.0760%" height="15" fill="rgb(211,107,10)"/>
+            <text x="0.2500%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>system_call (1 samples, 0.08%)</title>
+            <rect x="0.0760%" y="1141" width="0.0760%" height="15" fill="rgb(238,111,21)"/>
+            <text x="0.3260%" y="1151.50"></text>
+        </g>
+        <g>
             <title>[libpthread-2.19.so] (7 samples, 0.53%)</title>
             <rect x="0.0760%" y="1157" width="0.5323%" height="15" fill="rgb(233,49,7)"/>
             <text x="0.3260%" y="1167.50"></text>
@@ -59,6 +109,36 @@ var truncate_text_right = false;]]>
             <title>[unknown] (10 samples, 0.76%)</title>
             <rect x="0.0760%" y="1173" width="0.7605%" height="15" fill="rgb(228,31,8)"/>
             <text x="0.3260%" y="1183.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_vertx_lang_js_1_1_0_vertx_streams_j (1 samples, 0.08%)</title>
+            <rect x="0.7605%" y="1157" width="0.0760%" height="15" fill="rgb(216,68,4)"/>
+            <text x="1.0105%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>GCTaskManager::get_task (1 samples, 0.08%)</title>
+            <rect x="0.8365%" y="1141" width="0.0760%" height="15" fill="rgb(234,72,15)"/>
+            <text x="1.0865%" y="1151.50"></text>
+        </g>
+        <g>
+            <title>Monitor::wait (1 samples, 0.08%)</title>
+            <rect x="0.8365%" y="1125" width="0.0760%" height="15" fill="rgb(252,50,10)"/>
+            <text x="1.0865%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>Monitor::IWait (1 samples, 0.08%)</title>
+            <rect x="0.8365%" y="1109" width="0.0760%" height="15" fill="rgb(205,189,43)"/>
+            <text x="1.0865%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>__lll_unlock_wake (1 samples, 0.08%)</title>
+            <rect x="0.8365%" y="1093" width="0.0760%" height="15" fill="rgb(248,23,45)"/>
+            <text x="1.0865%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>sys_futex (1 samples, 0.08%)</title>
+            <rect x="0.8365%" y="1077" width="0.0760%" height="15" fill="rgb(231,188,10)"/>
+            <text x="1.0865%" y="1087.50"></text>
         </g>
         <g>
             <title>InstanceKlass::oop_push_contents (8 samples, 0.61%)</title>
@@ -91,6 +171,21 @@ var truncate_text_right = false;]]>
             <text x="2.5314%" y="1103.50"></text>
         </g>
         <g>
+            <title>ScavengeRootsTask::do_it (1 samples, 0.08%)</title>
+            <rect x="2.4335%" y="1141" width="0.0760%" height="15" fill="rgb(218,68,14)"/>
+            <text x="2.6835%" y="1151.50"></text>
+        </g>
+        <g>
+            <title>ClassLoaderDataGraph::oops_do (1 samples, 0.08%)</title>
+            <rect x="2.4335%" y="1125" width="0.0760%" height="15" fill="rgb(250,79,10)"/>
+            <text x="2.6835%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>PSScavengeKlassClosure::do_klass (1 samples, 0.08%)</title>
+            <rect x="2.4335%" y="1109" width="0.0760%" height="15" fill="rgb(231,82,43)"/>
+            <text x="2.6835%" y="1119.50"></text>
+        </g>
+        <g>
             <title>ParallelTaskTerminator::offer_termination (2 samples, 0.15%)</title>
             <rect x="2.5095%" y="1125" width="0.1521%" height="15" fill="rgb(252,79,44)"/>
             <text x="2.7595%" y="1135.50"></text>
@@ -99,6 +194,41 @@ var truncate_text_right = false;]]>
             <title>StealTask::do_it (3 samples, 0.23%)</title>
             <rect x="2.5095%" y="1141" width="0.2281%" height="15" fill="rgb(245,5,13)"/>
             <text x="2.7595%" y="1151.50"></text>
+        </g>
+        <g>
+            <title>SpinPause (1 samples, 0.08%)</title>
+            <rect x="2.6616%" y="1125" width="0.0760%" height="15" fill="rgb(234,18,0)"/>
+            <text x="2.9116%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>HandleArea::oops_do (1 samples, 0.08%)</title>
+            <rect x="2.7376%" y="1109" width="0.0760%" height="15" fill="rgb(227,170,52)"/>
+            <text x="2.9876%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>frame::oops_do_internal (1 samples, 0.08%)</title>
+            <rect x="2.8137%" y="1109" width="0.0760%" height="15" fill="rgb(237,8,33)"/>
+            <text x="3.0637%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>OopMapSet::all_do (1 samples, 0.08%)</title>
+            <rect x="2.8137%" y="1093" width="0.0760%" height="15" fill="rgb(247,221,23)"/>
+            <text x="3.0637%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>PSRootsClosure&lt;false&gt;::do_oop (1 samples, 0.08%)</title>
+            <rect x="2.8137%" y="1077" width="0.0760%" height="15" fill="rgb(220,115,51)"/>
+            <text x="3.0637%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>oopDesc* PSPromotionManager::copy_to_survivor_space&lt;false&gt; (1 samples, 0.08%)</title>
+            <rect x="2.8137%" y="1061" width="0.0760%" height="15" fill="rgb(211,97,38)"/>
+            <text x="3.0637%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>InstanceKlass::oop_push_contents (1 samples, 0.08%)</title>
+            <rect x="2.8137%" y="1045" width="0.0760%" height="15" fill="rgb(248,151,47)"/>
+            <text x="3.0637%" y="1055.50"></text>
         </g>
         <g>
             <title>GCTaskThread::run (28 samples, 2.13%)</title>
@@ -116,6 +246,16 @@ var truncate_text_right = false;]]>
             <text x="2.9876%" y="1135.50"></text>
         </g>
         <g>
+            <title>nmethod::fix_oop_relocations (1 samples, 0.08%)</title>
+            <rect x="2.8897%" y="1109" width="0.0760%" height="15" fill="rgb(236,133,8)"/>
+            <text x="3.1397%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.fireChannelReadComplete (1 samples, 0.08%)</title>
+            <rect x="3.4981%" y="965" width="0.0760%" height="15" fill="rgb(237,145,33)"/>
+            <text x="3.7481%" y="975.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AdaptiveRecvByteBufAllocator$HandleImpl:.record (2 samples, 0.15%)</title>
             <rect x="3.5741%" y="965" width="0.1521%" height="15" fill="rgb(212,139,1)"/>
             <text x="3.8241%" y="975.50"></text>
@@ -131,9 +271,24 @@ var truncate_text_right = false;]]>
             <text x="4.5846%" y="943.50"></text>
         </g>
         <g>
+            <title>java/nio/DirectByteBuffer:.duplicate (1 samples, 0.08%)</title>
+            <rect x="4.5627%" y="933" width="0.0760%" height="15" fill="rgb(215,13,10)"/>
+            <text x="4.8127%" y="943.50"></text>
+        </g>
+        <g>
+            <title>java/nio/channels/spi/AbstractInterruptibleChannel:.begin (1 samples, 0.08%)</title>
+            <rect x="4.8669%" y="917" width="0.0760%" height="15" fill="rgb(232,51,37)"/>
+            <text x="5.1169%" y="927.50"></text>
+        </g>
+        <g>
             <title>java/nio/channels/spi/AbstractInterruptibleChannel:.end (3 samples, 0.23%)</title>
             <rect x="4.9430%" y="917" width="0.2281%" height="15" fill="rgb(243,89,12)"/>
             <text x="5.1930%" y="927.50"></text>
+        </g>
+        <g>
+            <title>sun/nio/ch/FileDispatcherImpl:.read0 (1 samples, 0.08%)</title>
+            <rect x="5.1711%" y="917" width="0.0760%" height="15" fill="rgb(209,23,46)"/>
+            <text x="5.4211%" y="927.50"></text>
         </g>
         <g>
             <title>fget_light (3 samples, 0.23%)</title>
@@ -146,9 +301,34 @@ var truncate_text_right = false;]]>
             <text x="5.8774%" y="783.50"></text>
         </g>
         <g>
+            <title>lock_sock_nested (1 samples, 0.08%)</title>
+            <rect x="6.0837%" y="757" width="0.0760%" height="15" fill="rgb(252,7,51)"/>
+            <text x="6.3337%" y="767.50"></text>
+        </g>
+        <g>
             <title>tcp_rcv_space_adjust (2 samples, 0.15%)</title>
             <rect x="6.1597%" y="757" width="0.1521%" height="15" fill="rgb(231,208,3)"/>
             <text x="6.4097%" y="767.50"></text>
+        </g>
+        <g>
+            <title>lock_sock_nested (1 samples, 0.08%)</title>
+            <rect x="6.7681%" y="741" width="0.0760%" height="15" fill="rgb(252,7,51)"/>
+            <text x="7.0181%" y="751.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_bh (1 samples, 0.08%)</title>
+            <rect x="6.7681%" y="725" width="0.0760%" height="15" fill="rgb(218,157,7)"/>
+            <text x="7.0181%" y="735.50"></text>
+        </g>
+        <g>
+            <title>release_sock (1 samples, 0.08%)</title>
+            <rect x="6.8441%" y="741" width="0.0760%" height="15" fill="rgb(244,133,13)"/>
+            <text x="7.0941%" y="751.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_unlock_bh (1 samples, 0.08%)</title>
+            <rect x="6.8441%" y="725" width="0.0760%" height="15" fill="rgb(244,89,32)"/>
+            <text x="7.0941%" y="735.50"></text>
         </g>
         <g>
             <title>skb_copy_datagram_iovec (3 samples, 0.23%)</title>
@@ -191,6 +371,21 @@ var truncate_text_right = false;]]>
             <text x="7.3983%" y="751.50"></text>
         </g>
         <g>
+            <title>apparmor_file_permission (1 samples, 0.08%)</title>
+            <rect x="7.3004%" y="789" width="0.0760%" height="15" fill="rgb(243,206,54)"/>
+            <text x="7.5504%" y="799.50"></text>
+        </g>
+        <g>
+            <title>common_file_perm (1 samples, 0.08%)</title>
+            <rect x="7.3004%" y="773" width="0.0760%" height="15" fill="rgb(219,178,19)"/>
+            <text x="7.5504%" y="783.50"></text>
+        </g>
+        <g>
+            <title>aa_file_perm (1 samples, 0.08%)</title>
+            <rect x="7.3004%" y="757" width="0.0760%" height="15" fill="rgb(247,203,23)"/>
+            <text x="7.5504%" y="767.50"></text>
+        </g>
+        <g>
             <title>rw_verify_area (2 samples, 0.15%)</title>
             <rect x="7.3004%" y="821" width="0.1521%" height="15" fill="rgb(253,78,54)"/>
             <text x="7.5504%" y="831.50"></text>
@@ -199,6 +394,11 @@ var truncate_text_right = false;]]>
             <title>security_file_permission (2 samples, 0.15%)</title>
             <rect x="7.3004%" y="805" width="0.1521%" height="15" fill="rgb(235,38,22)"/>
             <text x="7.5504%" y="815.50"></text>
+        </g>
+        <g>
+            <title>fsnotify (1 samples, 0.08%)</title>
+            <rect x="7.3764%" y="789" width="0.0760%" height="15" fill="rgb(246,57,19)"/>
+            <text x="7.6264%" y="799.50"></text>
         </g>
         <g>
             <title>[libpthread-2.19.so] (30 samples, 2.28%)</title>
@@ -221,6 +421,11 @@ var truncate_text_right = false;]]>
             <text x="5.8774%" y="847.50">v..</text>
         </g>
         <g>
+            <title>security_file_permission (1 samples, 0.08%)</title>
+            <rect x="7.4525%" y="821" width="0.0760%" height="15" fill="rgb(235,38,22)"/>
+            <text x="7.7025%" y="831.50"></text>
+        </g>
+        <g>
             <title>sun/nio/ch/IOUtil:.readIntoNativeBuffer (31 samples, 2.36%)</title>
             <rect x="5.2471%" y="917" width="2.3574%" height="15" fill="rgb(210,17,5)"/>
             <text x="5.4971%" y="927.50">s..</text>
@@ -231,6 +436,11 @@ var truncate_text_right = false;]]>
             <text x="5.4971%" y="911.50">s..</text>
         </g>
         <g>
+            <title>fdval (1 samples, 0.08%)</title>
+            <rect x="7.5285%" y="885" width="0.0760%" height="15" fill="rgb(205,213,24)"/>
+            <text x="7.7785%" y="895.50"></text>
+        </g>
+        <g>
             <title>io/netty/buffer/PooledUnsafeDirectByteBuf:.setBytes (42 samples, 3.19%)</title>
             <rect x="4.4867%" y="949" width="3.1939%" height="15" fill="rgb(229,39,4)"/>
             <text x="4.7367%" y="959.50">io/..</text>
@@ -239,6 +449,16 @@ var truncate_text_right = false;]]>
             <title>sun/nio/ch/SocketChannelImpl:.read (40 samples, 3.04%)</title>
             <rect x="4.6388%" y="933" width="3.0418%" height="15" fill="rgb(251,175,44)"/>
             <text x="4.8888%" y="943.50">sun..</text>
+        </g>
+        <g>
+            <title>sun/nio/ch/NativeThread:.current (1 samples, 0.08%)</title>
+            <rect x="7.6046%" y="917" width="0.0760%" height="15" fill="rgb(245,149,21)"/>
+            <text x="7.8546%" y="927.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.executor (1 samples, 0.08%)</title>
+            <rect x="7.6806%" y="949" width="0.0760%" height="15" fill="rgb(218,81,7)"/>
+            <text x="7.9306%" y="959.50"></text>
         </g>
         <g>
             <title>io/netty/buffer/AbstractReferenceCountedByteBuf:.release (4 samples, 0.30%)</title>
@@ -256,9 +476,24 @@ var truncate_text_right = false;]]>
             <text x="8.6150%" y="927.50"></text>
         </g>
         <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.executor (1 samples, 0.08%)</title>
+            <rect x="8.5171%" y="917" width="0.0760%" height="15" fill="rgb(218,81,7)"/>
+            <text x="8.7671%" y="927.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.executor (1 samples, 0.08%)</title>
+            <rect x="9.0494%" y="901" width="0.0760%" height="15" fill="rgb(218,81,7)"/>
+            <text x="9.2994%" y="911.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AbstractChannel:.hashCode (4 samples, 0.30%)</title>
             <rect x="9.5817%" y="885" width="0.3042%" height="15" fill="rgb(248,167,4)"/>
             <text x="9.8317%" y="895.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpVersion:.compareTo (1 samples, 0.08%)</title>
+            <rect x="9.8859%" y="885" width="0.0760%" height="15" fill="rgb(216,44,54)"/>
+            <text x="10.1359%" y="895.50"></text>
         </g>
         <g>
             <title>java/util/concurrent/ConcurrentHashMap:.get (3 samples, 0.23%)</title>
@@ -271,9 +506,54 @@ var truncate_text_right = false;]]>
             <text x="10.9724%" y="879.50"></text>
         </g>
         <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="10.7985%" y="853" width="0.0760%" height="15" fill="rgb(219,199,7)"/>
+            <text x="11.0485%" y="863.50"></text>
+        </g>
+        <g>
             <title>io/netty/handler/codec/http/HttpVersion:.compareTo (2 samples, 0.15%)</title>
             <rect x="10.8745%" y="869" width="0.1521%" height="15" fill="rgb(216,44,54)"/>
             <text x="11.1245%" y="879.50"></text>
+        </g>
+        <g>
+            <title>java/lang/ThreadLocal:.get (1 samples, 0.08%)</title>
+            <rect x="11.0266%" y="869" width="0.0760%" height="15" fill="rgb(243,197,8)"/>
+            <text x="11.2766%" y="879.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/WrapFactory:.wrap (1 samples, 0.08%)</title>
+            <rect x="11.1027%" y="869" width="0.0760%" height="15" fill="rgb(244,189,42)"/>
+            <text x="11.3527%" y="879.50"></text>
+        </g>
+        <g>
+            <title>java/lang/ThreadLocal:.get (1 samples, 0.08%)</title>
+            <rect x="11.4068%" y="853" width="0.0760%" height="15" fill="rgb(243,197,8)"/>
+            <text x="11.6568%" y="863.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/NativeJavaObject:.initMembers (1 samples, 0.08%)</title>
+            <rect x="11.4829%" y="853" width="0.0760%" height="15" fill="rgb(230,172,54)"/>
+            <text x="11.7329%" y="863.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getTopLevelScope (1 samples, 0.08%)</title>
+            <rect x="11.5589%" y="853" width="0.0760%" height="15" fill="rgb(254,162,42)"/>
+            <text x="11.8089%" y="863.50"></text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="11.7110%" y="821" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="11.9610%" y="831.50"></text>
+        </g>
+        <g>
+            <title>java/util/HashMap:.getNode (1 samples, 0.08%)</title>
+            <rect x="11.7871%" y="821" width="0.0760%" height="15" fill="rgb(235,72,14)"/>
+            <text x="12.0371%" y="831.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getParentScope (1 samples, 0.08%)</title>
+            <rect x="11.8631%" y="821" width="0.0760%" height="15" fill="rgb(247,182,52)"/>
+            <text x="12.1131%" y="831.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/WrapFactory:.wrap (5 samples, 0.38%)</title>
@@ -286,9 +566,59 @@ var truncate_text_right = false;]]>
             <text x="11.9610%" y="847.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getTopScopeValue (1 samples, 0.08%)</title>
+            <rect x="11.9392%" y="821" width="0.0760%" height="15" fill="rgb(241,44,48)"/>
+            <text x="12.1892%" y="831.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/WrapFactory:.wrapAsJavaObject (1 samples, 0.08%)</title>
+            <rect x="12.0152%" y="853" width="0.0760%" height="15" fill="rgb(250,136,18)"/>
+            <text x="12.2652%" y="863.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/NativeJavaObject:.initMembers (1 samples, 0.08%)</title>
+            <rect x="12.0152%" y="837" width="0.0760%" height="15" fill="rgb(230,172,54)"/>
+            <text x="12.2652%" y="847.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="12.0152%" y="821" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="12.2652%" y="831.50"></text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="12.1673%" y="837" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="12.4173%" y="847.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="12.6236%" y="821" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="12.8736%" y="831.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="12.6236%" y="805" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="12.8736%" y="815.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="12.6996%" y="789" width="0.0760%" height="15" fill="rgb(242,102,17)"/>
+            <text x="12.9496%" y="799.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/IdScriptableObject:.get (2 samples, 0.15%)</title>
             <rect x="12.7757%" y="789" width="0.1521%" height="15" fill="rgb(242,197,6)"/>
             <text x="13.0257%" y="799.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="12.8517%" y="773" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="13.1017%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject$Slot:.getValue (1 samples, 0.08%)</title>
+            <rect x="12.9278%" y="789" width="0.0760%" height="15" fill="rgb(219,157,30)"/>
+            <text x="13.1778%" y="799.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/ScriptableObject:.getSlot (2 samples, 0.15%)</title>
@@ -311,6 +641,26 @@ var truncate_text_right = false;]]>
             <text x="13.4059%" y="799.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.toObjectOrNull (1 samples, 0.08%)</title>
+            <rect x="13.3080%" y="821" width="0.0760%" height="15" fill="rgb(249,136,46)"/>
+            <text x="13.5580%" y="831.50"></text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="13.4601%" y="805" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="13.7101%" y="815.50"></text>
+        </g>
+        <g>
+            <title>io/netty/buffer/AbstractByteBuf:.writeBytes (1 samples, 0.08%)</title>
+            <rect x="13.6882%" y="773" width="0.0760%" height="15" fill="rgb(234,163,23)"/>
+            <text x="13.9382%" y="783.50"></text>
+        </g>
+        <g>
+            <title>io/netty/buffer/AbstractByteBufAllocator:.heapBuffer (1 samples, 0.08%)</title>
+            <rect x="13.7643%" y="773" width="0.0760%" height="15" fill="rgb(209,33,3)"/>
+            <text x="14.0143%" y="783.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/NativeJavaMethod:.findCachedFunction (2 samples, 0.15%)</title>
             <rect x="13.8403%" y="773" width="0.1521%" height="15" fill="rgb(208,191,15)"/>
             <text x="14.0903%" y="783.50"></text>
@@ -319,6 +669,11 @@ var truncate_text_right = false;]]>
             <title>org/vertx/java/core/http/impl/AssembledFullHttpResponse:.toLastContent (2 samples, 0.15%)</title>
             <rect x="13.9924%" y="773" width="0.1521%" height="15" fill="rgb(243,10,3)"/>
             <text x="14.2424%" y="783.50"></text>
+        </g>
+        <g>
+            <title>io/netty/buffer/AbstractByteBuf:.checkSrcIndex (1 samples, 0.08%)</title>
+            <rect x="14.3726%" y="757" width="0.0760%" height="15" fill="rgb(237,59,24)"/>
+            <text x="14.6226%" y="767.50"></text>
         </g>
         <g>
             <title>io/netty/buffer/AbstractByteBuf:.writeBytes (5 samples, 0.38%)</title>
@@ -341,9 +696,39 @@ var truncate_text_right = false;]]>
             <text x="15.0789%" y="767.50"></text>
         </g>
         <g>
+            <title>io/netty/buffer/UnpooledHeapByteBuf:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="14.9810%" y="741" width="0.0760%" height="15" fill="rgb(223,62,46)"/>
+            <text x="15.2310%" y="751.50"></text>
+        </g>
+        <g>
+            <title>io/netty/buffer/UnpooledHeapByteBuf:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="15.0570%" y="757" width="0.0760%" height="15" fill="rgb(223,62,46)"/>
+            <text x="15.3070%" y="767.50"></text>
+        </g>
+        <g>
+            <title>io/netty/buffer/UnreleasableByteBuf:.duplicate (1 samples, 0.08%)</title>
+            <rect x="15.1331%" y="757" width="0.0760%" height="15" fill="rgb(232,198,31)"/>
+            <text x="15.3831%" y="767.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.newPromise (1 samples, 0.08%)</title>
+            <rect x="15.2091%" y="757" width="0.0760%" height="15" fill="rgb(248,122,33)"/>
+            <text x="15.4591%" y="767.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.write (2 samples, 0.15%)</title>
             <rect x="15.2852%" y="757" width="0.1521%" height="15" fill="rgb(228,161,40)"/>
             <text x="15.5352%" y="767.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.add0 (1 samples, 0.08%)</title>
+            <rect x="15.4373%" y="757" width="0.0760%" height="15" fill="rgb(244,147,33)"/>
+            <text x="15.6873%" y="767.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.add0 (1 samples, 0.08%)</title>
+            <rect x="15.5894%" y="741" width="0.0760%" height="15" fill="rgb(244,147,33)"/>
+            <text x="15.8394%" y="751.50"></text>
         </g>
         <g>
             <title>io/netty/handler/codec/http/DefaultHttpHeaders:.set (3 samples, 0.23%)</title>
@@ -351,9 +736,34 @@ var truncate_text_right = false;]]>
             <text x="15.7633%" y="767.50"></text>
         </g>
         <g>
+            <title>io/netty/handler/codec/http/HttpHeaders:.hash (1 samples, 0.08%)</title>
+            <rect x="15.6654%" y="741" width="0.0760%" height="15" fill="rgb(232,1,32)"/>
+            <text x="15.9154%" y="751.50"></text>
+        </g>
+        <g>
+            <title>java/lang/Integer:.toString (1 samples, 0.08%)</title>
+            <rect x="15.7414%" y="757" width="0.0760%" height="15" fill="rgb(235,33,53)"/>
+            <text x="15.9914%" y="767.50"></text>
+        </g>
+        <g>
+            <title>java/util/Arrays:.copyOf (1 samples, 0.08%)</title>
+            <rect x="15.8175%" y="709" width="0.0760%" height="15" fill="rgb(234,27,3)"/>
+            <text x="16.0675%" y="719.50"></text>
+        </g>
+        <g>
+            <title>jlong_disjoint_arraycopy (1 samples, 0.08%)</title>
+            <rect x="15.8175%" y="693" width="0.0760%" height="15" fill="rgb(229,25,4)"/>
+            <text x="16.0675%" y="703.50"></text>
+        </g>
+        <g>
             <title>java/nio/charset/CharsetEncoder:.replaceWith (2 samples, 0.15%)</title>
             <rect x="15.8175%" y="725" width="0.1521%" height="15" fill="rgb(220,162,29)"/>
             <text x="16.0675%" y="735.50"></text>
+        </g>
+        <g>
+            <title>jlong_disjoint_arraycopy (1 samples, 0.08%)</title>
+            <rect x="15.8935%" y="709" width="0.0760%" height="15" fill="rgb(229,25,4)"/>
+            <text x="16.1435%" y="719.50"></text>
         </g>
         <g>
             <title>java/lang/String:.getBytes (3 samples, 0.23%)</title>
@@ -366,14 +776,44 @@ var truncate_text_right = false;]]>
             <text x="16.0675%" y="751.50"></text>
         </g>
         <g>
+            <title>java/util/Arrays:.copyOf (1 samples, 0.08%)</title>
+            <rect x="15.9696%" y="725" width="0.0760%" height="15" fill="rgb(234,27,3)"/>
+            <text x="16.2196%" y="735.50"></text>
+        </g>
+        <g>
             <title>java/nio/charset/Charset:.lookup (2 samples, 0.15%)</title>
             <rect x="16.0456%" y="757" width="0.1521%" height="15" fill="rgb(247,151,37)"/>
             <text x="16.2956%" y="767.50"></text>
         </g>
         <g>
+            <title>org/vertx/java/core/http/impl/AssembledFullHttpResponse:.toLastContent (1 samples, 0.08%)</title>
+            <rect x="16.1977%" y="757" width="0.0760%" height="15" fill="rgb(243,10,3)"/>
+            <text x="16.4477%" y="767.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="16.1977%" y="741" width="0.0760%" height="15" fill="rgb(219,199,7)"/>
+            <text x="16.4477%" y="751.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.newPromise (1 samples, 0.08%)</title>
+            <rect x="16.2738%" y="741" width="0.0760%" height="15" fill="rgb(248,122,33)"/>
+            <text x="16.5238%" y="751.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.executor (1 samples, 0.08%)</title>
+            <rect x="16.2738%" y="725" width="0.0760%" height="15" fill="rgb(218,81,7)"/>
+            <text x="16.5238%" y="735.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.validatePromise (2 samples, 0.15%)</title>
             <rect x="16.3498%" y="741" width="0.1521%" height="15" fill="rgb(214,53,6)"/>
             <text x="16.5998%" y="751.50"></text>
+        </g>
+        <g>
+            <title>io/netty/buffer/AbstractByteBuf:.writeBytes (1 samples, 0.08%)</title>
+            <rect x="16.6540%" y="677" width="0.0760%" height="15" fill="rgb(234,163,23)"/>
+            <text x="16.9040%" y="687.50"></text>
         </g>
         <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.write (6 samples, 0.46%)</title>
@@ -386,6 +826,21 @@ var truncate_text_right = false;]]>
             <text x="16.9800%" y="671.50"></text>
         </g>
         <g>
+            <title>io/netty/channel/ChannelOutboundBuffer:.incrementPendingOutboundBytes (1 samples, 0.08%)</title>
+            <rect x="17.1103%" y="645" width="0.0760%" height="15" fill="rgb(253,23,45)"/>
+            <text x="17.3603%" y="655.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.contains (1 samples, 0.08%)</title>
+            <rect x="17.1863%" y="677" width="0.0760%" height="15" fill="rgb(223,152,45)"/>
+            <text x="17.4363%" y="687.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpHeaders:.encode (1 samples, 0.08%)</title>
+            <rect x="17.2624%" y="677" width="0.0760%" height="15" fill="rgb(226,112,48)"/>
+            <text x="17.5124%" y="687.50"></text>
+        </g>
+        <g>
             <title>io/netty/buffer/AbstractByteBuf:.writeBytes (3 samples, 0.23%)</title>
             <rect x="17.4905%" y="661" width="0.2281%" height="15" fill="rgb(234,163,23)"/>
             <text x="17.7405%" y="671.50"></text>
@@ -394,6 +849,11 @@ var truncate_text_right = false;]]>
             <title>io/netty/buffer/PooledByteBufAllocator:.newDirectBuffer (2 samples, 0.15%)</title>
             <rect x="17.7186%" y="661" width="0.1521%" height="15" fill="rgb(226,202,13)"/>
             <text x="17.9686%" y="671.50"></text>
+        </g>
+        <g>
+            <title>java/lang/ThreadLocal:.get (1 samples, 0.08%)</title>
+            <rect x="17.7947%" y="645" width="0.0760%" height="15" fill="rgb(243,197,8)"/>
+            <text x="18.0447%" y="655.50"></text>
         </g>
         <g>
             <title>io/netty/buffer/AbstractByteBuf:.writeBytes (4 samples, 0.30%)</title>
@@ -426,14 +886,54 @@ var truncate_text_right = false;]]>
             <text x="17.5884%" y="687.50"></text>
         </g>
         <g>
+            <title>unsafe_arraycopy (1 samples, 0.08%)</title>
+            <rect x="18.5551%" y="661" width="0.0760%" height="15" fill="rgb(241,187,17)"/>
+            <text x="18.8051%" y="671.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpResponseEncoder:.acceptOutboundMessage (1 samples, 0.08%)</title>
+            <rect x="18.6312%" y="677" width="0.0760%" height="15" fill="rgb(226,35,6)"/>
+            <text x="18.8812%" y="687.50"></text>
+        </g>
+        <g>
+            <title>io/netty/util/Recycler:.get (1 samples, 0.08%)</title>
+            <rect x="18.7072%" y="677" width="0.0760%" height="15" fill="rgb(239,73,50)"/>
+            <text x="18.9572%" y="687.50"></text>
+        </g>
+        <g>
+            <title>java/lang/ThreadLocal:.get (1 samples, 0.08%)</title>
+            <rect x="18.7072%" y="661" width="0.0760%" height="15" fill="rgb(243,197,8)"/>
+            <text x="18.9572%" y="671.50"></text>
+        </g>
+        <g>
+            <title>io/netty/util/Recycler:.recycle (1 samples, 0.08%)</title>
+            <rect x="18.7833%" y="677" width="0.0760%" height="15" fill="rgb(230,202,48)"/>
+            <text x="19.0333%" y="687.50"></text>
+        </g>
+        <g>
             <title>io/netty/handler/codec/MessageToMessageEncoder:.write (31 samples, 2.36%)</title>
             <rect x="16.5779%" y="693" width="2.3574%" height="15" fill="rgb(212,25,37)"/>
             <text x="16.8279%" y="703.50">i..</text>
         </g>
         <g>
+            <title>java/lang/ThreadLocal:.get (1 samples, 0.08%)</title>
+            <rect x="18.8593%" y="677" width="0.0760%" height="15" fill="rgb(243,197,8)"/>
+            <text x="19.1093%" y="687.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpObjectEncoder:.encode (1 samples, 0.08%)</title>
+            <rect x="18.9354%" y="693" width="0.0760%" height="15" fill="rgb(249,126,13)"/>
+            <text x="19.1854%" y="703.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.write (33 samples, 2.51%)</title>
             <rect x="16.5779%" y="709" width="2.5095%" height="15" fill="rgb(228,161,40)"/>
             <text x="16.8279%" y="719.50">io..</text>
+        </g>
+        <g>
+            <title>io/netty/util/Recycler:.get (1 samples, 0.08%)</title>
+            <rect x="19.0114%" y="693" width="0.0760%" height="15" fill="rgb(239,73,50)"/>
+            <text x="19.2614%" y="703.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/NativeJavaMethod:.call (74 samples, 5.63%)</title>
@@ -461,6 +961,21 @@ var truncate_text_right = false;]]>
             <text x="16.8279%" y="735.50">or..</text>
         </g>
         <g>
+            <title>io/netty/handler/codec/MessageToMessageEncoder:.write (1 samples, 0.08%)</title>
+            <rect x="19.0875%" y="709" width="0.0760%" height="15" fill="rgb(212,25,37)"/>
+            <text x="19.3375%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/NativeJavaMethod:.findCachedFunction (1 samples, 0.08%)</title>
+            <rect x="19.1635%" y="789" width="0.0760%" height="15" fill="rgb(208,191,15)"/>
+            <text x="19.4135%" y="799.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.getPropFunctionAndThisHelper (1 samples, 0.08%)</title>
+            <rect x="19.2395%" y="789" width="0.0760%" height="15" fill="rgb(253,156,42)"/>
+            <text x="19.4895%" y="799.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/gen/file__root_vert_x_2_1_5_Server2_js_1:.call (79 samples, 6.01%)</title>
             <rect x="13.3840%" y="821" width="6.0076%" height="15" fill="rgb(235,213,43)"/>
             <text x="13.6340%" y="831.50">org/mozi..</text>
@@ -471,9 +986,59 @@ var truncate_text_right = false;]]>
             <text x="13.7861%" y="815.50">org/moz..</text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.nameOrFunction (1 samples, 0.08%)</title>
+            <rect x="19.3156%" y="789" width="0.0760%" height="15" fill="rgb(215,193,36)"/>
+            <text x="19.5656%" y="799.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="19.3156%" y="773" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="19.5656%" y="783.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="19.3156%" y="757" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="19.5656%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/BaseFunction:.construct (1 samples, 0.08%)</title>
+            <rect x="19.4677%" y="805" width="0.0760%" height="15" fill="rgb(212,208,51)"/>
+            <text x="19.7177%" y="815.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.bind (1 samples, 0.08%)</title>
+            <rect x="19.5437%" y="805" width="0.0760%" height="15" fill="rgb(229,167,49)"/>
+            <text x="19.7937%" y="815.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.getObjectProp (1 samples, 0.08%)</title>
+            <rect x="19.6198%" y="805" width="0.0760%" height="15" fill="rgb(228,205,19)"/>
+            <text x="19.8698%" y="815.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.setObjectProp (3 samples, 0.23%)</title>
             <rect x="19.6958%" y="805" width="0.2281%" height="15" fill="rgb(207,175,28)"/>
             <text x="19.9458%" y="815.50"></text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="20.3042%" y="789" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="20.5542%" y="799.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="21.1407%" y="709" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="21.3907%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="21.1407%" y="693" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="21.3907%" y="703.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="21.2928%" y="693" width="0.0760%" height="15" fill="rgb(242,102,17)"/>
+            <text x="21.5428%" y="703.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.put (7 samples, 0.53%)</title>
@@ -511,6 +1076,16 @@ var truncate_text_right = false;]]>
             <text x="21.9990%" y="703.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.getPropFunctionAndThisHelper (1 samples, 0.08%)</title>
+            <rect x="22.1293%" y="725" width="0.0760%" height="15" fill="rgb(253,156,42)"/>
+            <text x="22.3793%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="22.1293%" y="709" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="22.3793%" y="719.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.nameOrFunction (4 samples, 0.30%)</title>
             <rect x="22.2053%" y="725" width="0.3042%" height="15" fill="rgb(215,193,36)"/>
             <text x="22.4553%" y="735.50"></text>
@@ -524,6 +1099,21 @@ var truncate_text_right = false;]]>
             <title>org/mozilla/javascript/ScriptableObject:.getSlot (2 samples, 0.15%)</title>
             <rect x="22.3574%" y="693" width="0.1521%" height="15" fill="rgb(250,37,53)"/>
             <text x="22.6074%" y="703.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="22.5856%" y="709" width="0.0760%" height="15" fill="rgb(242,102,17)"/>
+            <text x="22.8356%" y="719.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="23.2700%" y="693" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="23.5200%" y="703.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="23.3460%" y="693" width="0.0760%" height="15" fill="rgb(242,102,17)"/>
+            <text x="23.5960%" y="703.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.has (12 samples, 0.91%)</title>
@@ -556,9 +1146,19 @@ var truncate_text_right = false;]]>
             <text x="23.9002%" y="671.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.putImpl (1 samples, 0.08%)</title>
+            <rect x="24.4867%" y="709" width="0.0760%" height="15" fill="rgb(228,137,18)"/>
+            <text x="24.7367%" y="719.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.setObjectProp (28 samples, 2.13%)</title>
             <rect x="22.5095%" y="725" width="2.1293%" height="15" fill="rgb(207,175,28)"/>
             <text x="22.7595%" y="735.50">o..</text>
+        </g>
+        <g>
+            <title>vtable stub (1 samples, 0.08%)</title>
+            <rect x="24.5627%" y="709" width="0.0760%" height="15" fill="rgb(252,215,54)"/>
+            <text x="24.8127%" y="719.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/ScriptRuntime:.toObjectOrNull (2 samples, 0.15%)</title>
@@ -571,6 +1171,11 @@ var truncate_text_right = false;]]>
             <text x="25.2690%" y="719.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/TopLevel:.getBuiltinPrototype (1 samples, 0.08%)</title>
+            <rect x="25.0951%" y="693" width="0.0760%" height="15" fill="rgb(231,91,7)"/>
+            <text x="25.3451%" y="703.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/BaseFunction:.execIdCall (60 samples, 4.56%)</title>
             <rect x="20.6844%" y="741" width="4.5627%" height="15" fill="rgb(235,36,7)"/>
             <text x="20.9344%" y="751.50">org/m..</text>
@@ -579,6 +1184,21 @@ var truncate_text_right = false;]]>
             <title>org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_vertx_lang_js_1_1_0_vertx_streams_j (6 samples, 0.46%)</title>
             <rect x="24.7909%" y="725" width="0.4563%" height="15" fill="rgb(216,68,4)"/>
             <text x="25.0409%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getParentScope (1 samples, 0.08%)</title>
+            <rect x="25.1711%" y="709" width="0.0760%" height="15" fill="rgb(247,182,52)"/>
+            <text x="25.4211%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.has (1 samples, 0.08%)</title>
+            <rect x="25.2471%" y="741" width="0.0760%" height="15" fill="rgb(227,183,52)"/>
+            <text x="25.4971%" y="751.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="25.4753%" y="725" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="25.7253%" y="735.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.put (9 samples, 0.68%)</title>
@@ -611,14 +1231,59 @@ var truncate_text_right = false;]]>
             <text x="26.4857%" y="735.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="26.6920%" y="709" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="26.9420%" y="719.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="26.6920%" y="693" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="26.9420%" y="703.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/NativeCall:.&lt;init&gt; (20 samples, 1.52%)</title>
             <rect x="25.3232%" y="741" width="1.5209%" height="15" fill="rgb(219,29,36)"/>
             <text x="25.5732%" y="751.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject$RelinkedSlot:.getValue (1 samples, 0.08%)</title>
+            <rect x="26.7681%" y="725" width="0.0760%" height="15" fill="rgb(243,100,16)"/>
+            <text x="27.0181%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.bind (1 samples, 0.08%)</title>
+            <rect x="26.8441%" y="741" width="0.0760%" height="15" fill="rgb(229,167,49)"/>
+            <text x="27.0941%" y="751.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getBase (1 samples, 0.08%)</title>
+            <rect x="26.8441%" y="725" width="0.0760%" height="15" fill="rgb(213,104,19)"/>
+            <text x="27.0941%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.has (1 samples, 0.08%)</title>
+            <rect x="26.8441%" y="709" width="0.0760%" height="15" fill="rgb(227,183,52)"/>
+            <text x="27.0941%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="26.8441%" y="693" width="0.0760%" height="15" fill="rgb(242,102,17)"/>
+            <text x="27.0941%" y="703.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/BaseFunction:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="26.9962%" y="725" width="0.0760%" height="15" fill="rgb(216,32,1)"/>
+            <text x="27.2462%" y="735.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/BaseFunction:.findInstanceIdInfo (4 samples, 0.30%)</title>
             <rect x="27.1483%" y="709" width="0.3042%" height="15" fill="rgb(216,32,1)"/>
             <text x="27.3983%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/BaseFunction:.findPrototypeId (1 samples, 0.08%)</title>
+            <rect x="27.4525%" y="709" width="0.0760%" height="15" fill="rgb(225,47,38)"/>
+            <text x="27.7025%" y="719.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/ScriptRuntime:.getPropFunctionAndThisHelper (9 samples, 0.68%)</title>
@@ -631,14 +1296,54 @@ var truncate_text_right = false;]]>
             <text x="27.3222%" y="735.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/IdScriptableObject$PrototypeValues:.ensureId (1 samples, 0.08%)</title>
+            <rect x="27.5285%" y="709" width="0.0760%" height="15" fill="rgb(213,167,51)"/>
+            <text x="27.7785%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="27.6046%" y="725" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="27.8546%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="27.6046%" y="709" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="27.8546%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject$RelinkedSlot:.getValue (1 samples, 0.08%)</title>
+            <rect x="27.6806%" y="725" width="0.0760%" height="15" fill="rgb(243,100,16)"/>
+            <text x="27.9306%" y="735.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.nameOrFunction (3 samples, 0.23%)</title>
             <rect x="27.6046%" y="741" width="0.2281%" height="15" fill="rgb(215,193,36)"/>
             <text x="27.8546%" y="751.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject$Slot:.getValue (1 samples, 0.08%)</title>
+            <rect x="27.7567%" y="725" width="0.0760%" height="15" fill="rgb(219,157,30)"/>
+            <text x="28.0067%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.has (1 samples, 0.08%)</title>
+            <rect x="27.8327%" y="725" width="0.0760%" height="15" fill="rgb(227,183,52)"/>
+            <text x="28.0827%" y="735.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.setName (2 samples, 0.15%)</title>
             <rect x="27.8327%" y="741" width="0.1521%" height="15" fill="rgb(220,114,50)"/>
             <text x="28.0827%" y="751.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.put (1 samples, 0.08%)</title>
+            <rect x="27.9087%" y="725" width="0.0760%" height="15" fill="rgb(205,227,21)"/>
+            <text x="28.1587%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.putImpl (1 samples, 0.08%)</title>
+            <rect x="27.9087%" y="709" width="0.0760%" height="15" fill="rgb(228,137,18)"/>
+            <text x="28.1587%" y="719.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.has (7 samples, 0.53%)</title>
@@ -649,6 +1354,21 @@ var truncate_text_right = false;]]>
             <title>org/mozilla/javascript/ScriptableObject:.getSlot (4 samples, 0.30%)</title>
             <rect x="28.5171%" y="709" width="0.3042%" height="15" fill="rgb(250,37,53)"/>
             <text x="28.7671%" y="719.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="28.8213%" y="709" width="0.0760%" height="15" fill="rgb(242,102,17)"/>
+            <text x="29.0713%" y="719.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="29.0494%" y="693" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="29.2994%" y="703.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.addKnownAbsentSlot (1 samples, 0.08%)</title>
+            <rect x="29.5057%" y="677" width="0.0760%" height="15" fill="rgb(217,137,9)"/>
+            <text x="29.7557%" y="687.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.put (25 samples, 1.90%)</title>
@@ -671,9 +1391,24 @@ var truncate_text_right = false;]]>
             <text x="29.8317%" y="687.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.addKnownAbsentSlot (1 samples, 0.08%)</title>
+            <rect x="30.6464%" y="661" width="0.0760%" height="15" fill="rgb(217,137,9)"/>
+            <text x="30.8964%" y="671.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.setObjectProp (37 samples, 2.81%)</title>
             <rect x="27.9848%" y="741" width="2.8137%" height="15" fill="rgb(207,175,28)"/>
             <text x="28.2348%" y="751.50">or..</text>
+        </g>
+        <g>
+            <title>vtable stub (1 samples, 0.08%)</title>
+            <rect x="30.7224%" y="725" width="0.0760%" height="15" fill="rgb(252,215,54)"/>
+            <text x="30.9724%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.toObjectOrNull (1 samples, 0.08%)</title>
+            <rect x="30.7985%" y="741" width="0.0760%" height="15" fill="rgb(249,136,46)"/>
+            <text x="31.0485%" y="751.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/NativeFunction:.initScriptFunction (6 samples, 0.46%)</title>
@@ -716,9 +1451,39 @@ var truncate_text_right = false;]]>
             <text x="20.7823%" y="767.50">org/mozilla/javas..</text>
         </g>
         <g>
+            <title>org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_vertx_lang_js_1_1_0_vertx_streams_j (1 samples, 0.08%)</title>
+            <rect x="32.1673%" y="741" width="0.0760%" height="15" fill="rgb(216,68,4)"/>
+            <text x="32.4173%" y="751.50"></text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="32.5475%" y="773" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="32.7975%" y="783.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/IdScriptableObject:.get (2 samples, 0.15%)</title>
             <rect x="32.6236%" y="773" width="0.1521%" height="15" fill="rgb(242,197,6)"/>
             <text x="32.8736%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="33.0038%" y="757" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="33.2538%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="33.0038%" y="741" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="33.2538%" y="751.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="33.0038%" y="725" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="33.2538%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.has (1 samples, 0.08%)</title>
+            <rect x="33.0798%" y="757" width="0.0760%" height="15" fill="rgb(227,183,52)"/>
+            <text x="33.3298%" y="767.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.put (6 samples, 0.46%)</title>
@@ -751,9 +1516,44 @@ var truncate_text_right = false;]]>
             <text x="33.8622%" y="767.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="33.8403%" y="741" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="34.0903%" y="751.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="33.8403%" y="725" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="34.0903%" y="735.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/NativeCall:.&lt;init&gt; (16 samples, 1.22%)</title>
             <rect x="32.7757%" y="773" width="1.2167%" height="15" fill="rgb(219,29,36)"/>
             <text x="33.0257%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/TopLevel:.getBuiltinPrototype (1 samples, 0.08%)</title>
+            <rect x="33.9163%" y="757" width="0.0760%" height="15" fill="rgb(231,91,7)"/>
+            <text x="34.1663%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/NativeFunction:.initScriptFunction (1 samples, 0.08%)</title>
+            <rect x="33.9924%" y="773" width="0.0760%" height="15" fill="rgb(234,89,44)"/>
+            <text x="34.2424%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.getPropFunctionAndThisHelper (1 samples, 0.08%)</title>
+            <rect x="34.0684%" y="773" width="0.0760%" height="15" fill="rgb(253,156,42)"/>
+            <text x="34.3184%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.nameOrFunction (1 samples, 0.08%)</title>
+            <rect x="34.1445%" y="773" width="0.0760%" height="15" fill="rgb(215,193,36)"/>
+            <text x="34.3945%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="34.1445%" y="757" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="34.3945%" y="767.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.has (9 samples, 0.68%)</title>
@@ -764,6 +1564,21 @@ var truncate_text_right = false;]]>
             <title>org/mozilla/javascript/ScriptableObject:.getSlot (3 samples, 0.23%)</title>
             <rect x="34.6768%" y="741" width="0.2281%" height="15" fill="rgb(250,37,53)"/>
             <text x="34.9268%" y="751.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="34.8289%" y="725" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="35.0789%" y="735.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (1 samples, 0.08%)</title>
+            <rect x="34.9049%" y="741" width="0.0760%" height="15" fill="rgb(242,102,17)"/>
+            <text x="35.1549%" y="751.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="35.0570%" y="725" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="35.3070%" y="735.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.put (11 samples, 0.84%)</title>
@@ -791,9 +1606,24 @@ var truncate_text_right = false;]]>
             <text x="34.4705%" y="783.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="35.7414%" y="757" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="35.9914%" y="767.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/BaseFunction:.execIdCall (48 samples, 3.65%)</title>
             <rect x="32.2433%" y="789" width="3.6502%" height="15" fill="rgb(235,36,7)"/>
             <text x="32.4933%" y="799.50">org/..</text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_vertx_lang_js_1_1_0_vertx_streams_j (1 samples, 0.08%)</title>
+            <rect x="35.8175%" y="773" width="0.0760%" height="15" fill="rgb(216,68,4)"/>
+            <text x="36.0675%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/NativeFunction:.initScriptFunction (1 samples, 0.08%)</title>
+            <rect x="35.8175%" y="757" width="0.0760%" height="15" fill="rgb(234,89,44)"/>
+            <text x="36.0675%" y="767.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.has (3 samples, 0.23%)</title>
@@ -801,9 +1631,19 @@ var truncate_text_right = false;]]>
             <text x="36.1435%" y="799.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.setAttributes (1 samples, 0.08%)</title>
+            <rect x="36.1217%" y="789" width="0.0760%" height="15" fill="rgb(247,93,34)"/>
+            <text x="36.3717%" y="799.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/IdScriptableObject:.get (3 samples, 0.23%)</title>
             <rect x="36.5019%" y="773" width="0.2281%" height="15" fill="rgb(242,197,6)"/>
             <text x="36.7519%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="36.6540%" y="757" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="36.9040%" y="767.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.has (4 samples, 0.30%)</title>
@@ -814,6 +1654,16 @@ var truncate_text_right = false;]]>
             <title>org/mozilla/javascript/ScriptableObject:.getSlot (2 samples, 0.15%)</title>
             <rect x="36.8821%" y="757" width="0.1521%" height="15" fill="rgb(250,37,53)"/>
             <text x="37.1321%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="37.1103%" y="757" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="37.3603%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.addKnownAbsentSlot (1 samples, 0.08%)</title>
+            <rect x="37.5665%" y="725" width="0.0760%" height="15" fill="rgb(217,137,9)"/>
+            <text x="37.8165%" y="735.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.put (23 samples, 1.75%)</title>
@@ -836,6 +1686,11 @@ var truncate_text_right = false;]]>
             <text x="37.8926%" y="735.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.addKnownAbsentSlot (1 samples, 0.08%)</title>
+            <rect x="38.7072%" y="709" width="0.0760%" height="15" fill="rgb(217,137,9)"/>
+            <text x="38.9572%" y="719.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/IdScriptableObject:.setAttributes (12 samples, 0.91%)</title>
             <rect x="38.7833%" y="773" width="0.9125%" height="15" fill="rgb(247,93,34)"/>
             <text x="39.0333%" y="783.50"></text>
@@ -846,14 +1701,29 @@ var truncate_text_right = false;]]>
             <text x="39.0333%" y="767.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="39.6958%" y="773" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="39.9458%" y="783.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/NativeCall:.&lt;init&gt; (48 samples, 3.65%)</title>
             <rect x="36.1977%" y="789" width="3.6502%" height="15" fill="rgb(219,29,36)"/>
             <text x="36.4477%" y="799.50">org/..</text>
         </g>
         <g>
+            <title>org/mozilla/javascript/TopLevel:.getBuiltinPrototype (1 samples, 0.08%)</title>
+            <rect x="39.7719%" y="773" width="0.0760%" height="15" fill="rgb(231,91,7)"/>
+            <text x="40.0219%" y="783.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/NativeJavaMethod:.findFunction (2 samples, 0.15%)</title>
             <rect x="40.0000%" y="773" width="0.1521%" height="15" fill="rgb(208,158,6)"/>
             <text x="40.2500%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/NativeJavaObject:.initMembers (1 samples, 0.08%)</title>
+            <rect x="40.1521%" y="773" width="0.0760%" height="15" fill="rgb(230,172,54)"/>
+            <text x="40.4021%" y="783.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/NativeJavaMethod:.call (10 samples, 0.76%)</title>
@@ -881,9 +1751,24 @@ var truncate_text_right = false;]]>
             <text x="40.8584%" y="799.50"></text>
         </g>
         <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="40.9125%" y="773" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="41.1625%" y="783.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="41.0646%" y="741" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="41.3146%" y="751.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/IdScriptableObject:.has (3 samples, 0.23%)</title>
             <rect x="40.9886%" y="757" width="0.2281%" height="15" fill="rgb(227,183,52)"/>
             <text x="41.2386%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="41.1407%" y="741" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="41.3907%" y="751.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/ScriptRuntime:.bind (7 samples, 0.53%)</title>
@@ -896,6 +1781,26 @@ var truncate_text_right = false;]]>
             <text x="41.2386%" y="783.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="41.2167%" y="757" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="41.4667%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="41.3688%" y="773" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="41.6188%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="41.3688%" y="757" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="41.6188%" y="767.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="41.3688%" y="741" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="41.6188%" y="751.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.getObjectProp (4 samples, 0.30%)</title>
             <rect x="41.2928%" y="789" width="0.3042%" height="15" fill="rgb(228,205,19)"/>
             <text x="41.5428%" y="799.50"></text>
@@ -906,9 +1811,44 @@ var truncate_text_right = false;]]>
             <text x="41.6949%" y="783.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/IdScriptableObject:.get (1 samples, 0.08%)</title>
+            <rect x="41.7490%" y="773" width="0.0760%" height="15" fill="rgb(242,197,6)"/>
+            <text x="41.9990%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/BaseFunction:.findPrototypeId (1 samples, 0.08%)</title>
+            <rect x="41.7490%" y="757" width="0.0760%" height="15" fill="rgb(225,47,38)"/>
+            <text x="41.9990%" y="767.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/NativeJavaObject:.get (1 samples, 0.08%)</title>
+            <rect x="41.8251%" y="773" width="0.0760%" height="15" fill="rgb(226,78,13)"/>
+            <text x="42.0751%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/JavaMembers:.get (1 samples, 0.08%)</title>
+            <rect x="41.8251%" y="757" width="0.0760%" height="15" fill="rgb(213,78,31)"/>
+            <text x="42.0751%" y="767.50"></text>
+        </g>
+        <g>
+            <title>java/util/HashMap:.getNode (1 samples, 0.08%)</title>
+            <rect x="41.8251%" y="741" width="0.0760%" height="15" fill="rgb(235,72,14)"/>
+            <text x="42.0751%" y="751.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/ScriptRuntime:.getPropFunctionAndThisHelper (5 samples, 0.38%)</title>
             <rect x="41.5970%" y="789" width="0.3802%" height="15" fill="rgb(253,156,42)"/>
             <text x="41.8470%" y="799.50"></text>
+        </g>
+        <g>
+            <title>vtable stub (1 samples, 0.08%)</title>
+            <rect x="41.9011%" y="773" width="0.0760%" height="15" fill="rgb(252,215,54)"/>
+            <text x="42.1511%" y="783.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="42.0532%" y="757" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="42.3032%" y="767.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/ScriptRuntime:.nameOrFunction (5 samples, 0.38%)</title>
@@ -956,6 +1896,11 @@ var truncate_text_right = false;]]>
             <text x="42.8356%" y="767.50"></text>
         </g>
         <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="42.6616%" y="741" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="42.9116%" y="751.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/IdScriptableObject:.findInstanceIdInfo (2 samples, 0.15%)</title>
             <rect x="43.1939%" y="773" width="0.1521%" height="15" fill="rgb(242,102,17)"/>
             <text x="43.4439%" y="783.50"></text>
@@ -971,9 +1916,19 @@ var truncate_text_right = false;]]>
             <text x="45.2690%" y="767.50"></text>
         </g>
         <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="45.5513%" y="741" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="45.8013%" y="751.50"></text>
+        </g>
+        <g>
             <title>java/lang/String:.hashCode (2 samples, 0.15%)</title>
             <rect x="46.0076%" y="741" width="0.1521%" height="15" fill="rgb(220,81,20)"/>
             <text x="46.2576%" y="751.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.addKnownAbsentSlot (1 samples, 0.08%)</title>
+            <rect x="46.6160%" y="725" width="0.0760%" height="15" fill="rgb(217,137,9)"/>
+            <text x="46.8660%" y="735.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/IdScriptableObject:.put (47 samples, 3.57%)</title>
@@ -1004,6 +1959,21 @@ var truncate_text_right = false;]]>
             <title>org/mozilla/javascript/ScriptRuntime:.setObjectProp (86 samples, 6.54%)</title>
             <rect x="42.7376%" y="789" width="6.5399%" height="15" fill="rgb(207,175,28)"/>
             <text x="42.9876%" y="799.50">org/mozil..</text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getSlot (1 samples, 0.08%)</title>
+            <rect x="49.2015%" y="773" width="0.0760%" height="15" fill="rgb(250,37,53)"/>
+            <text x="49.4515%" y="783.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptRuntime:.toObjectOrNull (1 samples, 0.08%)</title>
+            <rect x="49.2776%" y="789" width="0.0760%" height="15" fill="rgb(249,136,46)"/>
+            <text x="49.5276%" y="799.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/ScriptableObject:.getPrototype (1 samples, 0.08%)</title>
+            <rect x="49.3536%" y="789" width="0.0760%" height="15" fill="rgb(218,63,46)"/>
+            <text x="49.6036%" y="799.50"></text>
         </g>
         <g>
             <title>org/mozilla/javascript/NativeFunction:.initScriptFunction (10 samples, 0.76%)</title>
@@ -1041,6 +2011,11 @@ var truncate_text_right = false;]]>
             <text x="20.1740%" y="815.50">org/mozilla/javascript/gen/file__root_vert_x_2_1_5..</text>
         </g>
         <g>
+            <title>org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_vertx_lang_js_1_1_0_vertx_streams_j (1 samples, 0.08%)</title>
+            <rect x="50.9506%" y="789" width="0.0760%" height="15" fill="rgb(216,68,4)"/>
+            <text x="51.2006%" y="799.50"></text>
+        </g>
+        <g>
             <title>org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_vertx_lang_js_1_1_0_vertx_http_js_2 (513 samples, 39.01%)</title>
             <rect x="12.0913%" y="853" width="39.0114%" height="15" fill="rgb(227,113,6)"/>
             <text x="12.3413%" y="863.50">org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_v..</text>
@@ -1051,14 +2026,39 @@ var truncate_text_right = false;]]>
             <text x="12.4933%" y="847.50">org/mozilla/javascript/gen/file__root_vert_x_2_1_5_sys_mods_io_..</text>
         </g>
         <g>
+            <title>vtable stub (1 samples, 0.08%)</title>
+            <rect x="51.0266%" y="821" width="0.0760%" height="15" fill="rgb(252,215,54)"/>
+            <text x="51.2766%" y="831.50"></text>
+        </g>
+        <g>
             <title>org/vertx/java/core/http/impl/ServerConnection:.handleRequest (526 samples, 40.00%)</title>
             <rect x="11.1787%" y="869" width="40.0000%" height="15" fill="rgb(239,140,22)"/>
             <text x="11.4287%" y="879.50">org/vertx/java/core/http/impl/ServerConnection:.handleRequest</text>
         </g>
         <g>
+            <title>org/vertx/java/platform/impl/RhinoContextFactory:.onContextCreated (1 samples, 0.08%)</title>
+            <rect x="51.1027%" y="853" width="0.0760%" height="15" fill="rgb(228,146,48)"/>
+            <text x="51.3527%" y="863.50"></text>
+        </g>
+        <g>
+            <title>org/mozilla/javascript/WrapFactory:.setJavaPrimitiveWrap (1 samples, 0.08%)</title>
+            <rect x="51.1027%" y="837" width="0.0760%" height="15" fill="rgb(250,5,2)"/>
+            <text x="51.3527%" y="847.50"></text>
+        </g>
+        <g>
+            <title>java/lang/ThreadLocal:.get (1 samples, 0.08%)</title>
+            <rect x="51.1027%" y="821" width="0.0760%" height="15" fill="rgb(243,197,8)"/>
+            <text x="51.3527%" y="831.50"></text>
+        </g>
+        <g>
             <title>org/vertx/java/core/http/impl/DefaultHttpServer$ServerHandler:.doMessageReceived (540 samples, 41.06%)</title>
             <rect x="10.1901%" y="885" width="41.0646%" height="15" fill="rgb(245,124,16)"/>
             <text x="10.4401%" y="895.50">org/vertx/java/core/http/impl/DefaultHttpServer$ServerHandler:.doMe..</text>
+        </g>
+        <g>
+            <title>org/vertx/java/core/impl/DefaultVertx:.setContext (1 samples, 0.08%)</title>
+            <rect x="51.1787%" y="869" width="0.0760%" height="15" fill="rgb(222,45,12)"/>
+            <text x="51.4287%" y="879.50"></text>
         </g>
         <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.fireChannelRead (562 samples, 42.74%)</title>
@@ -1071,6 +2071,11 @@ var truncate_text_right = false;]]>
             <text x="9.3755%" y="911.50">org/vertx/java/core/net/impl/VertxHandler:.channelRead</text>
         </g>
         <g>
+            <title>org/vertx/java/core/impl/DefaultVertx:.setContext (1 samples, 0.08%)</title>
+            <rect x="51.2548%" y="885" width="0.0760%" height="15" fill="rgb(222,45,12)"/>
+            <text x="51.5048%" y="895.50"></text>
+        </g>
+        <g>
             <title>io/netty/handler/codec/http/HttpMethod:.valueOf (2 samples, 0.15%)</title>
             <rect x="51.3308%" y="917" width="0.1521%" height="15" fill="rgb(223,176,18)"/>
             <text x="51.5808%" y="927.50"></text>
@@ -1081,6 +2086,11 @@ var truncate_text_right = false;]]>
             <text x="51.9610%" y="911.50"></text>
         </g>
         <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="51.8631%" y="901" width="0.0760%" height="15" fill="rgb(219,199,7)"/>
+            <text x="52.1131%" y="911.50"></text>
+        </g>
+        <g>
             <title>io/netty/handler/codec/http/DefaultHttpHeaders:.add0 (3 samples, 0.23%)</title>
             <rect x="51.9392%" y="901" width="0.2281%" height="15" fill="rgb(244,147,33)"/>
             <text x="52.1892%" y="911.50"></text>
@@ -1089,6 +2099,11 @@ var truncate_text_right = false;]]>
             <title>io/netty/handler/codec/http/DefaultHttpMessage:.&lt;init&gt; (2 samples, 0.15%)</title>
             <rect x="52.1673%" y="901" width="0.1521%" height="15" fill="rgb(253,199,45)"/>
             <text x="52.4173%" y="911.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="52.2433%" y="885" width="0.0760%" height="15" fill="rgb(219,199,7)"/>
+            <text x="52.4933%" y="895.50"></text>
         </g>
         <g>
             <title>io/netty/handler/codec/http/HttpHeaders:.hash (4 samples, 0.30%)</title>
@@ -1104,6 +2119,11 @@ var truncate_text_right = false;]]>
             <title>java/util/HashMap:.getNode (2 samples, 0.15%)</title>
             <rect x="52.6236%" y="885" width="0.1521%" height="15" fill="rgb(235,72,14)"/>
             <text x="52.8736%" y="895.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.equals (1 samples, 0.08%)</title>
+            <rect x="52.6996%" y="869" width="0.0760%" height="15" fill="rgb(235,208,52)"/>
+            <text x="52.9496%" y="879.50"></text>
         </g>
         <g>
             <title>io/netty/handler/codec/http/HttpObjectDecoder$LineParser:.parse (6 samples, 0.46%)</title>
@@ -1126,9 +2146,29 @@ var truncate_text_right = false;]]>
             <text x="54.0903%" y="895.50"></text>
         </g>
         <g>
+            <title>io/netty/handler/codec/http/DefaultHttpHeaders:.contains (1 samples, 0.08%)</title>
+            <rect x="53.9924%" y="885" width="0.0760%" height="15" fill="rgb(223,152,45)"/>
+            <text x="54.2424%" y="895.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpHeaders:.hash (1 samples, 0.08%)</title>
+            <rect x="53.9924%" y="869" width="0.0760%" height="15" fill="rgb(232,1,32)"/>
+            <text x="54.2424%" y="879.50"></text>
+        </g>
+        <g>
             <title>io/netty/handler/codec/http/HttpHeaders:.hash (2 samples, 0.15%)</title>
             <rect x="54.0684%" y="885" width="0.1521%" height="15" fill="rgb(232,1,32)"/>
             <text x="54.3184%" y="895.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpObjectDecoder$HeaderParser:.process (1 samples, 0.08%)</title>
+            <rect x="54.2205%" y="885" width="0.0760%" height="15" fill="rgb(235,189,7)"/>
+            <text x="54.4705%" y="895.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpObjectDecoder:.findNonWhitespace (1 samples, 0.08%)</title>
+            <rect x="54.5247%" y="869" width="0.0760%" height="15" fill="rgb(254,85,31)"/>
+            <text x="54.7747%" y="879.50"></text>
         </g>
         <g>
             <title>io/netty/handler/codec/http/HttpObjectDecoder:.readHeaders (22 samples, 1.67%)</title>
@@ -1156,9 +2196,24 @@ var truncate_text_right = false;]]>
             <text x="55.1549%" y="911.50"></text>
         </g>
         <g>
+            <title>io/netty/buffer/AbstractByteBuf:.getByte (1 samples, 0.08%)</title>
+            <rect x="54.9810%" y="885" width="0.0760%" height="15" fill="rgb(214,103,0)"/>
+            <text x="55.2310%" y="895.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpObjectDecoder:.findWhitespace (1 samples, 0.08%)</title>
+            <rect x="55.1331%" y="885" width="0.0760%" height="15" fill="rgb(211,74,5)"/>
+            <text x="55.3831%" y="895.50"></text>
+        </g>
+        <g>
             <title>io/netty/util/internal/AppendableCharSequence:.substring (2 samples, 0.15%)</title>
             <rect x="55.2091%" y="885" width="0.1521%" height="15" fill="rgb(222,41,34)"/>
             <text x="55.4591%" y="895.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="55.2852%" y="869" width="0.0760%" height="15" fill="rgb(232,108,30)"/>
+            <text x="55.5352%" y="879.50"></text>
         </g>
         <g>
             <title>io/netty/handler/codec/http/HttpObjectDecoder:.splitInitialLine (5 samples, 0.38%)</title>
@@ -1166,9 +2221,24 @@ var truncate_text_right = false;]]>
             <text x="55.3070%" y="911.50"></text>
         </g>
         <g>
+            <title>java/lang/String:.&lt;init&gt; (1 samples, 0.08%)</title>
+            <rect x="55.3612%" y="885" width="0.0760%" height="15" fill="rgb(232,108,30)"/>
+            <text x="55.6112%" y="895.50"></text>
+        </g>
+        <g>
             <title>io/netty/util/internal/AppendableCharSequence:.substring (2 samples, 0.15%)</title>
             <rect x="55.4373%" y="901" width="0.1521%" height="15" fill="rgb(222,41,34)"/>
             <text x="55.6873%" y="911.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.hashCode (1 samples, 0.08%)</title>
+            <rect x="55.5894%" y="901" width="0.0760%" height="15" fill="rgb(220,81,20)"/>
+            <text x="55.8394%" y="911.50"></text>
+        </g>
+        <g>
+            <title>java/lang/String:.trim (1 samples, 0.08%)</title>
+            <rect x="55.6654%" y="901" width="0.0760%" height="15" fill="rgb(247,220,30)"/>
+            <text x="55.9154%" y="911.50"></text>
         </g>
         <g>
             <title>io/netty/handler/codec/http/HttpObjectDecoder:.decode (57 samples, 4.33%)</title>
@@ -1176,9 +2246,24 @@ var truncate_text_right = false;]]>
             <text x="51.7329%" y="927.50">io/ne..</text>
         </g>
         <g>
+            <title>java/util/ArrayList:.ensureCapacityInternal (1 samples, 0.08%)</title>
+            <rect x="55.7414%" y="901" width="0.0760%" height="15" fill="rgb(243,132,43)"/>
+            <text x="55.9914%" y="911.50"></text>
+        </g>
+        <g>
             <title>io/netty/handler/codec/http/HttpObjectDecoder:.readHeaders (2 samples, 0.15%)</title>
             <rect x="55.8175%" y="917" width="0.1521%" height="15" fill="rgb(222,216,49)"/>
             <text x="56.0675%" y="927.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/http/HttpObjectDecoder:.skipControlCharacters (1 samples, 0.08%)</title>
+            <rect x="55.9696%" y="917" width="0.0760%" height="15" fill="rgb(252,149,8)"/>
+            <text x="56.2196%" y="927.50"></text>
+        </g>
+        <g>
+            <title>io/netty/util/Recycler:.get (1 samples, 0.08%)</title>
+            <rect x="56.0456%" y="917" width="0.0760%" height="15" fill="rgb(239,73,50)"/>
+            <text x="56.2956%" y="927.50"></text>
         </g>
         <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.fireChannelRead (637 samples, 48.44%)</title>
@@ -1189,6 +2274,21 @@ var truncate_text_right = false;]]>
             <title>io/netty/handler/codec/ByteToMessageDecoder:.channelRead (635 samples, 48.29%)</title>
             <rect x="7.9087%" y="933" width="48.2890%" height="15" fill="rgb(212,10,46)"/>
             <text x="8.1587%" y="943.50">io/netty/handler/codec/ByteToMessageDecoder:.channelRead</text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="56.1217%" y="917" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="56.3717%" y="927.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.flush (1 samples, 0.08%)</title>
+            <rect x="56.1977%" y="901" width="0.0760%" height="15" fill="rgb(239,217,31)"/>
+            <text x="56.4477%" y="911.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/ChannelOutboundBuffer:.current (1 samples, 0.08%)</title>
+            <rect x="56.4259%" y="789" width="0.0760%" height="15" fill="rgb(215,56,46)"/>
+            <text x="56.6759%" y="799.50"></text>
         </g>
         <g>
             <title>io/netty/channel/ChannelOutboundBuffer:.decrementPendingOutboundBytes (2 samples, 0.15%)</title>
@@ -1206,6 +2306,16 @@ var truncate_text_right = false;]]>
             <text x="57.2082%" y="767.50"></text>
         </g>
         <g>
+            <title>io/netty/channel/ChannelOutboundBuffer:.decrementPendingOutboundBytes (1 samples, 0.08%)</title>
+            <rect x="57.3384%" y="773" width="0.0760%" height="15" fill="rgb(230,208,17)"/>
+            <text x="57.5884%" y="783.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/ChannelOutboundBuffer:.progress (1 samples, 0.08%)</title>
+            <rect x="57.4144%" y="773" width="0.0760%" height="15" fill="rgb(213,192,25)"/>
+            <text x="57.6644%" y="783.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/DefaultChannelPromise:.trySuccess (3 samples, 0.23%)</title>
             <rect x="57.4905%" y="773" width="0.2281%" height="15" fill="rgb(243,11,29)"/>
             <text x="57.7405%" y="783.50"></text>
@@ -1216,14 +2326,64 @@ var truncate_text_right = false;]]>
             <text x="57.9686%" y="783.50"></text>
         </g>
         <g>
+            <title>java/nio/channels/spi/AbstractInterruptibleChannel:.begin (1 samples, 0.08%)</title>
+            <rect x="58.0228%" y="757" width="0.0760%" height="15" fill="rgb(232,51,37)"/>
+            <text x="58.2728%" y="767.50"></text>
+        </g>
+        <g>
+            <title>java/nio/channels/spi/AbstractInterruptibleChannel:.end (1 samples, 0.08%)</title>
+            <rect x="58.0989%" y="757" width="0.0760%" height="15" fill="rgb(243,89,12)"/>
+            <text x="58.3489%" y="767.50"></text>
+        </g>
+        <g>
+            <title>pthread_self (1 samples, 0.08%)</title>
+            <rect x="58.1749%" y="757" width="0.0760%" height="15" fill="rgb(240,125,22)"/>
+            <text x="58.4249%" y="767.50"></text>
+        </g>
+        <g>
+            <title>Java_sun_nio_ch_FileDispatcherImpl_write0 (1 samples, 0.08%)</title>
+            <rect x="58.4030%" y="741" width="0.0760%" height="15" fill="rgb(253,10,48)"/>
+            <text x="58.6530%" y="751.50"></text>
+        </g>
+        <g>
+            <title>fdval (1 samples, 0.08%)</title>
+            <rect x="58.4030%" y="725" width="0.0760%" height="15" fill="rgb(205,213,24)"/>
+            <text x="58.6530%" y="735.50"></text>
+        </g>
+        <g>
+            <title>fput (1 samples, 0.08%)</title>
+            <rect x="58.5551%" y="709" width="0.0760%" height="15" fill="rgb(251,219,26)"/>
+            <text x="58.8051%" y="719.50"></text>
+        </g>
+        <g>
             <title>fget_light (2 samples, 0.15%)</title>
             <rect x="58.6312%" y="693" width="0.1521%" height="15" fill="rgb(223,107,44)"/>
             <text x="58.8812%" y="703.50"></text>
         </g>
         <g>
+            <title>fput (1 samples, 0.08%)</title>
+            <rect x="58.7833%" y="693" width="0.0760%" height="15" fill="rgb(251,219,26)"/>
+            <text x="59.0333%" y="703.50"></text>
+        </g>
+        <g>
+            <title>__fsnotify_parent (1 samples, 0.08%)</title>
+            <rect x="59.0114%" y="677" width="0.0760%" height="15" fill="rgb(233,25,34)"/>
+            <text x="59.2614%" y="687.50"></text>
+        </g>
+        <g>
             <title>__srcu_read_lock (2 samples, 0.15%)</title>
             <rect x="59.0875%" y="677" width="0.1521%" height="15" fill="rgb(213,36,15)"/>
             <text x="59.3375%" y="687.50"></text>
+        </g>
+        <g>
+            <title>inet_sendmsg (1 samples, 0.08%)</title>
+            <rect x="59.2395%" y="661" width="0.0760%" height="15" fill="rgb(253,188,10)"/>
+            <text x="59.4895%" y="671.50"></text>
+        </g>
+        <g>
+            <title>apparmor_socket_sendmsg (1 samples, 0.08%)</title>
+            <rect x="59.3916%" y="645" width="0.0760%" height="15" fill="rgb(205,172,47)"/>
+            <text x="59.6416%" y="655.50"></text>
         </g>
         <g>
             <title>call_function_single_interrupt (4 samples, 0.30%)</title>
@@ -1281,6 +2441,21 @@ var truncate_text_right = false;]]>
             <text x="59.7177%" y="495.50"></text>
         </g>
         <g>
+            <title>msecs_to_jiffies (1 samples, 0.08%)</title>
+            <rect x="60.7605%" y="581" width="0.0760%" height="15" fill="rgb(243,13,19)"/>
+            <text x="61.0105%" y="591.50"></text>
+        </g>
+        <g>
+            <title>skb_push (1 samples, 0.08%)</title>
+            <rect x="60.8365%" y="581" width="0.0760%" height="15" fill="rgb(243,75,47)"/>
+            <text x="61.0865%" y="591.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock (1 samples, 0.08%)</title>
+            <rect x="61.2167%" y="517" width="0.0760%" height="15" fill="rgb(239,227,41)"/>
+            <text x="61.4667%" y="527.50"></text>
+        </g>
+        <g>
             <title>tcp_event_new_data_sent (6 samples, 0.46%)</title>
             <rect x="60.9125%" y="581" width="0.4563%" height="15" fill="rgb(243,147,20)"/>
             <text x="61.1625%" y="591.50"></text>
@@ -1301,6 +2476,31 @@ var truncate_text_right = false;]]>
             <text x="61.2386%" y="543.50"></text>
         </g>
         <g>
+            <title>_raw_spin_unlock_irqrestore (1 samples, 0.08%)</title>
+            <rect x="61.2928%" y="517" width="0.0760%" height="15" fill="rgb(215,4,12)"/>
+            <text x="61.5428%" y="527.50"></text>
+        </g>
+        <g>
+            <title>tcp_init_tso_segs (1 samples, 0.08%)</title>
+            <rect x="61.3688%" y="581" width="0.0760%" height="15" fill="rgb(254,208,16)"/>
+            <text x="61.6188%" y="591.50"></text>
+        </g>
+        <g>
+            <title>tcp_set_skb_tso_segs (1 samples, 0.08%)</title>
+            <rect x="61.3688%" y="565" width="0.0760%" height="15" fill="rgb(251,183,2)"/>
+            <text x="61.6188%" y="575.50"></text>
+        </g>
+        <g>
+            <title>internal_add_timer (1 samples, 0.08%)</title>
+            <rect x="61.5209%" y="533" width="0.0760%" height="15" fill="rgb(214,113,41)"/>
+            <text x="61.7709%" y="543.50"></text>
+        </g>
+        <g>
+            <title>__internal_add_timer (1 samples, 0.08%)</title>
+            <rect x="61.5209%" y="517" width="0.0760%" height="15" fill="rgb(241,204,17)"/>
+            <text x="61.7709%" y="527.50"></text>
+        </g>
+        <g>
             <title>tcp_schedule_loss_probe (3 samples, 0.23%)</title>
             <rect x="61.4449%" y="581" width="0.2281%" height="15" fill="rgb(222,137,53)"/>
             <text x="61.6949%" y="591.50"></text>
@@ -1316,9 +2516,39 @@ var truncate_text_right = false;]]>
             <text x="61.7709%" y="559.50"></text>
         </g>
         <g>
+            <title>lock_timer_base.isra.35 (1 samples, 0.08%)</title>
+            <rect x="61.5970%" y="533" width="0.0760%" height="15" fill="rgb(221,152,40)"/>
+            <text x="61.8470%" y="543.50"></text>
+        </g>
+        <g>
+            <title>__dev_queue_xmit (1 samples, 0.08%)</title>
+            <rect x="62.2814%" y="501" width="0.0760%" height="15" fill="rgb(216,173,24)"/>
+            <text x="62.5314%" y="511.50"></text>
+        </g>
+        <g>
+            <title>eth_type_trans (1 samples, 0.08%)</title>
+            <rect x="62.6616%" y="437" width="0.0760%" height="15" fill="rgb(239,73,12)"/>
+            <text x="62.9116%" y="447.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock (1 samples, 0.08%)</title>
+            <rect x="62.7376%" y="421" width="0.0760%" height="15" fill="rgb(239,227,41)"/>
+            <text x="62.9876%" y="431.50"></text>
+        </g>
+        <g>
             <title>netif_rx (2 samples, 0.15%)</title>
             <rect x="62.7376%" y="437" width="0.1521%" height="15" fill="rgb(244,4,26)"/>
             <text x="62.9876%" y="447.50"></text>
+        </g>
+        <g>
+            <title>enqueue_to_backlog (1 samples, 0.08%)</title>
+            <rect x="62.8137%" y="421" width="0.0760%" height="15" fill="rgb(224,171,40)"/>
+            <text x="63.0637%" y="431.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock (1 samples, 0.08%)</title>
+            <rect x="62.8137%" y="405" width="0.0760%" height="15" fill="rgb(239,227,41)"/>
+            <text x="63.0637%" y="415.50"></text>
         </g>
         <g>
             <title>loopback_xmit (5 samples, 0.38%)</title>
@@ -1331,6 +2561,11 @@ var truncate_text_right = false;]]>
             <text x="63.1397%" y="447.50"></text>
         </g>
         <g>
+            <title>sock_wfree (1 samples, 0.08%)</title>
+            <rect x="62.9658%" y="421" width="0.0760%" height="15" fill="rgb(250,21,39)"/>
+            <text x="63.2158%" y="431.50"></text>
+        </g>
+        <g>
             <title>__dev_queue_xmit (10 samples, 0.76%)</title>
             <rect x="62.3574%" y="485" width="0.7605%" height="15" fill="rgb(216,173,24)"/>
             <text x="62.6074%" y="495.50"></text>
@@ -1341,9 +2576,44 @@ var truncate_text_right = false;]]>
             <text x="62.6835%" y="479.50"></text>
         </g>
         <g>
+            <title>netif_skb_dev_features (1 samples, 0.08%)</title>
+            <rect x="63.0418%" y="453" width="0.0760%" height="15" fill="rgb(207,192,11)"/>
+            <text x="63.2918%" y="463.50"></text>
+        </g>
+        <g>
+            <title>skb_network_protocol (1 samples, 0.08%)</title>
+            <rect x="63.0418%" y="437" width="0.0760%" height="15" fill="rgb(228,61,46)"/>
+            <text x="63.2918%" y="447.50"></text>
+        </g>
+        <g>
             <title>dev_queue_xmit (11 samples, 0.84%)</title>
             <rect x="62.3574%" y="501" width="0.8365%" height="15" fill="rgb(221,152,51)"/>
             <text x="62.6074%" y="511.50"></text>
+        </g>
+        <g>
+            <title>netdev_pick_tx (1 samples, 0.08%)</title>
+            <rect x="63.1179%" y="485" width="0.0760%" height="15" fill="rgb(243,76,47)"/>
+            <text x="63.3679%" y="495.50"></text>
+        </g>
+        <g>
+            <title>msecs_to_jiffies (1 samples, 0.08%)</title>
+            <rect x="63.6502%" y="437" width="0.0760%" height="15" fill="rgb(243,13,19)"/>
+            <text x="63.9002%" y="447.50"></text>
+        </g>
+        <g>
+            <title>ip_local_deliver (1 samples, 0.08%)</title>
+            <rect x="64.1825%" y="357" width="0.0760%" height="15" fill="rgb(227,100,25)"/>
+            <text x="64.4325%" y="367.50"></text>
+        </g>
+        <g>
+            <title>raw_local_deliver (1 samples, 0.08%)</title>
+            <rect x="64.2586%" y="309" width="0.0760%" height="15" fill="rgb(208,206,25)"/>
+            <text x="64.5086%" y="319.50"></text>
+        </g>
+        <g>
+            <title>sock_put (1 samples, 0.08%)</title>
+            <rect x="64.3346%" y="309" width="0.0760%" height="15" fill="rgb(225,101,27)"/>
+            <text x="64.5846%" y="319.50"></text>
         </g>
         <g>
             <title>__inet_lookup_established (4 samples, 0.30%)</title>
@@ -1354,6 +2624,36 @@ var truncate_text_right = false;]]>
             <title>_raw_spin_lock (2 samples, 0.15%)</title>
             <rect x="64.7909%" y="293" width="0.1521%" height="15" fill="rgb(239,227,41)"/>
             <text x="65.0409%" y="303.50"></text>
+        </g>
+        <g>
+            <title>inet_ehashfn (1 samples, 0.08%)</title>
+            <rect x="64.9430%" y="293" width="0.0760%" height="15" fill="rgb(238,85,49)"/>
+            <text x="65.1930%" y="303.50"></text>
+        </g>
+        <g>
+            <title>ipv4_dst_check (1 samples, 0.08%)</title>
+            <rect x="65.0190%" y="293" width="0.0760%" height="15" fill="rgb(233,223,2)"/>
+            <text x="65.2690%" y="303.50"></text>
+        </g>
+        <g>
+            <title>tcp_md5_do_lookup (1 samples, 0.08%)</title>
+            <rect x="65.0951%" y="293" width="0.0760%" height="15" fill="rgb(215,150,44)"/>
+            <text x="65.3451%" y="303.50"></text>
+        </g>
+        <g>
+            <title>tcp_check_space (1 samples, 0.08%)</title>
+            <rect x="65.3992%" y="277" width="0.0760%" height="15" fill="rgb(219,195,15)"/>
+            <text x="65.6492%" y="287.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_unlock_irqrestore (1 samples, 0.08%)</title>
+            <rect x="65.7034%" y="197" width="0.0760%" height="15" fill="rgb(215,4,12)"/>
+            <text x="65.9534%" y="207.50"></text>
+        </g>
+        <g>
+            <title>detach_if_pending (1 samples, 0.08%)</title>
+            <rect x="65.7795%" y="197" width="0.0760%" height="15" fill="rgb(254,33,5)"/>
+            <text x="66.0295%" y="207.50"></text>
         </g>
         <g>
             <title>__tcp_ack_snd_check (5 samples, 0.38%)</title>
@@ -1374,6 +2674,16 @@ var truncate_text_right = false;]]>
             <title>mod_timer (5 samples, 0.38%)</title>
             <rect x="65.5513%" y="213" width="0.3802%" height="15" fill="rgb(241,115,42)"/>
             <text x="65.8013%" y="223.50"></text>
+        </g>
+        <g>
+            <title>internal_add_timer (1 samples, 0.08%)</title>
+            <rect x="65.8555%" y="197" width="0.0760%" height="15" fill="rgb(214,113,41)"/>
+            <text x="66.1055%" y="207.50"></text>
+        </g>
+        <g>
+            <title>dst_release (1 samples, 0.08%)</title>
+            <rect x="65.9316%" y="261" width="0.0760%" height="15" fill="rgb(236,33,21)"/>
+            <text x="66.1816%" y="271.50"></text>
         </g>
         <g>
             <title>sock_def_readable (2 samples, 0.15%)</title>
@@ -1406,6 +2716,31 @@ var truncate_text_right = false;]]>
             <text x="67.4743%" y="207.50"></text>
         </g>
         <g>
+            <title>skb_free_head (1 samples, 0.08%)</title>
+            <rect x="67.3764%" y="181" width="0.0760%" height="15" fill="rgb(212,173,42)"/>
+            <text x="67.6264%" y="191.50"></text>
+        </g>
+        <g>
+            <title>kfree (1 samples, 0.08%)</title>
+            <rect x="67.3764%" y="165" width="0.0760%" height="15" fill="rgb(239,188,1)"/>
+            <text x="67.6264%" y="175.50"></text>
+        </g>
+        <g>
+            <title>__slab_free (1 samples, 0.08%)</title>
+            <rect x="67.3764%" y="149" width="0.0760%" height="15" fill="rgb(218,181,24)"/>
+            <text x="67.6264%" y="159.50"></text>
+        </g>
+        <g>
+            <title>bictcp_acked (1 samples, 0.08%)</title>
+            <rect x="67.4525%" y="229" width="0.0760%" height="15" fill="rgb(212,225,6)"/>
+            <text x="67.7025%" y="239.50"></text>
+        </g>
+        <g>
+            <title>kfree_skbmem (1 samples, 0.08%)</title>
+            <rect x="67.5285%" y="229" width="0.0760%" height="15" fill="rgb(229,204,44)"/>
+            <text x="67.7785%" y="239.50"></text>
+        </g>
+        <g>
             <title>tcp_ack (20 samples, 1.52%)</title>
             <rect x="66.1597%" y="261" width="1.5209%" height="15" fill="rgb(214,177,25)"/>
             <text x="66.4097%" y="271.50"></text>
@@ -1416,9 +2751,44 @@ var truncate_text_right = false;]]>
             <text x="66.8660%" y="255.50"></text>
         </g>
         <g>
+            <title>ktime_get_real (1 samples, 0.08%)</title>
+            <rect x="67.6046%" y="229" width="0.0760%" height="15" fill="rgb(244,107,13)"/>
+            <text x="67.8546%" y="239.50"></text>
+        </g>
+        <g>
+            <title>getnstimeofday (1 samples, 0.08%)</title>
+            <rect x="67.6046%" y="213" width="0.0760%" height="15" fill="rgb(251,141,22)"/>
+            <text x="67.8546%" y="223.50"></text>
+        </g>
+        <g>
+            <title>__getnstimeofday (1 samples, 0.08%)</title>
+            <rect x="67.6046%" y="197" width="0.0760%" height="15" fill="rgb(249,105,26)"/>
+            <text x="67.8546%" y="207.50"></text>
+        </g>
+        <g>
+            <title>read_tsc (1 samples, 0.08%)</title>
+            <rect x="67.6046%" y="181" width="0.0760%" height="15" fill="rgb(230,11,23)"/>
+            <text x="67.8546%" y="191.50"></text>
+        </g>
+        <g>
+            <title>native_read_tsc (1 samples, 0.08%)</title>
+            <rect x="67.6046%" y="165" width="0.0760%" height="15" fill="rgb(218,188,37)"/>
+            <text x="67.8546%" y="175.50"></text>
+        </g>
+        <g>
             <title>tcp_check_space (3 samples, 0.23%)</title>
             <rect x="67.6806%" y="261" width="0.2281%" height="15" fill="rgb(219,195,15)"/>
             <text x="67.9306%" y="271.50"></text>
+        </g>
+        <g>
+            <title>tcp_clean_rtx_queue (1 samples, 0.08%)</title>
+            <rect x="67.9087%" y="261" width="0.0760%" height="15" fill="rgb(239,24,17)"/>
+            <text x="68.1587%" y="271.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock (1 samples, 0.08%)</title>
+            <rect x="68.8213%" y="117" width="0.0760%" height="15" fill="rgb(239,227,41)"/>
+            <text x="69.0713%" y="127.50"></text>
         </g>
         <g>
             <title>_raw_spin_lock_irqsave (2 samples, 0.15%)</title>
@@ -1439,6 +2809,16 @@ var truncate_text_right = false;]]>
             <title>idle_cpu (2 samples, 0.15%)</title>
             <rect x="69.2015%" y="101" width="0.1521%" height="15" fill="rgb(242,210,7)"/>
             <text x="69.4515%" y="111.50"></text>
+        </g>
+        <g>
+            <title>account_entity_enqueue (1 samples, 0.08%)</title>
+            <rect x="69.5057%" y="37" width="0.0760%" height="15" fill="rgb(224,81,6)"/>
+            <text x="69.7557%" y="47.50"></text>
+        </g>
+        <g>
+            <title>update_cfs_rq_blocked_load (1 samples, 0.08%)</title>
+            <rect x="69.5817%" y="37" width="0.0760%" height="15" fill="rgb(207,167,27)"/>
+            <text x="69.8317%" y="47.50"></text>
         </g>
         <g>
             <title>enqueue_task_fair (5 samples, 0.38%)</title>
@@ -1466,6 +2846,16 @@ var truncate_text_right = false;]]>
             <text x="69.6036%" y="95.50"></text>
         </g>
         <g>
+            <title>update_rq_clock.part.63 (1 samples, 0.08%)</title>
+            <rect x="69.8099%" y="69" width="0.0760%" height="15" fill="rgb(240,13,25)"/>
+            <text x="70.0599%" y="79.50"></text>
+        </g>
+        <g>
+            <title>sched_clock_cpu (1 samples, 0.08%)</title>
+            <rect x="69.8099%" y="53" width="0.0760%" height="15" fill="rgb(253,198,6)"/>
+            <text x="70.0599%" y="63.50"></text>
+        </g>
+        <g>
             <title>check_preempt_curr (2 samples, 0.15%)</title>
             <rect x="69.9620%" y="85" width="0.1521%" height="15" fill="rgb(237,112,25)"/>
             <text x="70.2120%" y="95.50"></text>
@@ -1486,9 +2876,19 @@ var truncate_text_right = false;]]>
             <text x="70.3641%" y="95.50"></text>
         </g>
         <g>
+            <title>ttwu_do_wakeup (1 samples, 0.08%)</title>
+            <rect x="70.2662%" y="117" width="0.0760%" height="15" fill="rgb(208,134,4)"/>
+            <text x="70.5162%" y="127.50"></text>
+        </g>
+        <g>
             <title>try_to_wake_up (24 samples, 1.83%)</title>
             <rect x="68.5932%" y="133" width="1.8251%" height="15" fill="rgb(210,218,31)"/>
             <text x="68.8432%" y="143.50">t..</text>
+        </g>
+        <g>
+            <title>ttwu_stat (1 samples, 0.08%)</title>
+            <rect x="70.3422%" y="117" width="0.0760%" height="15" fill="rgb(243,147,27)"/>
+            <text x="70.5922%" y="127.50"></text>
         </g>
         <g>
             <title>__wake_up_locked (25 samples, 1.90%)</title>
@@ -1506,6 +2906,11 @@ var truncate_text_right = false;]]>
             <text x="68.8432%" y="159.50">d..</text>
         </g>
         <g>
+            <title>ttwu_do_activate.constprop.74 (1 samples, 0.08%)</title>
+            <rect x="70.4183%" y="133" width="0.0760%" height="15" fill="rgb(240,41,3)"/>
+            <text x="70.6683%" y="143.50"></text>
+        </g>
+        <g>
             <title>__wake_up_sync_key (27 samples, 2.05%)</title>
             <rect x="68.5171%" y="229" width="2.0532%" height="15" fill="rgb(241,172,3)"/>
             <text x="68.7671%" y="239.50">_..</text>
@@ -1521,9 +2926,19 @@ var truncate_text_right = false;]]>
             <text x="68.7671%" y="207.50">e..</text>
         </g>
         <g>
+            <title>_raw_spin_lock_irqsave (1 samples, 0.08%)</title>
+            <rect x="70.4943%" y="181" width="0.0760%" height="15" fill="rgb(237,195,40)"/>
+            <text x="70.7443%" y="191.50"></text>
+        </g>
+        <g>
             <title>sock_def_readable (32 samples, 2.43%)</title>
             <rect x="68.2129%" y="245" width="2.4335%" height="15" fill="rgb(212,10,6)"/>
             <text x="68.4629%" y="255.50">so..</text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_irqsave (1 samples, 0.08%)</title>
+            <rect x="70.5703%" y="229" width="0.0760%" height="15" fill="rgb(237,195,40)"/>
+            <text x="70.8203%" y="239.50"></text>
         </g>
         <g>
             <title>tcp_queue_rcv (2 samples, 0.15%)</title>
@@ -1574,6 +2989,11 @@ var truncate_text_right = false;]]>
             <title>tcp_rcv_established (73 samples, 5.55%)</title>
             <rect x="65.4753%" y="277" width="5.5513%" height="15" fill="rgb(231,132,32)"/>
             <text x="65.7253%" y="287.50">tcp_rcv..</text>
+        </g>
+        <g>
+            <title>tcp_urg (1 samples, 0.08%)</title>
+            <rect x="70.9506%" y="261" width="0.0760%" height="15" fill="rgb(252,116,54)"/>
+            <text x="71.2006%" y="271.50"></text>
         </g>
         <g>
             <title>ip_queue_xmit (122 samples, 9.28%)</title>
@@ -1636,6 +3056,16 @@ var truncate_text_right = false;]]>
             <text x="64.2044%" y="399.50">__netif_re..</text>
         </g>
         <g>
+            <title>ip_rcv_finish (1 samples, 0.08%)</title>
+            <rect x="71.0266%" y="373" width="0.0760%" height="15" fill="rgb(250,103,51)"/>
+            <text x="71.2766%" y="383.50"></text>
+        </g>
+        <g>
+            <title>__getnstimeofday (1 samples, 0.08%)</title>
+            <rect x="71.1027%" y="533" width="0.0760%" height="15" fill="rgb(249,105,26)"/>
+            <text x="71.3527%" y="543.50"></text>
+        </g>
+        <g>
             <title>ktime_get_real (3 samples, 0.23%)</title>
             <rect x="71.1027%" y="565" width="0.2281%" height="15" fill="rgb(244,107,13)"/>
             <text x="71.3527%" y="575.50"></text>
@@ -1661,6 +3091,11 @@ var truncate_text_right = false;]]>
             <text x="71.5808%" y="559.50"></text>
         </g>
         <g>
+            <title>__copy_skb_header (1 samples, 0.08%)</title>
+            <rect x="71.5589%" y="533" width="0.0760%" height="15" fill="rgb(238,51,10)"/>
+            <text x="71.8089%" y="543.50"></text>
+        </g>
+        <g>
             <title>__tcp_push_pending_frames (149 samples, 11.33%)</title>
             <rect x="60.3802%" y="613" width="11.3308%" height="15" fill="rgb(205,62,21)"/>
             <text x="60.6302%" y="623.50">__tcp_push_pendin..</text>
@@ -1676,9 +3111,49 @@ var truncate_text_right = false;]]>
             <text x="61.9230%" y="591.50">tcp_transmit_skb</text>
         </g>
         <g>
+            <title>tcp_v4_send_check (1 samples, 0.08%)</title>
+            <rect x="71.6350%" y="565" width="0.0760%" height="15" fill="rgb(239,110,39)"/>
+            <text x="71.8850%" y="575.50"></text>
+        </g>
+        <g>
+            <title>__tcp_v4_send_check (1 samples, 0.08%)</title>
+            <rect x="71.6350%" y="549" width="0.0760%" height="15" fill="rgb(206,91,14)"/>
+            <text x="71.8850%" y="559.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_unlock_bh (1 samples, 0.08%)</title>
+            <rect x="71.7110%" y="613" width="0.0760%" height="15" fill="rgb(244,89,32)"/>
+            <text x="71.9610%" y="623.50"></text>
+        </g>
+        <g>
+            <title>lock_sock_nested (1 samples, 0.08%)</title>
+            <rect x="71.7871%" y="613" width="0.0760%" height="15" fill="rgb(252,7,51)"/>
+            <text x="72.0371%" y="623.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_bh (1 samples, 0.08%)</title>
+            <rect x="71.7871%" y="597" width="0.0760%" height="15" fill="rgb(218,157,7)"/>
+            <text x="72.0371%" y="607.50"></text>
+        </g>
+        <g>
             <title>release_sock (2 samples, 0.15%)</title>
             <rect x="71.8631%" y="613" width="0.1521%" height="15" fill="rgb(244,133,13)"/>
             <text x="72.1131%" y="623.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_bh (1 samples, 0.08%)</title>
+            <rect x="71.9392%" y="597" width="0.0760%" height="15" fill="rgb(218,157,7)"/>
+            <text x="72.1892%" y="607.50"></text>
+        </g>
+        <g>
+            <title>__kmalloc_node_track_caller (1 samples, 0.08%)</title>
+            <rect x="72.0913%" y="581" width="0.0760%" height="15" fill="rgb(242,124,1)"/>
+            <text x="72.3413%" y="591.50"></text>
+        </g>
+        <g>
+            <title>__kmalloc_node_track_caller (1 samples, 0.08%)</title>
+            <rect x="72.1673%" y="565" width="0.0760%" height="15" fill="rgb(242,124,1)"/>
+            <text x="72.4173%" y="575.50"></text>
         </g>
         <g>
             <title>__kmalloc_reserve.isra.26 (3 samples, 0.23%)</title>
@@ -1691,9 +3166,19 @@ var truncate_text_right = false;]]>
             <text x="72.4933%" y="575.50"></text>
         </g>
         <g>
+            <title>__slab_alloc (1 samples, 0.08%)</title>
+            <rect x="72.3954%" y="581" width="0.0760%" height="15" fill="rgb(253,9,42)"/>
+            <text x="72.6454%" y="591.50"></text>
+        </g>
+        <g>
             <title>kmem_cache_alloc_node (2 samples, 0.15%)</title>
             <rect x="72.4715%" y="581" width="0.1521%" height="15" fill="rgb(222,217,41)"/>
             <text x="72.7215%" y="591.50"></text>
+        </g>
+        <g>
+            <title>__slab_alloc (1 samples, 0.08%)</title>
+            <rect x="72.5475%" y="565" width="0.0760%" height="15" fill="rgb(253,9,42)"/>
+            <text x="72.7975%" y="575.50"></text>
         </g>
         <g>
             <title>__alloc_skb (9 samples, 0.68%)</title>
@@ -1701,9 +3186,24 @@ var truncate_text_right = false;]]>
             <text x="72.2652%" y="607.50"></text>
         </g>
         <g>
+            <title>ksize (1 samples, 0.08%)</title>
+            <rect x="72.6236%" y="581" width="0.0760%" height="15" fill="rgb(236,180,6)"/>
+            <text x="72.8736%" y="591.50"></text>
+        </g>
+        <g>
             <title>sk_stream_alloc_skb (10 samples, 0.76%)</title>
             <rect x="72.0152%" y="613" width="0.7605%" height="15" fill="rgb(208,157,7)"/>
             <text x="72.2652%" y="623.50"></text>
+        </g>
+        <g>
+            <title>ksize (1 samples, 0.08%)</title>
+            <rect x="72.6996%" y="597" width="0.0760%" height="15" fill="rgb(236,180,6)"/>
+            <text x="72.9496%" y="607.50"></text>
+        </g>
+        <g>
+            <title>ipv4_mtu (1 samples, 0.08%)</title>
+            <rect x="72.7757%" y="597" width="0.0760%" height="15" fill="rgb(215,185,43)"/>
+            <text x="73.0257%" y="607.50"></text>
         </g>
         <g>
             <title>tcp_established_options (4 samples, 0.30%)</title>
@@ -1731,6 +3231,21 @@ var truncate_text_right = false;]]>
             <text x="73.1017%" y="607.50"></text>
         </g>
         <g>
+            <title>tcp_v4_md5_lookup (1 samples, 0.08%)</title>
+            <rect x="73.1559%" y="581" width="0.0760%" height="15" fill="rgb(219,43,23)"/>
+            <text x="73.4059%" y="591.50"></text>
+        </g>
+        <g>
+            <title>security_socket_sendmsg (1 samples, 0.08%)</title>
+            <rect x="73.2319%" y="645" width="0.0760%" height="15" fill="rgb(229,70,35)"/>
+            <text x="73.4819%" y="655.50"></text>
+        </g>
+        <g>
+            <title>aa_revalidate_sk (1 samples, 0.08%)</title>
+            <rect x="73.2319%" y="629" width="0.0760%" height="15" fill="rgb(225,64,15)"/>
+            <text x="73.4819%" y="639.50"></text>
+        </g>
+        <g>
             <title>do_sync_write (186 samples, 14.14%)</title>
             <rect x="59.2395%" y="677" width="14.1445%" height="15" fill="rgb(253,86,14)"/>
             <text x="59.4895%" y="687.50">do_sync_write</text>
@@ -1739,6 +3254,11 @@ var truncate_text_right = false;]]>
             <title>sock_aio_write (185 samples, 14.07%)</title>
             <rect x="59.3156%" y="661" width="14.0684%" height="15" fill="rgb(208,104,23)"/>
             <text x="59.5656%" y="671.50">sock_aio_write</text>
+        </g>
+        <g>
+            <title>tcp_sendmsg (1 samples, 0.08%)</title>
+            <rect x="73.3080%" y="645" width="0.0760%" height="15" fill="rgb(228,107,50)"/>
+            <text x="73.5580%" y="655.50"></text>
         </g>
         <g>
             <title>[libpthread-2.19.so] (197 samples, 14.98%)</title>
@@ -1761,9 +3281,44 @@ var truncate_text_right = false;]]>
             <text x="59.1093%" y="703.50">vfs_write</text>
         </g>
         <g>
+            <title>rw_verify_area (1 samples, 0.08%)</title>
+            <rect x="73.3840%" y="677" width="0.0760%" height="15" fill="rgb(253,78,54)"/>
+            <text x="73.6340%" y="687.50"></text>
+        </g>
+        <g>
+            <title>security_file_permission (1 samples, 0.08%)</title>
+            <rect x="73.3840%" y="661" width="0.0760%" height="15" fill="rgb(235,38,22)"/>
+            <text x="73.6340%" y="671.50"></text>
+        </g>
+        <g>
+            <title>apparmor_file_permission (1 samples, 0.08%)</title>
+            <rect x="73.3840%" y="645" width="0.0760%" height="15" fill="rgb(243,206,54)"/>
+            <text x="73.6340%" y="655.50"></text>
+        </g>
+        <g>
+            <title>common_file_perm (1 samples, 0.08%)</title>
+            <rect x="73.3840%" y="629" width="0.0760%" height="15" fill="rgb(219,178,19)"/>
+            <text x="73.6340%" y="639.50"></text>
+        </g>
+        <g>
+            <title>__libc_write (1 samples, 0.08%)</title>
+            <rect x="73.4601%" y="741" width="0.0760%" height="15" fill="rgb(234,61,50)"/>
+            <text x="73.7101%" y="751.50"></text>
+        </g>
+        <g>
+            <title>__pthread_disable_asynccancel (1 samples, 0.08%)</title>
+            <rect x="73.5361%" y="741" width="0.0760%" height="15" fill="rgb(226,68,24)"/>
+            <text x="73.7861%" y="751.50"></text>
+        </g>
+        <g>
             <title>sun/nio/ch/FileDispatcherImpl:.write0 (203 samples, 15.44%)</title>
             <rect x="58.2510%" y="757" width="15.4373%" height="15" fill="rgb(225,214,44)"/>
             <text x="58.5010%" y="767.50">sun/nio/ch/FileDispatche..</text>
+        </g>
+        <g>
+            <title>jni_fast_GetIntField (1 samples, 0.08%)</title>
+            <rect x="73.6122%" y="741" width="0.0760%" height="15" fill="rgb(253,173,16)"/>
+            <text x="73.8622%" y="751.50"></text>
         </g>
         <g>
             <title>io/netty/channel/nio/AbstractNioByteChannel:.doWrite (225 samples, 17.11%)</title>
@@ -1776,6 +3331,11 @@ var truncate_text_right = false;]]>
             <text x="58.1207%" y="783.50">sun/nio/ch/SocketChannel..</text>
         </g>
         <g>
+            <title>sun/nio/ch/NativeThread:.current (1 samples, 0.08%)</title>
+            <rect x="73.6882%" y="757" width="0.0760%" height="15" fill="rgb(245,149,21)"/>
+            <text x="73.9382%" y="767.50"></text>
+        </g>
+        <g>
             <title>sun/nio/ch/SocketChannelImpl:.isConnected (2 samples, 0.15%)</title>
             <rect x="73.7643%" y="789" width="0.1521%" height="15" fill="rgb(241,176,23)"/>
             <text x="74.0143%" y="799.50"></text>
@@ -1786,9 +3346,19 @@ var truncate_text_right = false;]]>
             <text x="56.5998%" y="815.50">io/netty/channel/DefaultCha..</text>
         </g>
         <g>
+            <title>sun/nio/ch/SocketChannelImpl:.write (1 samples, 0.08%)</title>
+            <rect x="73.9163%" y="789" width="0.0760%" height="15" fill="rgb(236,84,45)"/>
+            <text x="74.1663%" y="799.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.flush (233 samples, 17.72%)</title>
             <rect x="56.3498%" y="821" width="17.7186%" height="15" fill="rgb(239,217,31)"/>
             <text x="56.5998%" y="831.50">io/netty/channel/AbstractCha..</text>
+        </g>
+        <g>
+            <title>sun/nio/ch/SocketChannelImpl:.isConnected (1 samples, 0.08%)</title>
+            <rect x="73.9924%" y="805" width="0.0760%" height="15" fill="rgb(241,176,23)"/>
+            <text x="74.2424%" y="815.50"></text>
         </g>
         <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.flush (235 samples, 17.87%)</title>
@@ -1806,6 +3376,11 @@ var truncate_text_right = false;]]>
             <text x="74.3184%" y="831.50"></text>
         </g>
         <g>
+            <title>io/netty/channel/ChannelOutboundHandlerAdapter:.flush (1 samples, 0.08%)</title>
+            <rect x="74.2205%" y="853" width="0.0760%" height="15" fill="rgb(248,179,37)"/>
+            <text x="74.4705%" y="863.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.flush (238 samples, 18.10%)</title>
             <rect x="56.2738%" y="885" width="18.0989%" height="15" fill="rgb(239,217,31)"/>
             <text x="56.5238%" y="895.50">io/netty/channel/AbstractCha..</text>
@@ -1814,6 +3389,16 @@ var truncate_text_right = false;]]>
             <title>io/netty/channel/ChannelDuplexHandler:.flush (237 samples, 18.02%)</title>
             <rect x="56.3498%" y="869" width="18.0228%" height="15" fill="rgb(224,204,13)"/>
             <text x="56.5998%" y="879.50">io/netty/channel/ChannelDupl..</text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="74.2966%" y="853" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="74.5466%" y="863.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/ChannelDuplexHandler:.flush (1 samples, 0.08%)</title>
+            <rect x="74.3726%" y="885" width="0.0760%" height="15" fill="rgb(224,204,13)"/>
+            <text x="74.6226%" y="895.50"></text>
         </g>
         <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.fireChannelReadComplete (241 samples, 18.33%)</title>
@@ -1826,6 +3411,11 @@ var truncate_text_right = false;]]>
             <text x="56.5238%" y="911.50">org/vertx/java/core/net/impl..</text>
         </g>
         <g>
+            <title>java/util/concurrent/ConcurrentHashMap:.get (1 samples, 0.08%)</title>
+            <rect x="74.4487%" y="885" width="0.0760%" height="15" fill="rgb(247,3,36)"/>
+            <text x="74.6987%" y="895.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.fireChannelReadComplete (242 samples, 18.40%)</title>
             <rect x="56.1977%" y="949" width="18.4030%" height="15" fill="rgb(237,145,33)"/>
             <text x="56.4477%" y="959.50">io/netty/channel/AbstractChan..</text>
@@ -1834,6 +3424,21 @@ var truncate_text_right = false;]]>
             <title>io/netty/handler/codec/ByteToMessageDecoder:.channelReadComplete (242 samples, 18.40%)</title>
             <rect x="56.1977%" y="933" width="18.4030%" height="15" fill="rgb(226,210,36)"/>
             <text x="56.4477%" y="943.50">io/netty/handler/codec/ByteTo..</text>
+        </g>
+        <g>
+            <title>itable stub (1 samples, 0.08%)</title>
+            <rect x="74.5247%" y="917" width="0.0760%" height="15" fill="rgb(249,120,0)"/>
+            <text x="74.7747%" y="927.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/AbstractChannelHandlerContext:.executor (1 samples, 0.08%)</title>
+            <rect x="74.6768%" y="901" width="0.0760%" height="15" fill="rgb(218,81,7)"/>
+            <text x="74.9268%" y="911.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/DefaultChannelPipeline$HeadContext:.read (1 samples, 0.08%)</title>
+            <rect x="74.7529%" y="869" width="0.0760%" height="15" fill="rgb(249,18,15)"/>
+            <text x="75.0029%" y="879.50"></text>
         </g>
         <g>
             <title>io/netty/channel/AbstractChannelHandlerContext:.read (4 samples, 0.30%)</title>
@@ -1861,6 +3466,21 @@ var truncate_text_right = false;]]>
             <text x="75.0029%" y="895.50"></text>
         </g>
         <g>
+            <title>sun/nio/ch/SocketChannelImpl:.isConnected (1 samples, 0.08%)</title>
+            <rect x="74.8289%" y="869" width="0.0760%" height="15" fill="rgb(241,176,23)"/>
+            <text x="75.0789%" y="879.50"></text>
+        </g>
+        <g>
+            <title>io/netty/channel/ChannelDuplexHandler:.read (1 samples, 0.08%)</title>
+            <rect x="74.9049%" y="949" width="0.0760%" height="15" fill="rgb(224,50,12)"/>
+            <text x="75.1549%" y="959.50"></text>
+        </g>
+        <g>
+            <title>io/netty/handler/codec/ByteToMessageDecoder:.channelRead (1 samples, 0.08%)</title>
+            <rect x="74.9810%" y="949" width="0.0760%" height="15" fill="rgb(212,10,46)"/>
+            <text x="75.2310%" y="959.50"></text>
+        </g>
+        <g>
             <title>io/netty/channel/nio/NioEventLoop:.processSelectedKeys (949 samples, 72.17%)</title>
             <rect x="2.9658%" y="997" width="72.1673%" height="15" fill="rgb(210,18,13)"/>
             <text x="3.2158%" y="1007.50">io/netty/channel/nio/NioEventLoop:.processSelectedKeys</text>
@@ -1874,6 +3494,11 @@ var truncate_text_right = false;]]>
             <title>io/netty/channel/nio/AbstractNioByteChannel$NioByteUnsafe:.read (939 samples, 71.41%)</title>
             <rect x="3.7262%" y="965" width="71.4068%" height="15" fill="rgb(251,92,35)"/>
             <text x="3.9762%" y="975.50">io/netty/channel/nio/AbstractNioByteChannel$NioByteUnsafe:.read</text>
+        </g>
+        <g>
+            <title>java/nio/DirectByteBuffer:.duplicate (1 samples, 0.08%)</title>
+            <rect x="75.0570%" y="949" width="0.0760%" height="15" fill="rgb(215,13,10)"/>
+            <text x="75.3070%" y="959.50"></text>
         </g>
         <g>
             <title>sun/nio/ch/EPollArrayWrapper:.poll (5 samples, 0.38%)</title>
@@ -1919,6 +3544,11 @@ var truncate_text_right = false;]]>
             <title>sock_poll (2 samples, 0.15%)</title>
             <rect x="75.4373%" y="837" width="0.1521%" height="15" fill="rgb(209,64,23)"/>
             <text x="75.6873%" y="847.50"></text>
+        </g>
+        <g>
+            <title>tcp_poll (1 samples, 0.08%)</title>
+            <rect x="75.5133%" y="821" width="0.0760%" height="15" fill="rgb(242,82,43)"/>
+            <text x="75.7633%" y="831.50"></text>
         </g>
         <g>
             <title>JavaThread::run (956 samples, 72.70%)</title>
@@ -1981,6 +3611,11 @@ var truncate_text_right = false;]]>
             <text x="75.3831%" y="991.50"></text>
         </g>
         <g>
+            <title>sun/nio/ch/EPollSelectorImpl:.updateSelectedKeys (1 samples, 0.08%)</title>
+            <rect x="75.5894%" y="965" width="0.0760%" height="15" fill="rgb(222,76,31)"/>
+            <text x="75.8394%" y="975.50"></text>
+        </g>
+        <g>
             <title>java (995 samples, 75.67%)</title>
             <rect x="0.0760%" y="1205" width="75.6654%" height="15" fill="rgb(205,22,45)"/>
             <text x="0.3260%" y="1215.50">java</text>
@@ -1994,6 +3629,131 @@ var truncate_text_right = false;]]>
             <title>java_start (985 samples, 74.90%)</title>
             <rect x="0.8365%" y="1173" width="74.9049%" height="15" fill="rgb(230,218,24)"/>
             <text x="1.0865%" y="1183.50">java_start</text>
+        </g>
+        <g>
+            <title>VMThread::run (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1157" width="0.0760%" height="15" fill="rgb(239,5,53)"/>
+            <text x="75.9154%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>VMThread::loop (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1141" width="0.0760%" height="15" fill="rgb(228,66,35)"/>
+            <text x="75.9154%" y="1151.50"></text>
+        </g>
+        <g>
+            <title>SafepointSynchronize::begin (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1125" width="0.0760%" height="15" fill="rgb(254,199,23)"/>
+            <text x="75.9154%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>__GI___mprotect (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1109" width="0.0760%" height="15" fill="rgb(234,92,26)"/>
+            <text x="75.9154%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>system_call_fastpath (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1093" width="0.0760%" height="15" fill="rgb(210,77,43)"/>
+            <text x="75.9154%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>sys_mprotect (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1077" width="0.0760%" height="15" fill="rgb(217,206,14)"/>
+            <text x="75.9154%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>mprotect_fixup (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1061" width="0.0760%" height="15" fill="rgb(251,184,27)"/>
+            <text x="75.9154%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>change_protection (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1045" width="0.0760%" height="15" fill="rgb(244,42,23)"/>
+            <text x="75.9154%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>change_protection_range (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1029" width="0.0760%" height="15" fill="rgb(220,203,35)"/>
+            <text x="75.9154%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>flush_tlb_mm_range (1 samples, 0.08%)</title>
+            <rect x="75.6654%" y="1013" width="0.0760%" height="15" fill="rgb(227,76,16)"/>
+            <text x="75.9154%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>ksoftirqd/3 (1 samples, 0.08%)</title>
+            <rect x="75.7414%" y="1205" width="0.0760%" height="15" fill="rgb(217,206,49)"/>
+            <text x="75.9914%" y="1215.50"></text>
+        </g>
+        <g>
+            <title>__switch_to (1 samples, 0.08%)</title>
+            <rect x="75.7414%" y="1189" width="0.0760%" height="15" fill="rgb(223,3,36)"/>
+            <text x="75.9914%" y="1199.50"></text>
+        </g>
+        <g>
+            <title>[perf] (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1125" width="0.0760%" height="15" fill="rgb(221,5,8)"/>
+            <text x="76.0675%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>__execve (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1109" width="0.0760%" height="15" fill="rgb(237,59,17)"/>
+            <text x="76.0675%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>stub_execve (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1093" width="0.0760%" height="15" fill="rgb(213,185,16)"/>
+            <text x="76.0675%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>sys_execve (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1077" width="0.0760%" height="15" fill="rgb(224,19,7)"/>
+            <text x="76.0675%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>do_execve_common.isra.22 (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1061" width="0.0760%" height="15" fill="rgb(226,107,7)"/>
+            <text x="76.0675%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>open_exec (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1045" width="0.0760%" height="15" fill="rgb(211,188,16)"/>
+            <text x="76.0675%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>do_filp_open (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1029" width="0.0760%" height="15" fill="rgb(218,214,7)"/>
+            <text x="76.0675%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>path_openat (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="1013" width="0.0760%" height="15" fill="rgb(240,20,53)"/>
+            <text x="76.0675%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>put_filp (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="997" width="0.0760%" height="15" fill="rgb(213,5,48)"/>
+            <text x="76.0675%" y="1007.50"></text>
+        </g>
+        <g>
+            <title>security_file_free (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="981" width="0.0760%" height="15" fill="rgb(250,129,46)"/>
+            <text x="76.0675%" y="991.50"></text>
+        </g>
+        <g>
+            <title>apparmor_file_free_security (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="965" width="0.0760%" height="15" fill="rgb(244,87,45)"/>
+            <text x="76.0675%" y="975.50"></text>
+        </g>
+        <g>
+            <title>kfree (1 samples, 0.08%)</title>
+            <rect x="75.8175%" y="949" width="0.0760%" height="15" fill="rgb(239,188,1)"/>
+            <text x="76.0675%" y="959.50"></text>
+        </g>
+        <g>
+            <title>generic_exec_single (1 samples, 0.08%)</title>
+            <rect x="75.8935%" y="981" width="0.0760%" height="15" fill="rgb(251,190,45)"/>
+            <text x="76.1435%" y="991.50"></text>
         </g>
         <g>
             <title>perf (6 samples, 0.46%)</title>
@@ -2106,6 +3866,11 @@ var truncate_text_right = false;]]>
             <text x="76.2196%" y="879.50"></text>
         </g>
         <g>
+            <title>native_load_tls (1 samples, 0.08%)</title>
+            <rect x="76.2738%" y="1189" width="0.0760%" height="15" fill="rgb(212,54,52)"/>
+            <text x="76.5238%" y="1199.50"></text>
+        </g>
+        <g>
             <title>native_write_msr_safe (3 samples, 0.23%)</title>
             <rect x="76.3498%" y="1189" width="0.2281%" height="15" fill="rgb(220,181,17)"/>
             <text x="76.5998%" y="1199.50"></text>
@@ -2176,6 +3941,11 @@ var truncate_text_right = false;]]>
             <text x="77.2842%" y="1119.50"></text>
         </g>
         <g>
+            <title>ktime_get (1 samples, 0.08%)</title>
+            <rect x="77.8707%" y="1125" width="0.0760%" height="15" fill="rgb(245,197,23)"/>
+            <text x="78.1207%" y="1135.50"></text>
+        </g>
+        <g>
             <title>cpuidle_idle_call (21 samples, 1.60%)</title>
             <rect x="76.6540%" y="1141" width="1.5970%" height="15" fill="rgb(224,43,42)"/>
             <text x="76.9040%" y="1151.50"></text>
@@ -2189,6 +3959,41 @@ var truncate_text_right = false;]]>
             <title>arch_cpu_idle (22 samples, 1.67%)</title>
             <rect x="76.6540%" y="1157" width="1.6730%" height="15" fill="rgb(242,17,0)"/>
             <text x="76.9040%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>menu_reflect (1 samples, 0.08%)</title>
+            <rect x="78.2510%" y="1141" width="0.0760%" height="15" fill="rgb(207,176,48)"/>
+            <text x="78.5010%" y="1151.50"></text>
+        </g>
+        <g>
+            <title>atomic_notifier_call_chain (1 samples, 0.08%)</title>
+            <rect x="78.3270%" y="1157" width="0.0760%" height="15" fill="rgb(229,132,37)"/>
+            <text x="78.5770%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>cpuidle_idle_call (1 samples, 0.08%)</title>
+            <rect x="78.4030%" y="1157" width="0.0760%" height="15" fill="rgb(224,43,42)"/>
+            <text x="78.6530%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>rcu_idle_enter (1 samples, 0.08%)</title>
+            <rect x="78.4791%" y="1157" width="0.0760%" height="15" fill="rgb(222,210,13)"/>
+            <text x="78.7291%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>rcu_sysidle_enter (1 samples, 0.08%)</title>
+            <rect x="78.4791%" y="1141" width="0.0760%" height="15" fill="rgb(227,79,15)"/>
+            <text x="78.7291%" y="1151.50"></text>
+        </g>
+        <g>
+            <title>rcu_idle_exit (1 samples, 0.08%)</title>
+            <rect x="78.5551%" y="1157" width="0.0760%" height="15" fill="rgb(236,130,53)"/>
+            <text x="78.8051%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>rcu_sysidle_exit (1 samples, 0.08%)</title>
+            <rect x="78.5551%" y="1141" width="0.0760%" height="15" fill="rgb(227,80,31)"/>
+            <text x="78.8051%" y="1151.50"></text>
         </g>
         <g>
             <title>schedule_preempt_disabled (4 samples, 0.30%)</title>
@@ -2211,9 +4016,54 @@ var truncate_text_right = false;]]>
             <text x="79.0333%" y="1119.50"></text>
         </g>
         <g>
+            <title>sched_clock_idle_sleep_event (1 samples, 0.08%)</title>
+            <rect x="78.9354%" y="1125" width="0.0760%" height="15" fill="rgb(208,31,37)"/>
+            <text x="79.1854%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>sched_clock_cpu (1 samples, 0.08%)</title>
+            <rect x="78.9354%" y="1109" width="0.0760%" height="15" fill="rgb(253,198,6)"/>
+            <text x="79.1854%" y="1119.50"></text>
+        </g>
+        <g>
             <title>get_next_timer_interrupt (3 samples, 0.23%)</title>
             <rect x="79.0114%" y="1109" width="0.2281%" height="15" fill="rgb(214,141,39)"/>
             <text x="79.2614%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock (1 samples, 0.08%)</title>
+            <rect x="79.1635%" y="1093" width="0.0760%" height="15" fill="rgb(239,227,41)"/>
+            <text x="79.4135%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>__remove_hrtimer (1 samples, 0.08%)</title>
+            <rect x="79.2395%" y="1077" width="0.0760%" height="15" fill="rgb(252,58,54)"/>
+            <text x="79.4895%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>hrtimer_force_reprogram (1 samples, 0.08%)</title>
+            <rect x="79.2395%" y="1061" width="0.0760%" height="15" fill="rgb(246,120,34)"/>
+            <text x="79.4895%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>tick_program_event (1 samples, 0.08%)</title>
+            <rect x="79.2395%" y="1045" width="0.0760%" height="15" fill="rgb(226,75,12)"/>
+            <text x="79.4895%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>clockevents_program_event (1 samples, 0.08%)</title>
+            <rect x="79.2395%" y="1029" width="0.0760%" height="15" fill="rgb(219,132,18)"/>
+            <text x="79.4895%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>lapic_next_deadline (1 samples, 0.08%)</title>
+            <rect x="79.2395%" y="1013" width="0.0760%" height="15" fill="rgb(216,61,21)"/>
+            <text x="79.4895%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>native_write_msr_safe (1 samples, 0.08%)</title>
+            <rect x="79.2395%" y="997" width="0.0760%" height="15" fill="rgb(220,181,17)"/>
+            <text x="79.4895%" y="1007.50"></text>
         </g>
         <g>
             <title>tick_nohz_idle_enter (6 samples, 0.46%)</title>
@@ -2239,6 +4089,11 @@ var truncate_text_right = false;]]>
             <title>__hrtimer_start_range_ns (2 samples, 0.15%)</title>
             <rect x="79.2395%" y="1093" width="0.1521%" height="15" fill="rgb(247,197,15)"/>
             <text x="79.4895%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>hrtimer_force_reprogram (1 samples, 0.08%)</title>
+            <rect x="79.3156%" y="1077" width="0.0760%" height="15" fill="rgb(246,120,34)"/>
+            <text x="79.5656%" y="1087.50"></text>
         </g>
         <g>
             <title>hrtimer_cancel (4 samples, 0.30%)</title>
@@ -2331,6 +4186,11 @@ var truncate_text_right = false;]]>
             <text x="79.6416%" y="1167.50"></text>
         </g>
         <g>
+            <title>update_cpu_load_nohz (1 samples, 0.08%)</title>
+            <rect x="79.8479%" y="1141" width="0.0760%" height="15" fill="rgb(215,185,10)"/>
+            <text x="80.0979%" y="1151.50"></text>
+        </g>
+        <g>
             <title>intel_idle (3 samples, 0.23%)</title>
             <rect x="80.0000%" y="1061" width="0.2281%" height="15" fill="rgb(228,194,53)"/>
             <text x="80.2500%" y="1071.50"></text>
@@ -2339,6 +4199,21 @@ var truncate_text_right = false;]]>
             <title>cpuidle_enter_state (4 samples, 0.30%)</title>
             <rect x="80.0000%" y="1077" width="0.3042%" height="15" fill="rgb(209,55,19)"/>
             <text x="80.2500%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>ktime_get (1 samples, 0.08%)</title>
+            <rect x="80.2281%" y="1061" width="0.0760%" height="15" fill="rgb(245,197,23)"/>
+            <text x="80.4781%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>read_tsc (1 samples, 0.08%)</title>
+            <rect x="80.2281%" y="1045" width="0.0760%" height="15" fill="rgb(230,11,23)"/>
+            <text x="80.4781%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>native_read_tsc (1 samples, 0.08%)</title>
+            <rect x="80.2281%" y="1029" width="0.0760%" height="15" fill="rgb(218,188,37)"/>
+            <text x="80.4781%" y="1039.50"></text>
         </g>
         <g>
             <title>cpuidle_idle_call (6 samples, 0.46%)</title>
@@ -2351,9 +4226,29 @@ var truncate_text_right = false;]]>
             <text x="80.5542%" y="1087.50"></text>
         </g>
         <g>
+            <title>int_sqrt (1 samples, 0.08%)</title>
+            <rect x="80.3802%" y="1061" width="0.0760%" height="15" fill="rgb(227,45,26)"/>
+            <text x="80.6302%" y="1071.50"></text>
+        </g>
+        <g>
             <title>arch_cpu_idle (7 samples, 0.53%)</title>
             <rect x="80.0000%" y="1109" width="0.5323%" height="15" fill="rgb(242,17,0)"/>
             <text x="80.2500%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>menu_select (1 samples, 0.08%)</title>
+            <rect x="80.4563%" y="1093" width="0.0760%" height="15" fill="rgb(216,201,34)"/>
+            <text x="80.7063%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>rcu_idle_enter (1 samples, 0.08%)</title>
+            <rect x="80.5323%" y="1109" width="0.0760%" height="15" fill="rgb(222,210,13)"/>
+            <text x="80.7823%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>rcu_sysidle_enter (1 samples, 0.08%)</title>
+            <rect x="80.5323%" y="1093" width="0.0760%" height="15" fill="rgb(227,79,15)"/>
+            <text x="80.7823%" y="1103.50"></text>
         </g>
         <g>
             <title>rcu_idle_exit (2 samples, 0.15%)</title>
@@ -2366,14 +4261,44 @@ var truncate_text_right = false;]]>
             <text x="80.8584%" y="1103.50"></text>
         </g>
         <g>
+            <title>__schedule (1 samples, 0.08%)</title>
+            <rect x="80.7605%" y="1093" width="0.0760%" height="15" fill="rgb(213,64,40)"/>
+            <text x="81.0105%" y="1103.50"></text>
+        </g>
+        <g>
             <title>schedule_preempt_disabled (2 samples, 0.15%)</title>
             <rect x="80.7605%" y="1109" width="0.1521%" height="15" fill="rgb(247,89,52)"/>
             <text x="81.0105%" y="1119.50"></text>
         </g>
         <g>
+            <title>_raw_spin_lock_irqsave (1 samples, 0.08%)</title>
+            <rect x="80.8365%" y="1093" width="0.0760%" height="15" fill="rgb(237,195,40)"/>
+            <text x="81.0865%" y="1103.50"></text>
+        </g>
+        <g>
             <title>get_next_timer_interrupt (2 samples, 0.15%)</title>
             <rect x="80.9125%" y="1061" width="0.1521%" height="15" fill="rgb(214,141,39)"/>
             <text x="81.1625%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>hrtimer_start (1 samples, 0.08%)</title>
+            <rect x="81.0646%" y="1061" width="0.0760%" height="15" fill="rgb(221,138,6)"/>
+            <text x="81.3146%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>__hrtimer_start_range_ns (1 samples, 0.08%)</title>
+            <rect x="81.0646%" y="1045" width="0.0760%" height="15" fill="rgb(247,197,15)"/>
+            <text x="81.3146%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>__remove_hrtimer (1 samples, 0.08%)</title>
+            <rect x="81.0646%" y="1029" width="0.0760%" height="15" fill="rgb(252,58,54)"/>
+            <text x="81.3146%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>timerqueue_del (1 samples, 0.08%)</title>
+            <rect x="81.0646%" y="1013" width="0.0760%" height="15" fill="rgb(220,48,51)"/>
+            <text x="81.3146%" y="1023.50"></text>
         </g>
         <g>
             <title>__tick_nohz_idle_enter (4 samples, 0.30%)</title>
@@ -2386,9 +4311,34 @@ var truncate_text_right = false;]]>
             <text x="81.1625%" y="1087.50"></text>
         </g>
         <g>
+            <title>rcu_cpu_has_callbacks (1 samples, 0.08%)</title>
+            <rect x="81.1407%" y="1061" width="0.0760%" height="15" fill="rgb(206,132,31)"/>
+            <text x="81.3907%" y="1071.50"></text>
+        </g>
+        <g>
             <title>tick_nohz_idle_enter (5 samples, 0.38%)</title>
             <rect x="80.9125%" y="1109" width="0.3802%" height="15" fill="rgb(235,44,12)"/>
             <text x="81.1625%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>ktime_get (1 samples, 0.08%)</title>
+            <rect x="81.2167%" y="1093" width="0.0760%" height="15" fill="rgb(245,197,23)"/>
+            <text x="81.4667%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>hrtimer_cancel (1 samples, 0.08%)</title>
+            <rect x="81.2928%" y="1077" width="0.0760%" height="15" fill="rgb(228,52,44)"/>
+            <text x="81.5428%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>hrtimer_try_to_cancel (1 samples, 0.08%)</title>
+            <rect x="81.2928%" y="1061" width="0.0760%" height="15" fill="rgb(224,117,46)"/>
+            <text x="81.5428%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_unlock_irqrestore (1 samples, 0.08%)</title>
+            <rect x="81.2928%" y="1045" width="0.0760%" height="15" fill="rgb(215,4,12)"/>
+            <text x="81.5428%" y="1055.50"></text>
         </g>
         <g>
             <title>tick_nohz_restart (4 samples, 0.30%)</title>
@@ -2436,6 +4386,16 @@ var truncate_text_right = false;]]>
             <text x="81.5428%" y="1119.50"></text>
         </g>
         <g>
+            <title>tick_nohz_stop_idle (1 samples, 0.08%)</title>
+            <rect x="81.5970%" y="1093" width="0.0760%" height="15" fill="rgb(206,32,28)"/>
+            <text x="81.8470%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>nr_iowait_cpu (1 samples, 0.08%)</title>
+            <rect x="81.5970%" y="1077" width="0.0760%" height="15" fill="rgb(205,181,36)"/>
+            <text x="81.8470%" y="1087.50"></text>
+        </g>
+        <g>
             <title>swapper (72 samples, 5.48%)</title>
             <rect x="76.2738%" y="1205" width="5.4753%" height="15" fill="rgb(252,229,9)"/>
             <text x="76.5238%" y="1215.50">swapper</text>
@@ -2461,6 +4421,21 @@ var truncate_text_right = false;]]>
             <text x="80.1740%" y="1151.50">r..</text>
         </g>
         <g>
+            <title>schedule_preempt_disabled (1 samples, 0.08%)</title>
+            <rect x="81.6730%" y="1125" width="0.0760%" height="15" fill="rgb(247,89,52)"/>
+            <text x="81.9230%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>[libc-2.19.so] (1 samples, 0.08%)</title>
+            <rect x="81.7490%" y="1125" width="0.0760%" height="15" fill="rgb(249,177,16)"/>
+            <text x="81.9990%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>sys_epoll_wait (1 samples, 0.08%)</title>
+            <rect x="81.7490%" y="1109" width="0.0760%" height="15" fill="rgb(235,82,0)"/>
+            <text x="81.9990%" y="1119.50"></text>
+        </g>
+        <g>
             <title>socket_readable (2 samples, 0.15%)</title>
             <rect x="81.7490%" y="1173" width="0.1521%" height="15" fill="rgb(210,55,33)"/>
             <text x="81.9990%" y="1183.50"></text>
@@ -2476,14 +4451,54 @@ var truncate_text_right = false;]]>
             <text x="81.9990%" y="1151.50"></text>
         </g>
         <g>
+            <title>epoll_ctl (1 samples, 0.08%)</title>
+            <rect x="81.8251%" y="1125" width="0.0760%" height="15" fill="rgb(236,195,16)"/>
+            <text x="82.0751%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>system_call (1 samples, 0.08%)</title>
+            <rect x="81.8251%" y="1109" width="0.0760%" height="15" fill="rgb(238,111,21)"/>
+            <text x="82.0751%" y="1119.50"></text>
+        </g>
+        <g>
             <title>aeProcessEvents (3 samples, 0.23%)</title>
             <rect x="81.7490%" y="1189" width="0.2281%" height="15" fill="rgb(227,13,34)"/>
             <text x="81.9990%" y="1199.50"></text>
         </g>
         <g>
+            <title>socket_writeable (1 samples, 0.08%)</title>
+            <rect x="81.9011%" y="1173" width="0.0760%" height="15" fill="rgb(211,41,47)"/>
+            <text x="82.1511%" y="1183.50"></text>
+        </g>
+        <g>
+            <title>epoll_ctl (1 samples, 0.08%)</title>
+            <rect x="81.9011%" y="1157" width="0.0760%" height="15" fill="rgb(236,195,16)"/>
+            <text x="82.1511%" y="1167.50"></text>
+        </g>
+        <g>
+            <title>system_call (1 samples, 0.08%)</title>
+            <rect x="81.9011%" y="1141" width="0.0760%" height="15" fill="rgb(238,111,21)"/>
+            <text x="82.1511%" y="1151.50"></text>
+        </g>
+        <g>
             <title>__schedule (2 samples, 0.15%)</title>
             <rect x="82.0532%" y="1125" width="0.1521%" height="15" fill="rgb(213,64,40)"/>
             <text x="82.3032%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>__switch_to (1 samples, 0.08%)</title>
+            <rect x="82.1293%" y="1109" width="0.0760%" height="15" fill="rgb(223,3,36)"/>
+            <text x="82.3793%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>__switch_to (1 samples, 0.08%)</title>
+            <rect x="82.2053%" y="1125" width="0.0760%" height="15" fill="rgb(223,3,36)"/>
+            <text x="82.4553%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>system_call_after_swapgs (1 samples, 0.08%)</title>
+            <rect x="82.2814%" y="1125" width="0.0760%" height="15" fill="rgb(248,86,14)"/>
+            <text x="82.5314%" y="1135.50"></text>
         </g>
         <g>
             <title>_raw_spin_lock_irqsave (2 samples, 0.15%)</title>
@@ -2511,6 +4526,11 @@ var truncate_text_right = false;]]>
             <text x="84.1283%" y="1055.50"></text>
         </g>
         <g>
+            <title>tcp_poll (1 samples, 0.08%)</title>
+            <rect x="84.0304%" y="1029" width="0.0760%" height="15" fill="rgb(242,82,43)"/>
+            <text x="84.2804%" y="1039.50"></text>
+        </g>
+        <g>
             <title>ep_scan_ready_list.isra.9 (20 samples, 1.52%)</title>
             <rect x="82.8137%" y="1077" width="1.5209%" height="15" fill="rgb(238,143,30)"/>
             <text x="83.0637%" y="1087.50"></text>
@@ -2521,9 +4541,54 @@ var truncate_text_right = false;]]>
             <text x="84.3565%" y="1071.50"></text>
         </g>
         <g>
+            <title>enqueue_hrtimer (1 samples, 0.08%)</title>
+            <rect x="84.4106%" y="1029" width="0.0760%" height="15" fill="rgb(216,22,49)"/>
+            <text x="84.6606%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>timerqueue_add (1 samples, 0.08%)</title>
+            <rect x="84.4106%" y="1013" width="0.0760%" height="15" fill="rgb(242,57,23)"/>
+            <text x="84.6606%" y="1023.50"></text>
+        </g>
+        <g>
             <title>__hrtimer_start_range_ns (3 samples, 0.23%)</title>
             <rect x="84.3346%" y="1045" width="0.2281%" height="15" fill="rgb(247,197,15)"/>
             <text x="84.5846%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>lock_hrtimer_base.isra.19 (1 samples, 0.08%)</title>
+            <rect x="84.4867%" y="1029" width="0.0760%" height="15" fill="rgb(246,162,18)"/>
+            <text x="84.7367%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_irqsave (1 samples, 0.08%)</title>
+            <rect x="84.4867%" y="1013" width="0.0760%" height="15" fill="rgb(237,195,40)"/>
+            <text x="84.7367%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>enqueue_hrtimer (1 samples, 0.08%)</title>
+            <rect x="84.5627%" y="1045" width="0.0760%" height="15" fill="rgb(216,22,49)"/>
+            <text x="84.8127%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>__remove_hrtimer (1 samples, 0.08%)</title>
+            <rect x="84.6388%" y="1029" width="0.0760%" height="15" fill="rgb(252,58,54)"/>
+            <text x="84.8888%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>timerqueue_del (1 samples, 0.08%)</title>
+            <rect x="84.6388%" y="1013" width="0.0760%" height="15" fill="rgb(220,48,51)"/>
+            <text x="84.8888%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>rb_erase (1 samples, 0.08%)</title>
+            <rect x="84.6388%" y="997" width="0.0760%" height="15" fill="rgb(209,52,50)"/>
+            <text x="84.8888%" y="1007.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_unlock_irqrestore (1 samples, 0.08%)</title>
+            <rect x="84.7148%" y="1029" width="0.0760%" height="15" fill="rgb(215,4,12)"/>
+            <text x="84.9648%" y="1039.50"></text>
         </g>
         <g>
             <title>hrtimer_try_to_cancel (3 samples, 0.23%)</title>
@@ -2531,14 +4596,59 @@ var truncate_text_right = false;]]>
             <text x="84.8888%" y="1055.50"></text>
         </g>
         <g>
+            <title>lock_hrtimer_base.isra.19 (1 samples, 0.08%)</title>
+            <rect x="84.7909%" y="1029" width="0.0760%" height="15" fill="rgb(246,162,18)"/>
+            <text x="85.0409%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_irqsave (1 samples, 0.08%)</title>
+            <rect x="84.7909%" y="1013" width="0.0760%" height="15" fill="rgb(237,195,40)"/>
+            <text x="85.0409%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>idle_cpu (1 samples, 0.08%)</title>
+            <rect x="84.8669%" y="1045" width="0.0760%" height="15" fill="rgb(242,210,7)"/>
+            <text x="85.1169%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>lock_hrtimer_base.isra.19 (1 samples, 0.08%)</title>
+            <rect x="84.9430%" y="1045" width="0.0760%" height="15" fill="rgb(246,162,18)"/>
+            <text x="85.1930%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>account_entity_dequeue (1 samples, 0.08%)</title>
+            <rect x="85.1711%" y="965" width="0.0760%" height="15" fill="rgb(229,43,30)"/>
+            <text x="85.4211%" y="975.50"></text>
+        </g>
+        <g>
+            <title>update_cfs_rq_blocked_load (1 samples, 0.08%)</title>
+            <rect x="85.3992%" y="949" width="0.0760%" height="15" fill="rgb(207,167,27)"/>
+            <text x="85.6492%" y="959.50"></text>
+        </g>
+        <g>
             <title>dequeue_entity (4 samples, 0.30%)</title>
             <rect x="85.2471%" y="965" width="0.3042%" height="15" fill="rgb(224,184,40)"/>
             <text x="85.4971%" y="975.50"></text>
         </g>
         <g>
+            <title>update_curr (1 samples, 0.08%)</title>
+            <rect x="85.4753%" y="949" width="0.0760%" height="15" fill="rgb(229,209,25)"/>
+            <text x="85.7253%" y="959.50"></text>
+        </g>
+        <g>
+            <title>cpuacct_charge (1 samples, 0.08%)</title>
+            <rect x="85.4753%" y="933" width="0.0760%" height="15" fill="rgb(213,101,4)"/>
+            <text x="85.7253%" y="943.50"></text>
+        </g>
+        <g>
             <title>dequeue_task_fair (6 samples, 0.46%)</title>
             <rect x="85.1711%" y="981" width="0.4563%" height="15" fill="rgb(211,227,42)"/>
             <text x="85.4211%" y="991.50"></text>
+        </g>
+        <g>
+            <title>update_min_vruntime (1 samples, 0.08%)</title>
+            <rect x="85.5513%" y="965" width="0.0760%" height="15" fill="rgb(246,72,17)"/>
+            <text x="85.8013%" y="975.50"></text>
         </g>
         <g>
             <title>deactivate_task (7 samples, 0.53%)</title>
@@ -2549,6 +4659,31 @@ var truncate_text_right = false;]]>
             <title>dequeue_task (7 samples, 0.53%)</title>
             <rect x="85.1711%" y="997" width="0.5323%" height="15" fill="rgb(245,227,9)"/>
             <text x="85.4211%" y="1007.50"></text>
+        </g>
+        <g>
+            <title>update_rq_clock.part.63 (1 samples, 0.08%)</title>
+            <rect x="85.6274%" y="981" width="0.0760%" height="15" fill="rgb(240,13,25)"/>
+            <text x="85.8774%" y="991.50"></text>
+        </g>
+        <g>
+            <title>sched_clock_cpu (1 samples, 0.08%)</title>
+            <rect x="85.6274%" y="965" width="0.0760%" height="15" fill="rgb(253,198,6)"/>
+            <text x="85.8774%" y="975.50"></text>
+        </g>
+        <g>
+            <title>sched_clock (1 samples, 0.08%)</title>
+            <rect x="85.6274%" y="949" width="0.0760%" height="15" fill="rgb(232,27,46)"/>
+            <text x="85.8774%" y="959.50"></text>
+        </g>
+        <g>
+            <title>native_sched_clock (1 samples, 0.08%)</title>
+            <rect x="85.6274%" y="933" width="0.0760%" height="15" fill="rgb(247,33,39)"/>
+            <text x="85.8774%" y="943.50"></text>
+        </g>
+        <g>
+            <title>pick_next_task_fair (1 samples, 0.08%)</title>
+            <rect x="85.7034%" y="1013" width="0.0760%" height="15" fill="rgb(214,159,37)"/>
+            <text x="85.9534%" y="1023.50"></text>
         </g>
         <g>
             <title>schedule_hrtimeout_range (20 samples, 1.52%)</title>
@@ -2571,6 +4706,11 @@ var truncate_text_right = false;]]>
             <text x="85.2690%" y="1039.50"></text>
         </g>
         <g>
+            <title>put_prev_task_fair (1 samples, 0.08%)</title>
+            <rect x="85.7795%" y="1013" width="0.0760%" height="15" fill="rgb(210,43,42)"/>
+            <text x="86.0295%" y="1023.50"></text>
+        </g>
+        <g>
             <title>select_estimate_accuracy (5 samples, 0.38%)</title>
             <rect x="85.8555%" y="1077" width="0.3802%" height="15" fill="rgb(218,65,16)"/>
             <text x="86.1055%" y="1087.50"></text>
@@ -2589,6 +4729,11 @@ var truncate_text_right = false;]]>
             <title>task_nice (2 samples, 0.15%)</title>
             <rect x="86.2357%" y="1077" width="0.1521%" height="15" fill="rgb(212,69,16)"/>
             <text x="86.4857%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>fget_light (1 samples, 0.08%)</title>
+            <rect x="86.3878%" y="1093" width="0.0760%" height="15" fill="rgb(223,107,44)"/>
+            <text x="86.6378%" y="1103.50"></text>
         </g>
         <g>
             <title>[libc-2.19.so] (61 samples, 4.64%)</title>
@@ -2616,14 +4761,124 @@ var truncate_text_right = false;]]>
             <text x="87.0941%" y="1135.50"></text>
         </g>
         <g>
+            <title>apic_timer_interrupt (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1125" width="0.0760%" height="15" fill="rgb(220,13,9)"/>
+            <text x="87.3983%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>smp_apic_timer_interrupt (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1109" width="0.0760%" height="15" fill="rgb(237,158,53)"/>
+            <text x="87.3983%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>local_apic_timer_interrupt (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1093" width="0.0760%" height="15" fill="rgb(248,203,15)"/>
+            <text x="87.3983%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>hrtimer_interrupt (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1077" width="0.0760%" height="15" fill="rgb(214,92,16)"/>
+            <text x="87.3983%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>__run_hrtimer (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1061" width="0.0760%" height="15" fill="rgb(233,34,51)"/>
+            <text x="87.3983%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>tick_sched_timer (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1045" width="0.0760%" height="15" fill="rgb(248,36,20)"/>
+            <text x="87.3983%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>tick_sched_handle.isra.17 (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1029" width="0.0760%" height="15" fill="rgb(218,90,30)"/>
+            <text x="87.3983%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>update_process_times (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="1013" width="0.0760%" height="15" fill="rgb(238,52,5)"/>
+            <text x="87.3983%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>account_process_tick (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="997" width="0.0760%" height="15" fill="rgb(231,9,12)"/>
+            <text x="87.3983%" y="1007.50"></text>
+        </g>
+        <g>
+            <title>account_user_time (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="981" width="0.0760%" height="15" fill="rgb(211,33,18)"/>
+            <text x="87.3983%" y="991.50"></text>
+        </g>
+        <g>
+            <title>acct_account_cputime (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="965" width="0.0760%" height="15" fill="rgb(229,198,30)"/>
+            <text x="87.3983%" y="975.50"></text>
+        </g>
+        <g>
+            <title>__acct_update_integrals (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="949" width="0.0760%" height="15" fill="rgb(220,103,18)"/>
+            <text x="87.3983%" y="959.50"></text>
+        </g>
+        <g>
+            <title>jiffies_to_timeval (1 samples, 0.08%)</title>
+            <rect x="87.1483%" y="933" width="0.0760%" height="15" fill="rgb(248,26,54)"/>
+            <text x="87.3983%" y="943.50"></text>
+        </g>
+        <g>
+            <title>gettimeofday@plt (1 samples, 0.08%)</title>
+            <rect x="87.2243%" y="1125" width="0.0760%" height="15" fill="rgb(225,37,52)"/>
+            <text x="87.4743%" y="1135.50"></text>
+        </g>
+        <g>
+            <title>http_parser_execute (1 samples, 0.08%)</title>
+            <rect x="87.3004%" y="1125" width="0.0760%" height="15" fill="rgb(253,147,45)"/>
+            <text x="87.5504%" y="1135.50"></text>
+        </g>
+        <g>
             <title>sock_read (2 samples, 0.15%)</title>
             <rect x="87.3764%" y="1125" width="0.1521%" height="15" fill="rgb(253,116,23)"/>
             <text x="87.6264%" y="1135.50"></text>
         </g>
         <g>
+            <title>system_call_after_swapgs (1 samples, 0.08%)</title>
+            <rect x="87.7567%" y="1093" width="0.0760%" height="15" fill="rgb(248,86,14)"/>
+            <text x="88.0067%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>fget_light (1 samples, 0.08%)</title>
+            <rect x="87.8327%" y="1077" width="0.0760%" height="15" fill="rgb(223,107,44)"/>
+            <text x="88.0827%" y="1087.50"></text>
+        </g>
+        <g>
             <title>fget_light (2 samples, 0.15%)</title>
             <rect x="87.9848%" y="1061" width="0.1521%" height="15" fill="rgb(223,107,44)"/>
             <text x="88.2348%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>__kfree_skb (1 samples, 0.08%)</title>
+            <rect x="88.5171%" y="965" width="0.0760%" height="15" fill="rgb(220,192,38)"/>
+            <text x="88.7671%" y="975.50"></text>
+        </g>
+        <g>
+            <title>kfree_skbmem (1 samples, 0.08%)</title>
+            <rect x="88.5171%" y="949" width="0.0760%" height="15" fill="rgb(229,204,44)"/>
+            <text x="88.7671%" y="959.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_bh (1 samples, 0.08%)</title>
+            <rect x="88.5932%" y="965" width="0.0760%" height="15" fill="rgb(218,157,7)"/>
+            <text x="88.8432%" y="975.50"></text>
+        </g>
+        <g>
+            <title>skb_copy_datagram_iovec (1 samples, 0.08%)</title>
+            <rect x="88.6692%" y="965" width="0.0760%" height="15" fill="rgb(205,218,18)"/>
+            <text x="88.9192%" y="975.50"></text>
+        </g>
+        <g>
+            <title>copy_user_generic_string (1 samples, 0.08%)</title>
+            <rect x="88.6692%" y="949" width="0.0760%" height="15" fill="rgb(253,91,47)"/>
+            <text x="88.9192%" y="959.50"></text>
         </g>
         <g>
             <title>do_sync_read (8 samples, 0.61%)</title>
@@ -2651,9 +4906,44 @@ var truncate_text_right = false;]]>
             <text x="88.5390%" y="991.50"></text>
         </g>
         <g>
+            <title>tcp_cleanup_rbuf (1 samples, 0.08%)</title>
+            <rect x="88.7452%" y="965" width="0.0760%" height="15" fill="rgb(206,61,24)"/>
+            <text x="88.9952%" y="975.50"></text>
+        </g>
+        <g>
+            <title>__tcp_select_window (1 samples, 0.08%)</title>
+            <rect x="88.7452%" y="949" width="0.0760%" height="15" fill="rgb(207,172,41)"/>
+            <text x="88.9952%" y="959.50"></text>
+        </g>
+        <g>
             <title>apparmor_file_permission (2 samples, 0.15%)</title>
             <rect x="88.9734%" y="1029" width="0.1521%" height="15" fill="rgb(243,206,54)"/>
             <text x="89.2234%" y="1039.50"></text>
+        </g>
+        <g>
+            <title>__fsnotify_parent (1 samples, 0.08%)</title>
+            <rect x="89.2015%" y="1013" width="0.0760%" height="15" fill="rgb(233,25,34)"/>
+            <text x="89.4515%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>apparmor_file_permission (1 samples, 0.08%)</title>
+            <rect x="89.2776%" y="1013" width="0.0760%" height="15" fill="rgb(243,206,54)"/>
+            <text x="89.5276%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>common_file_perm (1 samples, 0.08%)</title>
+            <rect x="89.2776%" y="997" width="0.0760%" height="15" fill="rgb(219,178,19)"/>
+            <text x="89.5276%" y="1007.50"></text>
+        </g>
+        <g>
+            <title>aa_file_perm (1 samples, 0.08%)</title>
+            <rect x="89.2776%" y="981" width="0.0760%" height="15" fill="rgb(247,203,23)"/>
+            <text x="89.5276%" y="991.50"></text>
+        </g>
+        <g>
+            <title>common_file_perm (1 samples, 0.08%)</title>
+            <rect x="89.3536%" y="1013" width="0.0760%" height="15" fill="rgb(219,178,19)"/>
+            <text x="89.6036%" y="1023.50"></text>
         </g>
         <g>
             <title>[libpthread-2.19.so] (26 samples, 1.98%)</title>
@@ -2686,6 +4976,36 @@ var truncate_text_right = false;]]>
             <text x="89.3755%" y="1039.50"></text>
         </g>
         <g>
+            <title>fsnotify (1 samples, 0.08%)</title>
+            <rect x="89.4297%" y="1013" width="0.0760%" height="15" fill="rgb(246,57,19)"/>
+            <text x="89.6797%" y="1023.50"></text>
+        </g>
+        <g>
+            <title>__libc_read (1 samples, 0.08%)</title>
+            <rect x="89.5057%" y="1109" width="0.0760%" height="15" fill="rgb(247,118,19)"/>
+            <text x="89.7557%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>[[vdso]] (1 samples, 0.08%)</title>
+            <rect x="90.7224%" y="1093" width="0.0760%" height="15" fill="rgb(246,184,46)"/>
+            <text x="90.9724%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>[[vdso]] (1 samples, 0.08%)</title>
+            <rect x="91.0266%" y="1077" width="0.0760%" height="15" fill="rgb(246,184,46)"/>
+            <text x="91.2766%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>mutex_unlock (1 samples, 0.08%)</title>
+            <rect x="91.1027%" y="1045" width="0.0760%" height="15" fill="rgb(230,191,50)"/>
+            <text x="91.3527%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_irq (1 samples, 0.08%)</title>
+            <rect x="91.4068%" y="1029" width="0.0760%" height="15" fill="rgb(226,192,23)"/>
+            <text x="91.6568%" y="1039.50"></text>
+        </g>
+        <g>
             <title>epoll_ctl (6 samples, 0.46%)</title>
             <rect x="91.1027%" y="1077" width="0.4563%" height="15" fill="rgb(236,195,16)"/>
             <text x="91.3527%" y="1087.50"></text>
@@ -2699,6 +5019,11 @@ var truncate_text_right = false;]]>
             <title>sys_epoll_ctl (5 samples, 0.38%)</title>
             <rect x="91.1787%" y="1045" width="0.3802%" height="15" fill="rgb(210,189,43)"/>
             <text x="91.4287%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>sock_poll (1 samples, 0.08%)</title>
+            <rect x="91.4829%" y="1029" width="0.0760%" height="15" fill="rgb(209,64,23)"/>
+            <text x="91.7329%" y="1039.50"></text>
         </g>
         <g>
             <title>response_complete (13 samples, 0.99%)</title>
@@ -2716,6 +5041,11 @@ var truncate_text_right = false;]]>
             <text x="89.8317%" y="1119.50">h..</text>
         </g>
         <g>
+            <title>stats_record (1 samples, 0.08%)</title>
+            <rect x="91.7871%" y="1093" width="0.0760%" height="15" fill="rgb(252,79,5)"/>
+            <text x="92.0371%" y="1103.50"></text>
+        </g>
+        <g>
             <title>socket_readable (60 samples, 4.56%)</title>
             <rect x="87.5285%" y="1125" width="4.5627%" height="15" fill="rgb(210,55,33)"/>
             <text x="87.7785%" y="1135.50">socke..</text>
@@ -2724,6 +5054,41 @@ var truncate_text_right = false;]]>
             <title>sock_read (3 samples, 0.23%)</title>
             <rect x="91.8631%" y="1109" width="0.2281%" height="15" fill="rgb(253,116,23)"/>
             <text x="92.1131%" y="1119.50"></text>
+        </g>
+        <g>
+            <title>system_call_after_swapgs (1 samples, 0.08%)</title>
+            <rect x="92.3194%" y="1093" width="0.0760%" height="15" fill="rgb(248,86,14)"/>
+            <text x="92.5694%" y="1103.50"></text>
+        </g>
+        <g>
+            <title>fget_light (1 samples, 0.08%)</title>
+            <rect x="92.4715%" y="1061" width="0.0760%" height="15" fill="rgb(223,107,44)"/>
+            <text x="92.7215%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>fsnotify (1 samples, 0.08%)</title>
+            <rect x="92.5475%" y="1061" width="0.0760%" height="15" fill="rgb(246,57,19)"/>
+            <text x="92.7975%" y="1071.50"></text>
+        </g>
+        <g>
+            <title>__srcu_read_unlock (1 samples, 0.08%)</title>
+            <rect x="92.6236%" y="1045" width="0.0760%" height="15" fill="rgb(251,34,1)"/>
+            <text x="92.8736%" y="1055.50"></text>
+        </g>
+        <g>
+            <title>__tcp_push_pending_frames (1 samples, 0.08%)</title>
+            <rect x="92.8517%" y="997" width="0.0760%" height="15" fill="rgb(205,62,21)"/>
+            <text x="93.1017%" y="1007.50"></text>
+        </g>
+        <g>
+            <title>tcp_transmit_skb (1 samples, 0.08%)</title>
+            <rect x="93.3840%" y="965" width="0.0760%" height="15" fill="rgb(212,100,38)"/>
+            <text x="93.6340%" y="975.50"></text>
+        </g>
+        <g>
+            <title>skb_clone (1 samples, 0.08%)</title>
+            <rect x="93.5361%" y="949" width="0.0760%" height="15" fill="rgb(238,197,14)"/>
+            <text x="93.7861%" y="959.50"></text>
         </g>
         <g>
             <title>tcp_event_new_data_sent (3 samples, 0.23%)</title>
@@ -2746,6 +5111,26 @@ var truncate_text_right = false;]]>
             <text x="93.8622%" y="911.50"></text>
         </g>
         <g>
+            <title>_raw_spin_unlock_irqrestore (1 samples, 0.08%)</title>
+            <rect x="93.7643%" y="885" width="0.0760%" height="15" fill="rgb(215,4,12)"/>
+            <text x="94.0143%" y="895.50"></text>
+        </g>
+        <g>
+            <title>__skb_clone (1 samples, 0.08%)</title>
+            <rect x="93.9924%" y="933" width="0.0760%" height="15" fill="rgb(253,228,45)"/>
+            <text x="94.2424%" y="943.50"></text>
+        </g>
+        <g>
+            <title>__ip_local_out (1 samples, 0.08%)</title>
+            <rect x="94.3726%" y="917" width="0.0760%" height="15" fill="rgb(222,48,23)"/>
+            <text x="94.6226%" y="927.50"></text>
+        </g>
+        <g>
+            <title>harmonize_features.isra.92.part.93 (1 samples, 0.08%)</title>
+            <rect x="94.6008%" y="821" width="0.0760%" height="15" fill="rgb(223,19,51)"/>
+            <text x="94.8508%" y="831.50"></text>
+        </g>
+        <g>
             <title>dev_queue_xmit (4 samples, 0.30%)</title>
             <rect x="94.4487%" y="869" width="0.3042%" height="15" fill="rgb(221,152,51)"/>
             <text x="94.6987%" y="879.50"></text>
@@ -2759,6 +5144,11 @@ var truncate_text_right = false;]]>
             <title>dev_hard_start_xmit (3 samples, 0.23%)</title>
             <rect x="94.5247%" y="837" width="0.2281%" height="15" fill="rgb(228,157,33)"/>
             <text x="94.7747%" y="847.50"></text>
+        </g>
+        <g>
+            <title>tcp_wfree (1 samples, 0.08%)</title>
+            <rect x="94.6768%" y="821" width="0.0760%" height="15" fill="rgb(254,113,18)"/>
+            <text x="94.9268%" y="831.50"></text>
         </g>
         <g>
             <title>call_function_single_interrupt (4 samples, 0.30%)</title>
@@ -2816,9 +5206,29 @@ var truncate_text_right = false;]]>
             <text x="95.0029%" y="703.50"></text>
         </g>
         <g>
+            <title>raw_local_deliver (1 samples, 0.08%)</title>
+            <rect x="95.5133%" y="677" width="0.0760%" height="15" fill="rgb(208,206,25)"/>
+            <text x="95.7633%" y="687.50"></text>
+        </g>
+        <g>
+            <title>sock_put (1 samples, 0.08%)</title>
+            <rect x="95.5894%" y="677" width="0.0760%" height="15" fill="rgb(225,101,27)"/>
+            <text x="95.8394%" y="687.50"></text>
+        </g>
+        <g>
+            <title>tcp_prequeue (1 samples, 0.08%)</title>
+            <rect x="95.6654%" y="677" width="0.0760%" height="15" fill="rgb(243,192,24)"/>
+            <text x="95.9154%" y="687.50"></text>
+        </g>
+        <g>
             <title>__inet_lookup_established (2 samples, 0.15%)</title>
             <rect x="95.8935%" y="661" width="0.1521%" height="15" fill="rgb(241,7,8)"/>
             <text x="96.1435%" y="671.50"></text>
+        </g>
+        <g>
+            <title>inet_ehashfn (1 samples, 0.08%)</title>
+            <rect x="95.9696%" y="645" width="0.0760%" height="15" fill="rgb(238,85,49)"/>
+            <text x="96.2196%" y="655.50"></text>
         </g>
         <g>
             <title>__tcp_ack_snd_check (3 samples, 0.23%)</title>
@@ -2846,6 +5256,31 @@ var truncate_text_right = false;]]>
             <text x="96.4477%" y="575.50"></text>
         </g>
         <g>
+            <title>__internal_add_timer (1 samples, 0.08%)</title>
+            <rect x="96.2738%" y="549" width="0.0760%" height="15" fill="rgb(241,204,17)"/>
+            <text x="96.5238%" y="559.50"></text>
+        </g>
+        <g>
+            <title>bictcp_cong_avoid (1 samples, 0.08%)</title>
+            <rect x="96.3498%" y="629" width="0.0760%" height="15" fill="rgb(215,138,19)"/>
+            <text x="96.5998%" y="639.50"></text>
+        </g>
+        <g>
+            <title>bictcp_cong_avoid (1 samples, 0.08%)</title>
+            <rect x="96.7300%" y="613" width="0.0760%" height="15" fill="rgb(215,138,19)"/>
+            <text x="96.9800%" y="623.50"></text>
+        </g>
+        <g>
+            <title>tcp_clean_rtx_queue (1 samples, 0.08%)</title>
+            <rect x="96.8061%" y="613" width="0.0760%" height="15" fill="rgb(239,24,17)"/>
+            <text x="97.0561%" y="623.50"></text>
+        </g>
+        <g>
+            <title>ns_to_timeval (1 samples, 0.08%)</title>
+            <rect x="96.8061%" y="597" width="0.0760%" height="15" fill="rgb(252,212,44)"/>
+            <text x="97.0561%" y="607.50"></text>
+        </g>
+        <g>
             <title>tcp_ack (9 samples, 0.68%)</title>
             <rect x="96.4259%" y="629" width="0.6844%" height="15" fill="rgb(214,177,25)"/>
             <text x="96.6759%" y="639.50"></text>
@@ -2866,9 +5301,29 @@ var truncate_text_right = false;]]>
             <text x="97.2082%" y="591.50"></text>
         </g>
         <g>
+            <title>lock_timer_base.isra.35 (1 samples, 0.08%)</title>
+            <rect x="97.0342%" y="565" width="0.0760%" height="15" fill="rgb(221,152,40)"/>
+            <text x="97.2842%" y="575.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_irqsave (1 samples, 0.08%)</title>
+            <rect x="97.0342%" y="549" width="0.0760%" height="15" fill="rgb(237,195,40)"/>
+            <text x="97.2842%" y="559.50"></text>
+        </g>
+        <g>
             <title>__wake_up_common (2 samples, 0.15%)</title>
             <rect x="97.3384%" y="581" width="0.1521%" height="15" fill="rgb(205,80,9)"/>
             <text x="97.5884%" y="591.50"></text>
+        </g>
+        <g>
+            <title>ep_poll_callback (1 samples, 0.08%)</title>
+            <rect x="97.4144%" y="565" width="0.0760%" height="15" fill="rgb(240,7,14)"/>
+            <text x="97.6644%" y="575.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_unlock_irqrestore (1 samples, 0.08%)</title>
+            <rect x="97.4144%" y="549" width="0.0760%" height="15" fill="rgb(215,4,12)"/>
+            <text x="97.6644%" y="559.50"></text>
         </g>
         <g>
             <title>sock_def_readable (5 samples, 0.38%)</title>
@@ -2879,6 +5334,16 @@ var truncate_text_right = false;]]>
             <title>__wake_up_sync_key (3 samples, 0.23%)</title>
             <rect x="97.3384%" y="597" width="0.2281%" height="15" fill="rgb(241,172,3)"/>
             <text x="97.5884%" y="607.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_lock_irqsave (1 samples, 0.08%)</title>
+            <rect x="97.4905%" y="581" width="0.0760%" height="15" fill="rgb(237,195,40)"/>
+            <text x="97.7405%" y="591.50"></text>
+        </g>
+        <g>
+            <title>tcp_event_data_recv (1 samples, 0.08%)</title>
+            <rect x="97.5665%" y="613" width="0.0760%" height="15" fill="rgb(209,192,48)"/>
+            <text x="97.8165%" y="623.50"></text>
         </g>
         <g>
             <title>__netif_receive_skb_core (33 samples, 2.51%)</title>
@@ -2951,6 +5416,11 @@ var truncate_text_right = false;]]>
             <text x="95.5352%" y="783.50">__..</text>
         </g>
         <g>
+            <title>ip_rcv (1 samples, 0.08%)</title>
+            <rect x="97.7947%" y="757" width="0.0760%" height="15" fill="rgb(232,118,47)"/>
+            <text x="98.0447%" y="767.50"></text>
+        </g>
+        <g>
             <title>ip_queue_xmit (51 samples, 3.88%)</title>
             <rect x="94.0684%" y="933" width="3.8783%" height="15" fill="rgb(242,123,36)"/>
             <text x="94.3184%" y="943.50">ip_q..</text>
@@ -2986,6 +5456,11 @@ var truncate_text_right = false;]]>
             <text x="95.3831%" y="847.50">do..</text>
         </g>
         <g>
+            <title>rcu_bh_qs (1 samples, 0.08%)</title>
+            <rect x="97.8707%" y="821" width="0.0760%" height="15" fill="rgb(232,134,16)"/>
+            <text x="98.1207%" y="831.50"></text>
+        </g>
+        <g>
             <title>__tcp_push_pending_frames (61 samples, 4.64%)</title>
             <rect x="93.3840%" y="981" width="4.6388%" height="15" fill="rgb(205,62,21)"/>
             <text x="93.6340%" y="991.50">__tcp..</text>
@@ -3001,6 +5476,46 @@ var truncate_text_right = false;]]>
             <text x="94.0903%" y="959.50">tcp_t..</text>
         </g>
         <g>
+            <title>skb_clone (1 samples, 0.08%)</title>
+            <rect x="97.9468%" y="933" width="0.0760%" height="15" fill="rgb(238,197,14)"/>
+            <text x="98.1968%" y="943.50"></text>
+        </g>
+        <g>
+            <title>__skb_clone (1 samples, 0.08%)</title>
+            <rect x="97.9468%" y="917" width="0.0760%" height="15" fill="rgb(253,228,45)"/>
+            <text x="98.1968%" y="927.50"></text>
+        </g>
+        <g>
+            <title>lock_sock_nested (1 samples, 0.08%)</title>
+            <rect x="98.0228%" y="981" width="0.0760%" height="15" fill="rgb(252,7,51)"/>
+            <text x="98.2728%" y="991.50"></text>
+        </g>
+        <g>
+            <title>local_bh_enable (1 samples, 0.08%)</title>
+            <rect x="98.0228%" y="965" width="0.0760%" height="15" fill="rgb(212,24,16)"/>
+            <text x="98.2728%" y="975.50"></text>
+        </g>
+        <g>
+            <title>release_sock (1 samples, 0.08%)</title>
+            <rect x="98.0989%" y="981" width="0.0760%" height="15" fill="rgb(244,133,13)"/>
+            <text x="98.3489%" y="991.50"></text>
+        </g>
+        <g>
+            <title>_raw_spin_unlock_bh (1 samples, 0.08%)</title>
+            <rect x="98.0989%" y="965" width="0.0760%" height="15" fill="rgb(244,89,32)"/>
+            <text x="98.3489%" y="975.50"></text>
+        </g>
+        <g>
+            <title>local_bh_enable_ip (1 samples, 0.08%)</title>
+            <rect x="98.0989%" y="949" width="0.0760%" height="15" fill="rgb(254,167,42)"/>
+            <text x="98.3489%" y="959.50"></text>
+        </g>
+        <g>
+            <title>__kmalloc_node_track_caller (1 samples, 0.08%)</title>
+            <rect x="98.3270%" y="949" width="0.0760%" height="15" fill="rgb(242,124,1)"/>
+            <text x="98.5770%" y="959.50"></text>
+        </g>
+        <g>
             <title>__slab_alloc (3 samples, 0.23%)</title>
             <rect x="98.4030%" y="933" width="0.2281%" height="15" fill="rgb(253,9,42)"/>
             <text x="98.6530%" y="943.50"></text>
@@ -3009,6 +5524,21 @@ var truncate_text_right = false;]]>
             <title>new_slab (2 samples, 0.15%)</title>
             <rect x="98.4791%" y="917" width="0.1521%" height="15" fill="rgb(240,115,27)"/>
             <text x="98.7291%" y="927.50"></text>
+        </g>
+        <g>
+            <title>alloc_pages_current (1 samples, 0.08%)</title>
+            <rect x="98.5551%" y="901" width="0.0760%" height="15" fill="rgb(218,56,25)"/>
+            <text x="98.8051%" y="911.50"></text>
+        </g>
+        <g>
+            <title>__alloc_pages_nodemask (1 samples, 0.08%)</title>
+            <rect x="98.5551%" y="885" width="0.0760%" height="15" fill="rgb(233,173,51)"/>
+            <text x="98.8051%" y="895.50"></text>
+        </g>
+        <g>
+            <title>get_page_from_freelist (1 samples, 0.08%)</title>
+            <rect x="98.5551%" y="869" width="0.0760%" height="15" fill="rgb(215,89,37)"/>
+            <text x="98.8051%" y="879.50"></text>
         </g>
         <g>
             <title>sk_stream_alloc_skb (7 samples, 0.53%)</title>
@@ -3026,6 +5556,11 @@ var truncate_text_right = false;]]>
             <text x="98.6530%" y="959.50"></text>
         </g>
         <g>
+            <title>arch_local_irq_save (1 samples, 0.08%)</title>
+            <rect x="98.6312%" y="933" width="0.0760%" height="15" fill="rgb(244,95,12)"/>
+            <text x="98.8812%" y="943.50"></text>
+        </g>
+        <g>
             <title>inet_sendmsg (78 samples, 5.93%)</title>
             <rect x="92.8517%" y="1013" width="5.9316%" height="15" fill="rgb(253,188,10)"/>
             <text x="93.1017%" y="1023.50">inet_sen..</text>
@@ -3034,6 +5569,26 @@ var truncate_text_right = false;]]>
             <title>tcp_sendmsg (77 samples, 5.86%)</title>
             <rect x="92.9278%" y="997" width="5.8555%" height="15" fill="rgb(228,107,50)"/>
             <text x="93.1778%" y="1007.50">tcp_sen..</text>
+        </g>
+        <g>
+            <title>tcp_send_mss (1 samples, 0.08%)</title>
+            <rect x="98.7072%" y="981" width="0.0760%" height="15" fill="rgb(213,61,11)"/>
+            <text x="98.9572%" y="991.50"></text>
+        </g>
+        <g>
+            <title>tcp_current_mss (1 samples, 0.08%)</title>
+            <rect x="98.7072%" y="965" width="0.0760%" height="15" fill="rgb(227,178,24)"/>
+            <text x="98.9572%" y="975.50"></text>
+        </g>
+        <g>
+            <title>tcp_established_options (1 samples, 0.08%)</title>
+            <rect x="98.7072%" y="949" width="0.0760%" height="15" fill="rgb(242,46,48)"/>
+            <text x="98.9572%" y="959.50"></text>
+        </g>
+        <g>
+            <title>tcp_md5_do_lookup (1 samples, 0.08%)</title>
+            <rect x="98.7072%" y="933" width="0.0760%" height="15" fill="rgb(215,150,44)"/>
+            <text x="98.9572%" y="943.50"></text>
         </g>
         <g>
             <title>do_sync_write (82 samples, 6.24%)</title>
@@ -3086,6 +5641,21 @@ var truncate_text_right = false;]]>
             <text x="99.1854%" y="1039.50"></text>
         </g>
         <g>
+            <title>_copy_from_user (1 samples, 0.08%)</title>
+            <rect x="99.0875%" y="1077" width="0.0760%" height="15" fill="rgb(247,129,49)"/>
+            <text x="99.3375%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>mutex_unlock (1 samples, 0.08%)</title>
+            <rect x="99.1635%" y="1077" width="0.0760%" height="15" fill="rgb(230,191,50)"/>
+            <text x="99.4135%" y="1087.50"></text>
+        </g>
+        <g>
+            <title>fget_light (1 samples, 0.08%)</title>
+            <rect x="99.3916%" y="1061" width="0.0760%" height="15" fill="rgb(223,107,44)"/>
+            <text x="99.6416%" y="1071.50"></text>
+        </g>
+        <g>
             <title>aeProcessEvents (171 samples, 13.00%)</title>
             <rect x="86.6160%" y="1141" width="13.0038%" height="15" fill="rgb(227,13,34)"/>
             <text x="86.8660%" y="1151.50">aeProcessEvents</text>
@@ -3116,6 +5686,11 @@ var truncate_text_right = false;]]>
             <text x="99.7177%" y="1071.50"></text>
         </g>
         <g>
+            <title>epoll_wait (1 samples, 0.08%)</title>
+            <rect x="99.6198%" y="1141" width="0.0760%" height="15" fill="rgb(237,102,25)"/>
+            <text x="99.8698%" y="1151.50"></text>
+        </g>
+        <g>
             <title>socket_readable (2 samples, 0.15%)</title>
             <rect x="99.6958%" y="1141" width="0.1521%" height="15" fill="rgb(210,55,33)"/>
             <text x="99.9458%" y="1151.50"></text>
@@ -3124,6 +5699,11 @@ var truncate_text_right = false;]]>
             <title>aeMain (236 samples, 17.95%)</title>
             <rect x="81.9772%" y="1157" width="17.9468%" height="15" fill="rgb(220,197,39)"/>
             <text x="82.2272%" y="1167.50">aeMain</text>
+        </g>
+        <g>
+            <title>socket_writeable (1 samples, 0.08%)</title>
+            <rect x="99.8479%" y="1141" width="0.0760%" height="15" fill="rgb(211,41,47)"/>
+            <text x="100.0979%" y="1151.50"></text>
         </g>
         <g>
             <title>all (1,315 samples, 100%)</title>
@@ -3144,6 +5724,11 @@ var truncate_text_right = false;]]>
             <title>thread_main (237 samples, 18.02%)</title>
             <rect x="81.9772%" y="1173" width="18.0228%" height="15" fill="rgb(218,20,12)"/>
             <text x="82.2272%" y="1183.50">thread_main</text>
+        </g>
+        <g>
+            <title>aeProcessEvents (1 samples, 0.08%)</title>
+            <rect x="99.9240%" y="1157" width="0.0760%" height="15" fill="rgb(227,13,34)"/>
+            <text x="100.1740%" y="1167.50"></text>
         </g>
     </svg>
 </svg>

--- a/tests/data/flamegraph/flamechart/flame.svg
+++ b/tests/data/flamegraph/flamechart/flame.svg
@@ -51,1348 +51,1703 @@ var truncate_text_right = false;]]>
             <text x="0.3503%" y="159.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="1.0361%" y="117" width="0.0167%" height="15" fill="rgb(248,212,6)"/>
+            <text x="1.2861%" y="127.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="1.2032%" y="101" width="0.1170%" height="15" fill="rgb(248,212,6)"/>
+            <rect x="1.2032%" y="101" width="0.1170%" height="15" fill="rgb(208,68,35)"/>
             <text x="1.4532%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,800 samples, 0.30%)</title>
-            <rect x="1.0361%" y="133" width="0.3008%" height="15" fill="rgb(208,68,35)"/>
+            <rect x="1.0361%" y="133" width="0.3008%" height="15" fill="rgb(232,128,0)"/>
             <text x="1.2861%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,700 samples, 0.28%)</title>
-            <rect x="1.0528%" y="117" width="0.2841%" height="15" fill="rgb(232,128,0)"/>
+            <rect x="1.0528%" y="117" width="0.2841%" height="15" fill="rgb(207,160,47)"/>
             <text x="1.3028%" y="127.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (300 samples, 0.05%)</title>
+            <rect x="1.3369%" y="133" width="0.0501%" height="15" fill="rgb(228,23,34)"/>
+            <text x="1.5869%" y="143.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (600 samples, 0.10%)</title>
-            <rect x="1.4706%" y="101" width="0.1003%" height="15" fill="rgb(207,160,47)"/>
+            <rect x="1.4706%" y="101" width="0.1003%" height="15" fill="rgb(218,30,26)"/>
             <text x="1.7206%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="1.3870%" y="133" width="0.2005%" height="15" fill="rgb(228,23,34)"/>
+            <rect x="1.3870%" y="133" width="0.2005%" height="15" fill="rgb(220,122,19)"/>
             <text x="1.6370%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="1.3870%" y="117" width="0.2005%" height="15" fill="rgb(218,30,26)"/>
+            <rect x="1.3870%" y="117" width="0.2005%" height="15" fill="rgb(250,228,42)"/>
             <text x="1.6370%" y="127.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,200 samples, 0.37%)</title>
-            <rect x="1.5876%" y="133" width="0.3676%" height="15" fill="rgb(220,122,19)"/>
+            <rect x="1.5876%" y="133" width="0.3676%" height="15" fill="rgb(240,193,28)"/>
             <text x="1.8376%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (5,700 samples, 0.95%)</title>
-            <rect x="1.0194%" y="149" width="0.9525%" height="15" fill="rgb(250,228,42)"/>
+            <rect x="1.0194%" y="149" width="0.9525%" height="15" fill="rgb(216,20,37)"/>
             <text x="1.2694%" y="159.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (800 samples, 0.13%)</title>
-            <rect x="2.0889%" y="133" width="0.1337%" height="15" fill="rgb(240,193,28)"/>
+            <rect x="2.0889%" y="133" width="0.1337%" height="15" fill="rgb(206,188,39)"/>
             <text x="2.3389%" y="143.50"></text>
         </g>
         <g>
             <title>Samples (7,500 samples, 1.25%)</title>
-            <rect x="0.9860%" y="165" width="1.2533%" height="15" fill="rgb(216,20,37)"/>
+            <rect x="0.9860%" y="165" width="1.2533%" height="15" fill="rgb(217,207,13)"/>
             <text x="1.2360%" y="175.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,600 samples, 0.27%)</title>
-            <rect x="1.9719%" y="149" width="0.2674%" height="15" fill="rgb(206,188,39)"/>
+            <rect x="1.9719%" y="149" width="0.2674%" height="15" fill="rgb(231,73,38)"/>
             <text x="2.2219%" y="159.50"></text>
         </g>
         <g>
             <title>u8::master_compress (13,000 samples, 2.17%)</title>
-            <rect x="0.0836%" y="181" width="2.1725%" height="15" fill="rgb(217,207,13)"/>
+            <rect x="0.0836%" y="181" width="2.1725%" height="15" fill="rgb(225,20,46)"/>
             <text x="0.3336%" y="191.50">u..</text>
         </g>
         <g>
             <title>u8::CopyToLowered (1,600 samples, 0.27%)</title>
-            <rect x="2.2560%" y="181" width="0.2674%" height="15" fill="rgb(231,73,38)"/>
+            <rect x="2.2560%" y="181" width="0.2674%" height="15" fill="rgb(210,31,41)"/>
             <text x="2.5060%" y="191.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (14,700 samples, 2.46%)</title>
-            <rect x="0.0836%" y="197" width="2.4566%" height="15" fill="rgb(225,20,46)"/>
+            <rect x="0.0836%" y="197" width="2.4566%" height="15" fill="rgb(221,200,47)"/>
             <text x="0.3336%" y="207.50">al..</text>
         </g>
         <g>
+            <title>&amp;[bool]::encode_packed_bool (400 samples, 0.07%)</title>
+            <rect x="2.5735%" y="133" width="0.0668%" height="15" fill="rgb(226,26,5)"/>
+            <text x="2.8235%" y="143.50"></text>
+        </g>
+        <g>
             <title>Final (600 samples, 0.10%)</title>
-            <rect x="2.5568%" y="165" width="0.1003%" height="15" fill="rgb(210,31,41)"/>
+            <rect x="2.5568%" y="165" width="0.1003%" height="15" fill="rgb(249,33,26)"/>
             <text x="2.8068%" y="175.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::types::boolean::PackedBoolCompressor::compress_PackedBool (500 samples, 0.08%)</title>
+            <rect x="2.5735%" y="149" width="0.0836%" height="15" fill="rgb(235,183,28)"/>
+            <text x="2.8235%" y="159.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="2.6905%" y="133" width="0.0167%" height="15" fill="rgb(221,5,38)"/>
+            <text x="2.9405%" y="143.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (600 samples, 0.10%)</title>
-            <rect x="2.8910%" y="117" width="0.1003%" height="15" fill="rgb(221,200,47)"/>
+            <rect x="2.8910%" y="117" width="0.1003%" height="15" fill="rgb(247,18,42)"/>
             <text x="3.1410%" y="127.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,900 samples, 0.32%)</title>
-            <rect x="2.6905%" y="149" width="0.3175%" height="15" fill="rgb(226,26,5)"/>
+            <rect x="2.6905%" y="149" width="0.3175%" height="15" fill="rgb(241,131,45)"/>
             <text x="2.9405%" y="159.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,800 samples, 0.30%)</title>
-            <rect x="2.7072%" y="133" width="0.3008%" height="15" fill="rgb(249,33,26)"/>
+            <rect x="2.7072%" y="133" width="0.3008%" height="15" fill="rgb(249,31,29)"/>
             <text x="2.9572%" y="143.50"></text>
         </g>
         <g>
             <title>u8::CopyToLowered (1,900 samples, 0.32%)</title>
-            <rect x="3.0080%" y="149" width="0.3175%" height="15" fill="rgb(235,183,28)"/>
+            <rect x="3.0080%" y="149" width="0.3175%" height="15" fill="rgb(225,111,53)"/>
             <text x="3.2580%" y="159.50"></text>
         </g>
         <g>
             <title>Samples (4,100 samples, 0.69%)</title>
-            <rect x="2.6571%" y="165" width="0.6852%" height="15" fill="rgb(221,5,38)"/>
+            <rect x="2.6571%" y="165" width="0.6852%" height="15" fill="rgb(238,160,17)"/>
             <text x="2.9071%" y="175.50"></text>
         </g>
         <g>
             <title>bool::master_compress (4,900 samples, 0.82%)</title>
-            <rect x="2.5401%" y="181" width="0.8189%" height="15" fill="rgb(247,18,42)"/>
+            <rect x="2.5401%" y="181" width="0.8189%" height="15" fill="rgb(214,148,48)"/>
             <text x="2.7901%" y="191.50"></text>
         </g>
         <g>
+            <title>Final (200 samples, 0.03%)</title>
+            <rect x="3.4258%" y="101" width="0.0334%" height="15" fill="rgb(232,36,49)"/>
+            <text x="3.6758%" y="111.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::PrefixVarInt_compress (100 samples, 0.02%)</title>
+            <rect x="3.4425%" y="85" width="0.0167%" height="15" fill="rgb(209,103,24)"/>
+            <text x="3.6925%" y="95.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::PrefixVarIntCompressor)&gt;::fast_size_for (200 samples, 0.03%)</title>
+            <rect x="3.4759%" y="85" width="0.0334%" height="15" fill="rgb(229,88,8)"/>
+            <text x="3.7259%" y="95.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="3.5094%" y="85" width="0.0167%" height="15" fill="rgb(213,181,19)"/>
+            <text x="3.7594%" y="95.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (300 samples, 0.05%)</title>
+            <rect x="3.5261%" y="85" width="0.0501%" height="15" fill="rgb(254,191,54)"/>
+            <text x="3.7761%" y="95.50"></text>
+        </g>
+        <g>
+            <title>Needless_copy_to_u32 (200 samples, 0.03%)</title>
+            <rect x="3.5428%" y="69" width="0.0334%" height="15" fill="rgb(241,83,37)"/>
+            <text x="3.7928%" y="79.50"></text>
+        </g>
+        <g>
             <title>u16::master_compress (1,000 samples, 0.17%)</title>
-            <rect x="3.4258%" y="117" width="0.1671%" height="15" fill="rgb(241,131,45)"/>
+            <rect x="3.4258%" y="117" width="0.1671%" height="15" fill="rgb(233,36,39)"/>
             <text x="3.6758%" y="127.50"></text>
         </g>
         <g>
             <title>Samples (800 samples, 0.13%)</title>
-            <rect x="3.4592%" y="101" width="0.1337%" height="15" fill="rgb(249,31,29)"/>
+            <rect x="3.4592%" y="101" width="0.1337%" height="15" fill="rgb(226,3,54)"/>
             <text x="3.7092%" y="111.50"></text>
         </g>
         <g>
+            <title>u16::CopyToLowered (200 samples, 0.03%)</title>
+            <rect x="3.5929%" y="117" width="0.0334%" height="15" fill="rgb(245,192,40)"/>
+            <text x="3.8429%" y="127.50"></text>
+        </g>
+        <g>
             <title>&amp;[bool]::encode_rle_bool (2,100 samples, 0.35%)</title>
-            <rect x="3.3924%" y="149" width="0.3509%" height="15" fill="rgb(225,111,53)"/>
+            <rect x="3.3924%" y="149" width="0.3509%" height="15" fill="rgb(238,167,29)"/>
             <text x="3.6424%" y="159.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (2,000 samples, 0.33%)</title>
-            <rect x="3.4091%" y="133" width="0.3342%" height="15" fill="rgb(238,160,17)"/>
+            <rect x="3.4091%" y="133" width="0.3342%" height="15" fill="rgb(232,182,51)"/>
             <text x="3.6591%" y="143.50"></text>
         </g>
         <g>
             <title>Final (2,200 samples, 0.37%)</title>
-            <rect x="3.3924%" y="165" width="0.3676%" height="15" fill="rgb(214,148,48)"/>
+            <rect x="3.3924%" y="165" width="0.3676%" height="15" fill="rgb(231,60,39)"/>
             <text x="3.6424%" y="175.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="3.7934%" y="133" width="0.0167%" height="15" fill="rgb(208,69,12)"/>
+            <text x="4.0434%" y="143.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (300 samples, 0.05%)</title>
+            <rect x="3.8102%" y="133" width="0.0501%" height="15" fill="rgb(235,93,37)"/>
+            <text x="4.0602%" y="143.50"></text>
+        </g>
+        <g>
+            <title>Needless_copy_to_u32 (200 samples, 0.03%)</title>
+            <rect x="3.8269%" y="117" width="0.0334%" height="15" fill="rgb(213,116,39)"/>
+            <text x="4.0769%" y="127.50"></text>
+        </g>
+        <g>
+            <title>u8::master_fast_size_for (500 samples, 0.08%)</title>
+            <rect x="3.7934%" y="149" width="0.0836%" height="15" fill="rgb(222,207,29)"/>
+            <text x="4.0434%" y="159.50"></text>
+        </g>
+        <g>
             <title>Samples (1,100 samples, 0.18%)</title>
-            <rect x="3.7600%" y="165" width="0.1838%" height="15" fill="rgb(232,36,49)"/>
+            <rect x="3.7600%" y="165" width="0.1838%" height="15" fill="rgb(206,96,30)"/>
             <text x="4.0100%" y="175.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (400 samples, 0.07%)</title>
+            <rect x="3.8770%" y="149" width="0.0668%" height="15" fill="rgb(218,138,4)"/>
+            <text x="4.1270%" y="159.50"></text>
+        </g>
+        <g>
             <title>alloc::vec::Vec&lt;bool&gt;::Boolean_encode_all (8,500 samples, 1.42%)</title>
-            <rect x="2.5401%" y="197" width="1.4205%" height="15" fill="rgb(209,103,24)"/>
+            <rect x="2.5401%" y="197" width="1.4205%" height="15" fill="rgb(250,191,14)"/>
             <text x="2.7901%" y="207.50"></text>
         </g>
         <g>
             <title>bool::master_compress (3,500 samples, 0.58%)</title>
-            <rect x="3.3757%" y="181" width="0.5849%" height="15" fill="rgb(229,88,8)"/>
+            <rect x="3.3757%" y="181" width="0.5849%" height="15" fill="rgb(239,60,40)"/>
             <text x="3.6257%" y="191.50"></text>
         </g>
         <g>
             <title>Final (2,900 samples, 0.48%)</title>
-            <rect x="4.0274%" y="149" width="0.4846%" height="15" fill="rgb(213,181,19)"/>
+            <rect x="4.0274%" y="149" width="0.4846%" height="15" fill="rgb(206,27,48)"/>
             <text x="4.2774%" y="159.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::PrefixVarInt_compress (2,800 samples, 0.47%)</title>
-            <rect x="4.0441%" y="133" width="0.4679%" height="15" fill="rgb(254,191,54)"/>
+            <rect x="4.0441%" y="133" width="0.4679%" height="15" fill="rgb(225,35,8)"/>
             <text x="4.2941%" y="143.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="4.5622%" y="101" width="0.0167%" height="15" fill="rgb(250,213,24)"/>
+            <text x="4.8122%" y="111.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="4.5789%" y="101" width="0.2005%" height="15" fill="rgb(241,83,37)"/>
+            <rect x="4.5789%" y="101" width="0.2005%" height="15" fill="rgb(247,123,22)"/>
             <text x="4.8289%" y="111.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="4.6290%" y="85" width="0.1504%" height="15" fill="rgb(233,36,39)"/>
+            <rect x="4.6290%" y="85" width="0.1504%" height="15" fill="rgb(231,138,38)"/>
             <text x="4.8790%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="4.5455%" y="117" width="0.2507%" height="15" fill="rgb(226,3,54)"/>
+            <rect x="4.5455%" y="117" width="0.2507%" height="15" fill="rgb(231,145,46)"/>
             <text x="4.7955%" y="127.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (400 samples, 0.07%)</title>
+            <rect x="4.7961%" y="117" width="0.0668%" height="15" fill="rgb(251,118,11)"/>
+            <text x="5.0461%" y="127.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::fast_size_for (300 samples, 0.05%)</title>
+            <rect x="4.8797%" y="101" width="0.0501%" height="15" fill="rgb(217,147,25)"/>
+            <text x="5.1297%" y="111.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (1,000 samples, 0.17%)</title>
-            <rect x="5.9993%" y="85" width="0.1671%" height="15" fill="rgb(245,192,40)"/>
+            <rect x="5.9993%" y="85" width="0.1671%" height="15" fill="rgb(247,81,37)"/>
             <text x="6.2493%" y="95.50"></text>
         </g>
         <g>
             <title>u32::master_fast_size_for (7,900 samples, 1.32%)</title>
-            <rect x="4.8630%" y="117" width="1.3202%" height="15" fill="rgb(238,167,29)"/>
+            <rect x="4.8630%" y="117" width="1.3202%" height="15" fill="rgb(209,12,38)"/>
             <text x="5.1130%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (7,500 samples, 1.25%)</title>
-            <rect x="4.9298%" y="101" width="1.2533%" height="15" fill="rgb(232,182,51)"/>
+            <rect x="4.9298%" y="101" width="1.2533%" height="15" fill="rgb(227,1,9)"/>
             <text x="5.1798%" y="111.50"></text>
         </g>
         <g>
             <title>&amp;[u32]::RLE_get_runs (2,000 samples, 0.33%)</title>
-            <rect x="6.1832%" y="117" width="0.3342%" height="15" fill="rgb(231,60,39)"/>
+            <rect x="6.1832%" y="117" width="0.3342%" height="15" fill="rgb(248,47,43)"/>
             <text x="6.4332%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::DeltaZigZagCompressor,_tree_buf::internal::types::integer::PrefixVarIntCompressor)&gt;::fast_size_for (12,000 samples, 2.01%)</title>
-            <rect x="4.5287%" y="133" width="2.0053%" height="15" fill="rgb(208,69,12)"/>
+            <rect x="4.5287%" y="133" width="2.0053%" height="15" fill="rgb(221,10,30)"/>
             <text x="4.7787%" y="143.50">t..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::fast_size_for (2,100 samples, 0.35%)</title>
-            <rect x="6.5341%" y="133" width="0.3509%" height="15" fill="rgb(235,93,37)"/>
+            <rect x="6.5341%" y="133" width="0.3509%" height="15" fill="rgb(210,229,1)"/>
             <text x="6.7841%" y="143.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,100 samples, 0.18%)</title>
-            <rect x="8.0047%" y="117" width="0.1838%" height="15" fill="rgb(213,116,39)"/>
+            <rect x="8.0047%" y="117" width="0.1838%" height="15" fill="rgb(222,148,37)"/>
             <text x="8.2547%" y="127.50"></text>
         </g>
         <g>
             <title>u32::master_compress (25,100 samples, 4.19%)</title>
-            <rect x="4.0107%" y="165" width="4.1945%" height="15" fill="rgb(222,207,29)"/>
+            <rect x="4.0107%" y="165" width="4.1945%" height="15" fill="rgb(234,67,33)"/>
             <text x="4.2607%" y="175.50">u32::..</text>
         </g>
         <g>
             <title>Samples (22,100 samples, 3.69%)</title>
-            <rect x="4.5120%" y="149" width="3.6932%" height="15" fill="rgb(206,96,30)"/>
+            <rect x="4.5120%" y="149" width="3.6932%" height="15" fill="rgb(247,98,35)"/>
             <text x="4.7620%" y="159.50">Samp..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (7,900 samples, 1.32%)</title>
-            <rect x="6.8850%" y="133" width="1.3202%" height="15" fill="rgb(218,138,4)"/>
+            <rect x="6.8850%" y="133" width="1.3202%" height="15" fill="rgb(247,138,52)"/>
             <text x="7.1350%" y="143.50"></text>
         </g>
         <g>
+            <title>u32::CopyToLowered (500 samples, 0.08%)</title>
+            <rect x="8.2052%" y="165" width="0.0836%" height="15" fill="rgb(213,79,30)"/>
+            <text x="8.4552%" y="175.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_compress (2,800 samples, 0.47%)</title>
-            <rect x="8.4893%" y="133" width="0.4679%" height="15" fill="rgb(250,191,14)"/>
+            <rect x="8.4893%" y="133" width="0.4679%" height="15" fill="rgb(246,177,23)"/>
             <text x="8.7393%" y="143.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,100 samples, 0.18%)</title>
-            <rect x="8.7734%" y="117" width="0.1838%" height="15" fill="rgb(239,60,40)"/>
+            <rect x="8.7734%" y="117" width="0.1838%" height="15" fill="rgb(230,62,27)"/>
             <text x="9.0234%" y="127.50"></text>
         </g>
         <g>
             <title>Final (2,900 samples, 0.48%)</title>
-            <rect x="8.4893%" y="149" width="0.4846%" height="15" fill="rgb(206,27,48)"/>
+            <rect x="8.4893%" y="149" width="0.4846%" height="15" fill="rgb(216,154,8)"/>
             <text x="8.7393%" y="159.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="9.0241%" y="101" width="0.0167%" height="15" fill="rgb(244,35,45)"/>
+            <text x="9.2741%" y="111.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="9.1745%" y="85" width="0.1170%" height="15" fill="rgb(225,35,8)"/>
+            <rect x="9.1745%" y="85" width="0.1170%" height="15" fill="rgb(251,115,12)"/>
             <text x="9.4245%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,800 samples, 0.30%)</title>
-            <rect x="9.0074%" y="117" width="0.3008%" height="15" fill="rgb(250,213,24)"/>
+            <rect x="9.0074%" y="117" width="0.3008%" height="15" fill="rgb(240,54,50)"/>
             <text x="9.2574%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,600 samples, 0.27%)</title>
-            <rect x="9.0408%" y="101" width="0.2674%" height="15" fill="rgb(247,123,22)"/>
+            <rect x="9.0408%" y="101" width="0.2674%" height="15" fill="rgb(233,84,52)"/>
             <text x="9.2908%" y="111.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (300 samples, 0.05%)</title>
+            <rect x="9.3082%" y="117" width="0.0501%" height="15" fill="rgb(207,117,47)"/>
+            <text x="9.5582%" y="127.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,300 samples, 0.22%)</title>
-            <rect x="9.3583%" y="101" width="0.2172%" height="15" fill="rgb(231,138,38)"/>
+            <rect x="9.3583%" y="101" width="0.2172%" height="15" fill="rgb(249,43,39)"/>
             <text x="9.6083%" y="111.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (600 samples, 0.10%)</title>
-            <rect x="9.4753%" y="85" width="0.1003%" height="15" fill="rgb(231,145,46)"/>
+            <rect x="9.4753%" y="85" width="0.1003%" height="15" fill="rgb(209,38,44)"/>
             <text x="9.7253%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,400 samples, 0.23%)</title>
-            <rect x="9.3583%" y="117" width="0.2340%" height="15" fill="rgb(251,118,11)"/>
+            <rect x="9.3583%" y="117" width="0.2340%" height="15" fill="rgb(236,212,23)"/>
             <text x="9.6083%" y="127.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,200 samples, 0.37%)</title>
-            <rect x="9.5922%" y="117" width="0.3676%" height="15" fill="rgb(217,147,25)"/>
+            <rect x="9.5922%" y="117" width="0.3676%" height="15" fill="rgb(242,79,21)"/>
             <text x="9.8422%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (6,000 samples, 1.00%)</title>
-            <rect x="8.9906%" y="133" width="1.0027%" height="15" fill="rgb(247,81,37)"/>
+            <rect x="8.9906%" y="133" width="1.0027%" height="15" fill="rgb(211,96,35)"/>
             <text x="9.2406%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,200 samples, 0.37%)</title>
-            <rect x="9.9933%" y="133" width="0.3676%" height="15" fill="rgb(209,12,38)"/>
+            <rect x="9.9933%" y="133" width="0.3676%" height="15" fill="rgb(253,215,40)"/>
             <text x="10.2433%" y="143.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="10.2106%" y="117" width="0.1504%" height="15" fill="rgb(227,1,9)"/>
+            <rect x="10.2106%" y="117" width="0.1504%" height="15" fill="rgb(211,81,21)"/>
             <text x="10.4606%" y="127.50"></text>
         </g>
         <g>
             <title>u8::master_compress (11,400 samples, 1.91%)</title>
-            <rect x="8.4726%" y="165" width="1.9051%" height="15" fill="rgb(248,47,43)"/>
+            <rect x="8.4726%" y="165" width="1.9051%" height="15" fill="rgb(208,190,38)"/>
             <text x="8.7226%" y="175.50">u..</text>
         </g>
         <g>
             <title>Samples (8,400 samples, 1.40%)</title>
-            <rect x="8.9739%" y="149" width="1.4037%" height="15" fill="rgb(221,10,30)"/>
+            <rect x="8.9739%" y="149" width="1.4037%" height="15" fill="rgb(235,213,38)"/>
             <text x="9.2239%" y="159.50"></text>
         </g>
         <g>
             <title>u8::CopyToLowered (900 samples, 0.15%)</title>
-            <rect x="10.3777%" y="165" width="0.1504%" height="15" fill="rgb(210,229,1)"/>
+            <rect x="10.3777%" y="165" width="0.1504%" height="15" fill="rgb(237,122,38)"/>
             <text x="10.6277%" y="175.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (39,300 samples, 6.57%)</title>
-            <rect x="3.9773%" y="181" width="6.5675%" height="15" fill="rgb(222,148,37)"/>
+            <rect x="3.9773%" y="181" width="6.5675%" height="15" fill="rgb(244,218,35)"/>
             <text x="4.2273%" y="191.50">alloc::ve..</text>
         </g>
         <g>
+            <title>Final (500 samples, 0.08%)</title>
+            <rect x="10.5949%" y="133" width="0.0836%" height="15" fill="rgb(240,68,47)"/>
+            <text x="10.8449%" y="143.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::BytesCompressor::Bytes_compress (400 samples, 0.07%)</title>
+            <rect x="10.6116%" y="117" width="0.0668%" height="15" fill="rgb(210,16,53)"/>
+            <text x="10.8616%" y="127.50"></text>
+        </g>
+        <g>
+            <title>bool::master_fast_size_for (500 samples, 0.08%)</title>
+            <rect x="10.7119%" y="101" width="0.0836%" height="15" fill="rgb(235,124,12)"/>
+            <text x="10.9619%" y="111.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (800 samples, 0.13%)</title>
-            <rect x="11.2801%" y="69" width="0.1337%" height="15" fill="rgb(234,67,33)"/>
+            <rect x="11.2801%" y="69" width="0.1337%" height="15" fill="rgb(224,169,11)"/>
             <text x="11.5301%" y="79.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (3,800 samples, 0.64%)</title>
-            <rect x="10.7955%" y="101" width="0.6350%" height="15" fill="rgb(247,98,35)"/>
+            <rect x="10.7955%" y="101" width="0.6350%" height="15" fill="rgb(250,166,2)"/>
             <text x="11.0455%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (3,800 samples, 0.64%)</title>
-            <rect x="10.7955%" y="85" width="0.6350%" height="15" fill="rgb(247,138,52)"/>
+            <rect x="10.7955%" y="85" width="0.6350%" height="15" fill="rgb(242,216,29)"/>
             <text x="11.0455%" y="95.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (1,800 samples, 0.30%)</title>
-            <rect x="11.4305%" y="101" width="0.3008%" height="15" fill="rgb(213,79,30)"/>
+            <rect x="11.4305%" y="101" width="0.3008%" height="15" fill="rgb(230,116,27)"/>
             <text x="11.6805%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (6,400 samples, 1.07%)</title>
-            <rect x="10.6952%" y="117" width="1.0695%" height="15" fill="rgb(246,177,23)"/>
+            <rect x="10.6952%" y="117" width="1.0695%" height="15" fill="rgb(228,99,48)"/>
             <text x="10.9452%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="12.3496%" y="101" width="0.1504%" height="15" fill="rgb(230,62,27)"/>
+            <rect x="12.3496%" y="101" width="0.1504%" height="15" fill="rgb(253,11,6)"/>
             <text x="12.5996%" y="111.50"></text>
         </g>
         <g>
             <title>Samples (11,000 samples, 1.84%)</title>
-            <rect x="10.6785%" y="133" width="1.8382%" height="15" fill="rgb(216,154,8)"/>
+            <rect x="10.6785%" y="133" width="1.8382%" height="15" fill="rgb(247,143,39)"/>
             <text x="10.9285%" y="143.50">S..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (4,500 samples, 0.75%)</title>
-            <rect x="11.7647%" y="117" width="0.7520%" height="15" fill="rgb(244,35,45)"/>
+            <rect x="11.7647%" y="117" width="0.7520%" height="15" fill="rgb(236,97,10)"/>
             <text x="12.0147%" y="127.50"></text>
         </g>
         <g>
             <title>u8::master_compress (13,900 samples, 2.32%)</title>
-            <rect x="10.5949%" y="149" width="2.3229%" height="15" fill="rgb(251,115,12)"/>
+            <rect x="10.5949%" y="149" width="2.3229%" height="15" fill="rgb(233,208,19)"/>
             <text x="10.8449%" y="159.50">u..</text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u8&gt;::Integer_encode_all (14,100 samples, 2.36%)</title>
-            <rect x="10.5782%" y="165" width="2.3563%" height="15" fill="rgb(240,54,50)"/>
+            <rect x="10.5782%" y="165" width="2.3563%" height="15" fill="rgb(216,164,2)"/>
             <text x="10.8282%" y="175.50">a..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::array_fixed::_20::ArrayEncoder&lt;alloc::vec::Vec&lt;u8&gt;&gt;::ArrayFixed_flush (14,400 samples, 2.41%)</title>
-            <rect x="10.5448%" y="181" width="2.4064%" height="15" fill="rgb(233,84,52)"/>
+            <rect x="10.5448%" y="181" width="2.4064%" height="15" fill="rgb(220,129,5)"/>
             <text x="10.7948%" y="191.50">tr..</text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,800 samples, 0.30%)</title>
-            <rect x="13.7199%" y="117" width="0.3008%" height="15" fill="rgb(207,117,47)"/>
+            <rect x="13.7199%" y="117" width="0.3008%" height="15" fill="rgb(242,17,10)"/>
             <text x="13.9699%" y="127.50"></text>
         </g>
         <g>
             <title>Final (6,400 samples, 1.07%)</title>
-            <rect x="12.9679%" y="149" width="1.0695%" height="15" fill="rgb(249,43,39)"/>
+            <rect x="12.9679%" y="149" width="1.0695%" height="15" fill="rgb(242,107,0)"/>
             <text x="13.2179%" y="159.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_compress (6,300 samples, 1.05%)</title>
-            <rect x="12.9846%" y="133" width="1.0528%" height="15" fill="rgb(209,38,44)"/>
+            <rect x="12.9846%" y="133" width="1.0528%" height="15" fill="rgb(251,28,31)"/>
             <text x="13.2346%" y="143.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="14.0876%" y="101" width="0.0167%" height="15" fill="rgb(233,223,10)"/>
+            <text x="14.3376%" y="111.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="14.1043%" y="101" width="0.2507%" height="15" fill="rgb(236,212,23)"/>
+            <rect x="14.1043%" y="101" width="0.2507%" height="15" fill="rgb(215,21,27)"/>
             <text x="14.3543%" y="111.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="14.2380%" y="85" width="0.1170%" height="15" fill="rgb(242,79,21)"/>
+            <rect x="14.2380%" y="85" width="0.1170%" height="15" fill="rgb(232,23,21)"/>
             <text x="14.4880%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,800 samples, 0.30%)</title>
-            <rect x="14.0709%" y="117" width="0.3008%" height="15" fill="rgb(211,96,35)"/>
+            <rect x="14.0709%" y="117" width="0.3008%" height="15" fill="rgb(244,5,23)"/>
             <text x="14.3209%" y="127.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (300 samples, 0.05%)</title>
+            <rect x="14.3717%" y="117" width="0.0501%" height="15" fill="rgb(226,81,46)"/>
+            <text x="14.6217%" y="127.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,300 samples, 0.22%)</title>
-            <rect x="14.4218%" y="101" width="0.2172%" height="15" fill="rgb(253,215,40)"/>
+            <rect x="14.4218%" y="101" width="0.2172%" height="15" fill="rgb(247,70,30)"/>
             <text x="14.6718%" y="111.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="14.5221%" y="85" width="0.1170%" height="15" fill="rgb(211,81,21)"/>
+            <rect x="14.5221%" y="85" width="0.1170%" height="15" fill="rgb(212,68,19)"/>
             <text x="14.7721%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,400 samples, 0.23%)</title>
-            <rect x="14.4218%" y="117" width="0.2340%" height="15" fill="rgb(208,190,38)"/>
+            <rect x="14.4218%" y="117" width="0.2340%" height="15" fill="rgb(240,187,13)"/>
             <text x="14.6718%" y="127.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,000 samples, 0.33%)</title>
-            <rect x="14.6557%" y="117" width="0.3342%" height="15" fill="rgb(235,213,38)"/>
+            <rect x="14.6557%" y="117" width="0.3342%" height="15" fill="rgb(223,113,26)"/>
             <text x="14.9057%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (5,700 samples, 0.95%)</title>
-            <rect x="14.0541%" y="133" width="0.9525%" height="15" fill="rgb(237,122,38)"/>
+            <rect x="14.0541%" y="133" width="0.9525%" height="15" fill="rgb(206,192,2)"/>
             <text x="14.3041%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,200 samples, 0.37%)</title>
-            <rect x="15.0067%" y="133" width="0.3676%" height="15" fill="rgb(244,218,35)"/>
+            <rect x="15.0067%" y="133" width="0.3676%" height="15" fill="rgb(241,108,4)"/>
             <text x="15.2567%" y="143.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="15.2239%" y="117" width="0.1504%" height="15" fill="rgb(240,68,47)"/>
+            <rect x="15.2239%" y="117" width="0.1504%" height="15" fill="rgb(247,173,49)"/>
             <text x="15.4739%" y="127.50"></text>
         </g>
         <g>
             <title>u8::master_compress (14,500 samples, 2.42%)</title>
-            <rect x="12.9679%" y="165" width="2.4231%" height="15" fill="rgb(210,16,53)"/>
+            <rect x="12.9679%" y="165" width="2.4231%" height="15" fill="rgb(224,114,35)"/>
             <text x="13.2179%" y="175.50">u8..</text>
         </g>
         <g>
             <title>Samples (8,100 samples, 1.35%)</title>
-            <rect x="14.0374%" y="149" width="1.3536%" height="15" fill="rgb(235,124,12)"/>
+            <rect x="14.0374%" y="149" width="1.3536%" height="15" fill="rgb(245,159,27)"/>
             <text x="14.2874%" y="159.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (16,000 samples, 2.67%)</title>
-            <rect x="12.9512%" y="181" width="2.6738%" height="15" fill="rgb(224,169,11)"/>
+            <rect x="12.9512%" y="181" width="2.6738%" height="15" fill="rgb(245,172,44)"/>
             <text x="13.2012%" y="191.50">al..</text>
         </g>
         <g>
             <title>u8::CopyToLowered (1,400 samples, 0.23%)</title>
-            <rect x="15.3910%" y="165" width="0.2340%" height="15" fill="rgb(250,166,2)"/>
+            <rect x="15.3910%" y="165" width="0.2340%" height="15" fill="rgb(236,23,11)"/>
             <text x="15.6410%" y="175.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::array::VecArrayEncoder&lt;graphql::schemas::treebuf::BidTreeBufEncoderArray&gt;::Array_flush (70,100 samples, 11.71%)</title>
-            <rect x="3.9606%" y="197" width="11.7146%" height="15" fill="rgb(242,216,29)"/>
+            <rect x="3.9606%" y="197" width="11.7146%" height="15" fill="rgb(205,117,38)"/>
             <text x="4.2106%" y="207.50">tree_buf::interna..</text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,700 samples, 0.28%)</title>
-            <rect x="16.3937%" y="133" width="0.2841%" height="15" fill="rgb(230,116,27)"/>
+            <rect x="16.3937%" y="133" width="0.2841%" height="15" fill="rgb(237,72,25)"/>
             <text x="16.6437%" y="143.50"></text>
         </g>
         <g>
             <title>Final (6,000 samples, 1.00%)</title>
-            <rect x="15.6918%" y="165" width="1.0027%" height="15" fill="rgb(228,99,48)"/>
+            <rect x="15.6918%" y="165" width="1.0027%" height="15" fill="rgb(244,70,9)"/>
             <text x="15.9418%" y="175.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_compress (5,900 samples, 0.99%)</title>
-            <rect x="15.7086%" y="149" width="0.9860%" height="15" fill="rgb(253,11,6)"/>
+            <rect x="15.7086%" y="149" width="0.9860%" height="15" fill="rgb(217,125,39)"/>
             <text x="15.9586%" y="159.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="16.7447%" y="117" width="0.0167%" height="15" fill="rgb(235,36,10)"/>
+            <text x="16.9947%" y="127.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="16.8783%" y="101" width="0.1170%" height="15" fill="rgb(247,143,39)"/>
+            <rect x="16.8783%" y="101" width="0.1170%" height="15" fill="rgb(251,123,47)"/>
             <text x="17.1283%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,700 samples, 0.28%)</title>
-            <rect x="16.7279%" y="133" width="0.2841%" height="15" fill="rgb(236,97,10)"/>
+            <rect x="16.7279%" y="133" width="0.2841%" height="15" fill="rgb(221,13,13)"/>
             <text x="16.9779%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="16.7614%" y="117" width="0.2507%" height="15" fill="rgb(233,208,19)"/>
+            <rect x="16.7614%" y="117" width="0.2507%" height="15" fill="rgb(238,131,9)"/>
             <text x="17.0114%" y="127.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (300 samples, 0.05%)</title>
+            <rect x="17.0120%" y="133" width="0.0501%" height="15" fill="rgb(211,50,8)"/>
+            <text x="17.2620%" y="143.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (600 samples, 0.10%)</title>
-            <rect x="17.1624%" y="101" width="0.1003%" height="15" fill="rgb(216,164,2)"/>
+            <rect x="17.1624%" y="101" width="0.1003%" height="15" fill="rgb(245,182,24)"/>
             <text x="17.4124%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,300 samples, 0.22%)</title>
-            <rect x="17.0622%" y="133" width="0.2172%" height="15" fill="rgb(220,129,5)"/>
+            <rect x="17.0622%" y="133" width="0.2172%" height="15" fill="rgb(242,14,37)"/>
             <text x="17.3122%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="17.0789%" y="117" width="0.2005%" height="15" fill="rgb(242,17,10)"/>
+            <rect x="17.0789%" y="117" width="0.2005%" height="15" fill="rgb(246,228,12)"/>
             <text x="17.3289%" y="127.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,400 samples, 0.40%)</title>
-            <rect x="17.2794%" y="133" width="0.4011%" height="15" fill="rgb(242,107,0)"/>
+            <rect x="17.2794%" y="133" width="0.4011%" height="15" fill="rgb(213,55,15)"/>
             <text x="17.5294%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (5,900 samples, 0.99%)</title>
-            <rect x="16.7112%" y="149" width="0.9860%" height="15" fill="rgb(251,28,31)"/>
+            <rect x="16.7112%" y="149" width="0.9860%" height="15" fill="rgb(209,9,3)"/>
             <text x="16.9612%" y="159.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="17.8476%" y="133" width="0.1504%" height="15" fill="rgb(233,223,10)"/>
+            <rect x="17.8476%" y="133" width="0.1504%" height="15" fill="rgb(230,59,30)"/>
             <text x="18.0976%" y="143.50"></text>
         </g>
         <g>
             <title>Samples (7,900 samples, 1.32%)</title>
-            <rect x="16.6945%" y="165" width="1.3202%" height="15" fill="rgb(215,21,27)"/>
+            <rect x="16.6945%" y="165" width="1.3202%" height="15" fill="rgb(209,121,21)"/>
             <text x="16.9445%" y="175.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,900 samples, 0.32%)</title>
-            <rect x="17.6972%" y="149" width="0.3175%" height="15" fill="rgb(232,23,21)"/>
+            <rect x="17.6972%" y="149" width="0.3175%" height="15" fill="rgb(220,109,13)"/>
             <text x="17.9472%" y="159.50"></text>
         </g>
         <g>
             <title>u8::master_compress (14,100 samples, 2.36%)</title>
-            <rect x="15.6751%" y="181" width="2.3563%" height="15" fill="rgb(244,5,23)"/>
+            <rect x="15.6751%" y="181" width="2.3563%" height="15" fill="rgb(232,18,1)"/>
             <text x="15.9251%" y="191.50">u..</text>
         </g>
         <g>
             <title>u8::CopyToLowered (1,500 samples, 0.25%)</title>
-            <rect x="18.0314%" y="181" width="0.2507%" height="15" fill="rgb(226,81,46)"/>
+            <rect x="18.0314%" y="181" width="0.2507%" height="15" fill="rgb(215,41,42)"/>
             <text x="18.2814%" y="191.50"></text>
         </g>
         <g>
+            <title>Final (300 samples, 0.05%)</title>
+            <rect x="18.3824%" y="85" width="0.0501%" height="15" fill="rgb(224,123,36)"/>
+            <text x="18.6324%" y="95.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::PrefixVarInt_compress (200 samples, 0.03%)</title>
+            <rect x="18.3991%" y="69" width="0.0334%" height="15" fill="rgb(240,125,3)"/>
+            <text x="18.6491%" y="79.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::PrefixVarIntCompressor)&gt;::fast_size_for (200 samples, 0.03%)</title>
+            <rect x="18.4492%" y="69" width="0.0334%" height="15" fill="rgb(205,98,50)"/>
+            <text x="18.6992%" y="79.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::fast_size_for (200 samples, 0.03%)</title>
+            <rect x="18.4826%" y="69" width="0.0334%" height="15" fill="rgb(205,185,37)"/>
+            <text x="18.7326%" y="79.50"></text>
+        </g>
+        <g>
+            <title>Needless_copy_to_u32 (100 samples, 0.02%)</title>
+            <rect x="18.5328%" y="53" width="0.0167%" height="15" fill="rgb(238,207,15)"/>
+            <text x="18.7828%" y="63.50"></text>
+        </g>
+        <g>
             <title>Samples (800 samples, 0.13%)</title>
-            <rect x="18.4325%" y="85" width="0.1337%" height="15" fill="rgb(247,70,30)"/>
+            <rect x="18.4325%" y="85" width="0.1337%" height="15" fill="rgb(213,199,42)"/>
             <text x="18.6825%" y="95.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (300 samples, 0.05%)</title>
+            <rect x="18.5160%" y="69" width="0.0501%" height="15" fill="rgb(235,201,11)"/>
+            <text x="18.7660%" y="79.50"></text>
+        </g>
+        <g>
             <title>u16::master_compress (1,300 samples, 0.22%)</title>
-            <rect x="18.3656%" y="101" width="0.2172%" height="15" fill="rgb(212,68,19)"/>
+            <rect x="18.3656%" y="101" width="0.2172%" height="15" fill="rgb(207,46,11)"/>
             <text x="18.6156%" y="111.50"></text>
         </g>
         <g>
+            <title>u16::CopyToLowered (200 samples, 0.03%)</title>
+            <rect x="18.5829%" y="101" width="0.0334%" height="15" fill="rgb(241,35,35)"/>
+            <text x="18.8329%" y="111.50"></text>
+        </g>
+        <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (2,200 samples, 0.37%)</title>
-            <rect x="18.3656%" y="117" width="0.3676%" height="15" fill="rgb(240,187,13)"/>
+            <rect x="18.3656%" y="117" width="0.3676%" height="15" fill="rgb(243,32,47)"/>
             <text x="18.6156%" y="127.50"></text>
         </g>
         <g>
             <title>Final (2,500 samples, 0.42%)</title>
-            <rect x="18.3322%" y="149" width="0.4178%" height="15" fill="rgb(223,113,26)"/>
+            <rect x="18.3322%" y="149" width="0.4178%" height="15" fill="rgb(247,202,23)"/>
             <text x="18.5822%" y="159.50"></text>
         </g>
         <g>
             <title>&amp;[bool]::encode_rle_bool (2,400 samples, 0.40%)</title>
-            <rect x="18.3489%" y="133" width="0.4011%" height="15" fill="rgb(206,192,2)"/>
+            <rect x="18.3489%" y="133" width="0.4011%" height="15" fill="rgb(219,102,11)"/>
             <text x="18.5989%" y="143.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="18.8001%" y="117" width="0.0167%" height="15" fill="rgb(243,110,44)"/>
+            <text x="19.0501%" y="127.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (300 samples, 0.05%)</title>
+            <rect x="18.8168%" y="117" width="0.0501%" height="15" fill="rgb(222,74,54)"/>
+            <text x="19.0668%" y="127.50"></text>
+        </g>
+        <g>
+            <title>Needless_copy_to_u32 (200 samples, 0.03%)</title>
+            <rect x="18.8336%" y="101" width="0.0334%" height="15" fill="rgb(216,99,12)"/>
+            <text x="19.0836%" y="111.50"></text>
+        </g>
+        <g>
             <title>u8::master_fast_size_for (600 samples, 0.10%)</title>
-            <rect x="18.7834%" y="133" width="0.1003%" height="15" fill="rgb(241,108,4)"/>
+            <rect x="18.7834%" y="133" width="0.1003%" height="15" fill="rgb(226,22,26)"/>
             <text x="19.0334%" y="143.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (400 samples, 0.07%)</title>
+            <rect x="18.8837%" y="133" width="0.0668%" height="15" fill="rgb(217,163,10)"/>
+            <text x="19.1337%" y="143.50"></text>
+        </g>
+        <g>
             <title>bool::master_compress (3,900 samples, 0.65%)</title>
-            <rect x="18.3155%" y="165" width="0.6517%" height="15" fill="rgb(247,173,49)"/>
+            <rect x="18.3155%" y="165" width="0.6517%" height="15" fill="rgb(213,25,53)"/>
             <text x="18.5655%" y="175.50"></text>
         </g>
         <g>
             <title>Samples (1,300 samples, 0.22%)</title>
-            <rect x="18.7500%" y="149" width="0.2172%" height="15" fill="rgb(224,114,35)"/>
+            <rect x="18.7500%" y="149" width="0.2172%" height="15" fill="rgb(252,105,26)"/>
             <text x="19.0000%" y="159.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;bool&gt;::Boolean_encode_all (4,800 samples, 0.80%)</title>
-            <rect x="18.3155%" y="181" width="0.8021%" height="15" fill="rgb(245,159,27)"/>
+            <rect x="18.3155%" y="181" width="0.8021%" height="15" fill="rgb(220,39,43)"/>
             <text x="18.5655%" y="191.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (20,800 samples, 3.48%)</title>
-            <rect x="15.6751%" y="197" width="3.4759%" height="15" fill="rgb(245,172,44)"/>
+            <rect x="15.6751%" y="197" width="3.4759%" height="15" fill="rgb(229,68,48)"/>
             <text x="15.9251%" y="207.50">all..</text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,800 samples, 0.30%)</title>
-            <rect x="21.4238%" y="69" width="0.3008%" height="15" fill="rgb(236,23,11)"/>
+            <rect x="21.4238%" y="69" width="0.3008%" height="15" fill="rgb(252,8,32)"/>
             <text x="21.6738%" y="79.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_compress (15,000 samples, 2.51%)</title>
-            <rect x="19.2346%" y="85" width="2.5067%" height="15" fill="rgb(205,117,38)"/>
+            <rect x="19.2346%" y="85" width="2.5067%" height="15" fill="rgb(223,20,43)"/>
             <text x="19.4846%" y="95.50">tr..</text>
         </g>
         <g>
             <title>Final (15,100 samples, 2.52%)</title>
-            <rect x="19.2346%" y="101" width="2.5234%" height="15" fill="rgb(237,72,25)"/>
+            <rect x="19.2346%" y="101" width="2.5234%" height="15" fill="rgb(229,81,49)"/>
             <text x="19.4846%" y="111.50">Fi..</text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (200 samples, 0.03%)</title>
+            <rect x="21.7914%" y="53" width="0.0334%" height="15" fill="rgb(236,28,36)"/>
+            <text x="22.0414%" y="63.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="21.8249%" y="53" width="0.2005%" height="15" fill="rgb(244,70,9)"/>
+            <rect x="21.8249%" y="53" width="0.2005%" height="15" fill="rgb(249,185,26)"/>
             <text x="22.0749%" y="63.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (800 samples, 0.13%)</title>
-            <rect x="21.8917%" y="37" width="0.1337%" height="15" fill="rgb(217,125,39)"/>
+            <rect x="21.8917%" y="37" width="0.1337%" height="15" fill="rgb(249,174,33)"/>
             <text x="22.1417%" y="47.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="21.7914%" y="69" width="0.2507%" height="15" fill="rgb(235,36,10)"/>
+            <rect x="21.7914%" y="69" width="0.2507%" height="15" fill="rgb(233,201,37)"/>
             <text x="22.0414%" y="79.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (400 samples, 0.07%)</title>
+            <rect x="22.0421%" y="69" width="0.0668%" height="15" fill="rgb(221,78,26)"/>
+            <text x="22.2921%" y="79.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (3,200 samples, 0.53%)</title>
-            <rect x="22.1090%" y="53" width="0.5348%" height="15" fill="rgb(251,123,47)"/>
+            <rect x="22.1090%" y="53" width="0.5348%" height="15" fill="rgb(250,127,30)"/>
             <text x="22.3590%" y="63.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="22.4933%" y="37" width="0.1504%" height="15" fill="rgb(221,13,13)"/>
+            <rect x="22.4933%" y="37" width="0.1504%" height="15" fill="rgb(230,49,44)"/>
             <text x="22.7433%" y="47.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (3,300 samples, 0.55%)</title>
-            <rect x="22.1090%" y="69" width="0.5515%" height="15" fill="rgb(238,131,9)"/>
+            <rect x="22.1090%" y="69" width="0.5515%" height="15" fill="rgb(229,67,23)"/>
             <text x="22.3590%" y="79.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,000 samples, 0.33%)</title>
-            <rect x="22.6604%" y="69" width="0.3342%" height="15" fill="rgb(211,50,8)"/>
+            <rect x="22.6604%" y="69" width="0.3342%" height="15" fill="rgb(249,83,47)"/>
             <text x="22.9104%" y="79.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (7,500 samples, 1.25%)</title>
-            <rect x="21.7747%" y="85" width="1.2533%" height="15" fill="rgb(245,182,24)"/>
+            <rect x="21.7747%" y="85" width="1.2533%" height="15" fill="rgb(215,43,3)"/>
             <text x="22.0247%" y="95.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (3,700 samples, 0.62%)</title>
-            <rect x="23.0281%" y="85" width="0.6183%" height="15" fill="rgb(242,14,37)"/>
+            <rect x="23.0281%" y="85" width="0.6183%" height="15" fill="rgb(238,154,13)"/>
             <text x="23.2781%" y="95.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,100 samples, 0.18%)</title>
-            <rect x="23.4626%" y="69" width="0.1838%" height="15" fill="rgb(246,228,12)"/>
+            <rect x="23.4626%" y="69" width="0.1838%" height="15" fill="rgb(219,56,2)"/>
             <text x="23.7126%" y="79.50"></text>
         </g>
         <g>
             <title>u8::master_compress (26,600 samples, 4.45%)</title>
-            <rect x="19.2179%" y="117" width="4.4452%" height="15" fill="rgb(213,55,15)"/>
+            <rect x="19.2179%" y="117" width="4.4452%" height="15" fill="rgb(233,0,4)"/>
             <text x="19.4679%" y="127.50">u8::m..</text>
         </g>
         <g>
             <title>Samples (11,400 samples, 1.91%)</title>
-            <rect x="21.7580%" y="101" width="1.9051%" height="15" fill="rgb(209,9,3)"/>
+            <rect x="21.7580%" y="101" width="1.9051%" height="15" fill="rgb(235,30,7)"/>
             <text x="22.0080%" y="111.50">S..</text>
         </g>
         <g>
             <title>u8::CopyToLowered (1,700 samples, 0.28%)</title>
-            <rect x="23.6631%" y="117" width="0.2841%" height="15" fill="rgb(230,59,30)"/>
+            <rect x="23.6631%" y="117" width="0.2841%" height="15" fill="rgb(250,79,13)"/>
             <text x="23.9131%" y="127.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (28,500 samples, 4.76%)</title>
-            <rect x="19.2012%" y="133" width="4.7627%" height="15" fill="rgb(209,121,21)"/>
+            <rect x="19.2012%" y="133" width="4.7627%" height="15" fill="rgb(211,146,34)"/>
             <text x="19.4512%" y="143.50">alloc:..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_compress (2,200 samples, 0.37%)</title>
-            <rect x="23.9639%" y="117" width="0.3676%" height="15" fill="rgb(220,109,13)"/>
+            <rect x="23.9639%" y="117" width="0.3676%" height="15" fill="rgb(228,22,38)"/>
             <text x="24.2139%" y="127.50"></text>
         </g>
         <g>
             <title>&amp;alloc::string::String::master_compress (2,300 samples, 0.38%)</title>
-            <rect x="23.9639%" y="133" width="0.3844%" height="15" fill="rgb(232,18,1)"/>
+            <rect x="23.9639%" y="133" width="0.3844%" height="15" fill="rgb(235,168,5)"/>
             <text x="24.2139%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::dictionary::Dictionary&lt;(tree_buf::internal::types::string::Utf8Compressor,)&gt;::compress (79,800 samples, 13.34%)</title>
-            <rect x="19.1845%" y="149" width="13.3356%" height="15" fill="rgb(215,41,42)"/>
+            <rect x="19.1845%" y="149" width="13.3356%" height="15" fill="rgb(221,155,16)"/>
             <text x="19.4345%" y="159.50">tree_buf::internal::..</text>
         </g>
         <g>
             <title>&amp;alloc::string::String::get_lookup_table (48,900 samples, 8.17%)</title>
-            <rect x="24.3483%" y="133" width="8.1718%" height="15" fill="rgb(224,123,36)"/>
+            <rect x="24.3483%" y="133" width="8.1718%" height="15" fill="rgb(215,215,53)"/>
             <text x="24.5983%" y="143.50">&amp;alloc::str..</text>
         </g>
         <g>
             <title>Final (80,000 samples, 13.37%)</title>
-            <rect x="19.1678%" y="165" width="13.3690%" height="15" fill="rgb(240,125,3)"/>
+            <rect x="19.1678%" y="165" width="13.3690%" height="15" fill="rgb(223,4,10)"/>
             <text x="19.4178%" y="175.50">Final</text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="32.6036%" y="85" width="0.0167%" height="15" fill="rgb(234,103,6)"/>
+            <text x="32.8536%" y="95.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (800 samples, 0.13%)</title>
-            <rect x="32.7039%" y="69" width="0.1337%" height="15" fill="rgb(205,98,50)"/>
+            <rect x="32.7039%" y="69" width="0.1337%" height="15" fill="rgb(227,97,0)"/>
             <text x="32.9539%" y="79.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="32.6036%" y="101" width="0.2507%" height="15" fill="rgb(205,185,37)"/>
+            <rect x="32.6036%" y="101" width="0.2507%" height="15" fill="rgb(234,150,53)"/>
             <text x="32.8536%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,400 samples, 0.23%)</title>
-            <rect x="32.6203%" y="85" width="0.2340%" height="15" fill="rgb(238,207,15)"/>
+            <rect x="32.6203%" y="85" width="0.2340%" height="15" fill="rgb(228,201,54)"/>
             <text x="32.8703%" y="95.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (400 samples, 0.07%)</title>
+            <rect x="32.8543%" y="101" width="0.0668%" height="15" fill="rgb(222,22,37)"/>
+            <text x="33.1043%" y="111.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (800 samples, 0.13%)</title>
-            <rect x="33.3723%" y="69" width="0.1337%" height="15" fill="rgb(213,199,42)"/>
+            <rect x="33.3723%" y="69" width="0.1337%" height="15" fill="rgb(237,53,32)"/>
             <text x="33.6223%" y="79.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (3,600 samples, 0.60%)</title>
-            <rect x="32.9211%" y="101" width="0.6016%" height="15" fill="rgb(235,201,11)"/>
+            <rect x="32.9211%" y="101" width="0.6016%" height="15" fill="rgb(233,25,53)"/>
             <text x="33.1711%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (3,500 samples, 0.58%)</title>
-            <rect x="32.9378%" y="85" width="0.5849%" height="15" fill="rgb(207,46,11)"/>
+            <rect x="32.9378%" y="85" width="0.5849%" height="15" fill="rgb(210,40,34)"/>
             <text x="33.1878%" y="95.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,000 samples, 0.33%)</title>
-            <rect x="33.5227%" y="101" width="0.3342%" height="15" fill="rgb(241,35,35)"/>
+            <rect x="33.5227%" y="101" width="0.3342%" height="15" fill="rgb(241,220,44)"/>
             <text x="33.7727%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (7,700 samples, 1.29%)</title>
-            <rect x="32.5869%" y="117" width="1.2868%" height="15" fill="rgb(243,32,47)"/>
+            <rect x="32.5869%" y="117" width="1.2868%" height="15" fill="rgb(235,28,35)"/>
             <text x="32.8369%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (4,200 samples, 0.70%)</title>
-            <rect x="33.8737%" y="117" width="0.7019%" height="15" fill="rgb(247,202,23)"/>
+            <rect x="33.8737%" y="117" width="0.7019%" height="15" fill="rgb(210,56,17)"/>
             <text x="34.1237%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,000 samples, 0.17%)</title>
-            <rect x="34.4084%" y="101" width="0.1671%" height="15" fill="rgb(219,102,11)"/>
+            <rect x="34.4084%" y="101" width="0.1671%" height="15" fill="rgb(224,130,29)"/>
             <text x="34.6584%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (12,100 samples, 2.02%)</title>
-            <rect x="32.5702%" y="133" width="2.0221%" height="15" fill="rgb(243,110,44)"/>
+            <rect x="32.5702%" y="133" width="2.0221%" height="15" fill="rgb(235,212,8)"/>
             <text x="32.8202%" y="143.50">u..</text>
         </g>
         <g>
             <title>u8::CopyToLowered (800 samples, 0.13%)</title>
-            <rect x="34.5922%" y="133" width="0.1337%" height="15" fill="rgb(222,74,54)"/>
+            <rect x="34.5922%" y="133" width="0.1337%" height="15" fill="rgb(223,33,50)"/>
             <text x="34.8422%" y="143.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_fast_size_for (200 samples, 0.03%)</title>
+            <rect x="34.7259%" y="117" width="0.0334%" height="15" fill="rgb(219,149,13)"/>
+            <text x="34.9759%" y="127.50"></text>
+        </g>
+        <g>
+            <title>&amp;alloc::string::String::master_fast_size_for (300 samples, 0.05%)</title>
+            <rect x="34.7259%" y="133" width="0.0501%" height="15" fill="rgb(250,156,29)"/>
+            <text x="34.9759%" y="143.50"></text>
+        </g>
+        <g>
             <title>&amp;alloc::string::String::get_lookup_table (19,500 samples, 3.26%)</title>
-            <rect x="34.7761%" y="133" width="3.2587%" height="15" fill="rgb(216,99,12)"/>
+            <rect x="34.7761%" y="133" width="3.2587%" height="15" fill="rgb(216,193,19)"/>
             <text x="35.0261%" y="143.50">&amp;al..</text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::dictionary::Dictionary&lt;(tree_buf::internal::types::string::Utf8Compressor,)&gt;::fast_size_for (32,900 samples, 5.50%)</title>
-            <rect x="32.5535%" y="149" width="5.4980%" height="15" fill="rgb(226,22,26)"/>
+            <rect x="32.5535%" y="149" width="5.4980%" height="15" fill="rgb(216,135,14)"/>
             <text x="32.8035%" y="159.50">tree_bu..</text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="38.0849%" y="117" width="0.0167%" height="15" fill="rgb(241,47,5)"/>
+            <text x="38.3349%" y="127.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="38.1684%" y="101" width="0.1504%" height="15" fill="rgb(217,163,10)"/>
+            <rect x="38.1684%" y="101" width="0.1504%" height="15" fill="rgb(233,42,35)"/>
             <text x="38.4184%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,600 samples, 0.27%)</title>
-            <rect x="38.0682%" y="133" width="0.2674%" height="15" fill="rgb(213,25,53)"/>
+            <rect x="38.0682%" y="133" width="0.2674%" height="15" fill="rgb(231,13,6)"/>
             <text x="38.3182%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,400 samples, 0.23%)</title>
-            <rect x="38.1016%" y="117" width="0.2340%" height="15" fill="rgb(252,105,26)"/>
+            <rect x="38.1016%" y="117" width="0.2340%" height="15" fill="rgb(207,181,40)"/>
             <text x="38.3516%" y="127.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (400 samples, 0.07%)</title>
+            <rect x="38.3356%" y="133" width="0.0668%" height="15" fill="rgb(254,173,49)"/>
+            <text x="38.5856%" y="143.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_fast_size_for (200 samples, 0.03%)</title>
+            <rect x="38.4191%" y="117" width="0.0334%" height="15" fill="rgb(221,1,38)"/>
+            <text x="38.6691%" y="127.50"></text>
+        </g>
+        <g>
+            <title>&amp;alloc::string::String::master_fast_size_for (400 samples, 0.07%)</title>
+            <rect x="38.4024%" y="133" width="0.0668%" height="15" fill="rgb(206,124,46)"/>
+            <text x="38.6524%" y="143.50"></text>
+        </g>
+        <g>
             <title>&amp;[&amp;alloc::string::String]::RLE_get_runs (3,400 samples, 0.57%)</title>
-            <rect x="38.4693%" y="133" width="0.5682%" height="15" fill="rgb(220,39,43)"/>
+            <rect x="38.4693%" y="133" width="0.5682%" height="15" fill="rgb(249,21,11)"/>
             <text x="38.7193%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::string::Utf8Compressor,)&gt;::fast_size_for (6,000 samples, 1.00%)</title>
-            <rect x="38.0515%" y="149" width="1.0027%" height="15" fill="rgb(229,68,48)"/>
+            <rect x="38.0515%" y="149" width="1.0027%" height="15" fill="rgb(222,201,40)"/>
             <text x="38.3015%" y="159.50"></text>
         </g>
         <g>
             <title>Samples (39,500 samples, 6.60%)</title>
-            <rect x="32.5368%" y="165" width="6.6009%" height="15" fill="rgb(252,8,32)"/>
+            <rect x="32.5368%" y="165" width="6.6009%" height="15" fill="rgb(235,61,29)"/>
             <text x="32.7868%" y="175.50">Samples</text>
         </g>
         <g>
+            <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_fast_size_for (500 samples, 0.08%)</title>
+            <rect x="39.0541%" y="149" width="0.0836%" height="15" fill="rgb(219,207,3)"/>
+            <text x="39.3041%" y="159.50"></text>
+        </g>
+        <g>
             <title>&amp;alloc::string::String::master_compress (119,700 samples, 20.00%)</title>
-            <rect x="19.1511%" y="181" width="20.0033%" height="15" fill="rgb(223,20,43)"/>
+            <rect x="19.1511%" y="181" width="20.0033%" height="15" fill="rgb(222,56,46)"/>
             <text x="19.4011%" y="191.50">&amp;alloc::string::String::master_..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_compress (7,000 samples, 1.17%)</title>
-            <rect x="39.2547%" y="85" width="1.1698%" height="15" fill="rgb(229,81,49)"/>
+            <rect x="39.2547%" y="85" width="1.1698%" height="15" fill="rgb(239,76,54)"/>
             <text x="39.5047%" y="95.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,800 samples, 0.30%)</title>
-            <rect x="40.1237%" y="69" width="0.3008%" height="15" fill="rgb(236,28,36)"/>
+            <rect x="40.1237%" y="69" width="0.3008%" height="15" fill="rgb(231,124,27)"/>
             <text x="40.3737%" y="79.50"></text>
         </g>
         <g>
             <title>Final (7,100 samples, 1.19%)</title>
-            <rect x="39.2547%" y="101" width="1.1865%" height="15" fill="rgb(249,185,26)"/>
+            <rect x="39.2547%" y="101" width="1.1865%" height="15" fill="rgb(249,195,6)"/>
             <text x="39.5047%" y="111.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="40.4746%" y="53" width="0.0167%" height="15" fill="rgb(237,174,47)"/>
+            <text x="40.7246%" y="63.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="40.4913%" y="53" width="0.2005%" height="15" fill="rgb(249,174,33)"/>
+            <rect x="40.4913%" y="53" width="0.2005%" height="15" fill="rgb(206,201,31)"/>
             <text x="40.7413%" y="63.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="40.5749%" y="37" width="0.1170%" height="15" fill="rgb(233,201,37)"/>
+            <rect x="40.5749%" y="37" width="0.1170%" height="15" fill="rgb(231,57,52)"/>
             <text x="40.8249%" y="47.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,400 samples, 0.23%)</title>
-            <rect x="40.4746%" y="69" width="0.2340%" height="15" fill="rgb(221,78,26)"/>
+            <rect x="40.4746%" y="69" width="0.2340%" height="15" fill="rgb(248,177,22)"/>
             <text x="40.7246%" y="79.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (200 samples, 0.03%)</title>
+            <rect x="40.7086%" y="69" width="0.0334%" height="15" fill="rgb(215,211,37)"/>
+            <text x="40.9586%" y="79.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,000 samples, 0.17%)</title>
-            <rect x="40.7587%" y="53" width="0.1671%" height="15" fill="rgb(250,127,30)"/>
+            <rect x="40.7587%" y="53" width="0.1671%" height="15" fill="rgb(241,128,51)"/>
             <text x="41.0087%" y="63.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="40.8088%" y="37" width="0.1170%" height="15" fill="rgb(230,49,44)"/>
+            <rect x="40.8088%" y="37" width="0.1170%" height="15" fill="rgb(227,165,31)"/>
             <text x="41.0588%" y="47.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="40.7420%" y="69" width="0.2005%" height="15" fill="rgb(229,67,23)"/>
+            <rect x="40.7420%" y="69" width="0.2005%" height="15" fill="rgb(228,167,24)"/>
             <text x="40.9920%" y="79.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (1,700 samples, 0.28%)</title>
-            <rect x="40.9425%" y="69" width="0.2841%" height="15" fill="rgb(249,83,47)"/>
+            <rect x="40.9425%" y="69" width="0.2841%" height="15" fill="rgb(228,143,12)"/>
             <text x="41.1925%" y="79.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (4,800 samples, 0.80%)</title>
-            <rect x="40.4579%" y="85" width="0.8021%" height="15" fill="rgb(215,43,3)"/>
+            <rect x="40.4579%" y="85" width="0.8021%" height="15" fill="rgb(249,149,8)"/>
             <text x="40.7079%" y="95.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,000 samples, 0.17%)</title>
-            <rect x="41.4271%" y="69" width="0.1671%" height="15" fill="rgb(238,154,13)"/>
+            <rect x="41.4271%" y="69" width="0.1671%" height="15" fill="rgb(243,35,44)"/>
             <text x="41.6771%" y="79.50"></text>
         </g>
         <g>
             <title>Samples (7,000 samples, 1.17%)</title>
-            <rect x="40.4412%" y="101" width="1.1698%" height="15" fill="rgb(219,56,2)"/>
+            <rect x="40.4412%" y="101" width="1.1698%" height="15" fill="rgb(246,89,9)"/>
             <text x="40.6912%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,100 samples, 0.35%)</title>
-            <rect x="41.2600%" y="85" width="0.3509%" height="15" fill="rgb(233,0,4)"/>
+            <rect x="41.2600%" y="85" width="0.3509%" height="15" fill="rgb(233,213,13)"/>
             <text x="41.5100%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_compress (14,300 samples, 2.39%)</title>
-            <rect x="39.2380%" y="117" width="2.3897%" height="15" fill="rgb(235,30,7)"/>
+            <rect x="39.2380%" y="117" width="2.3897%" height="15" fill="rgb(233,141,41)"/>
             <text x="39.4880%" y="127.50">u8..</text>
         </g>
         <g>
             <title>u8::CopyToLowered (1,900 samples, 0.32%)</title>
-            <rect x="41.6277%" y="117" width="0.3175%" height="15" fill="rgb(250,79,13)"/>
+            <rect x="41.6277%" y="117" width="0.3175%" height="15" fill="rgb(239,167,4)"/>
             <text x="41.8777%" y="127.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (16,400 samples, 2.74%)</title>
-            <rect x="39.2213%" y="133" width="2.7406%" height="15" fill="rgb(211,146,34)"/>
+            <rect x="39.2213%" y="133" width="2.7406%" height="15" fill="rgb(209,217,16)"/>
             <text x="39.4713%" y="143.50">al..</text>
         </g>
         <g>
+            <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_compress (400 samples, 0.07%)</title>
+            <rect x="41.9619%" y="117" width="0.0668%" height="15" fill="rgb(219,88,35)"/>
+            <text x="42.2119%" y="127.50"></text>
+        </g>
+        <g>
+            <title>&amp;alloc::string::String::master_compress (500 samples, 0.08%)</title>
+            <rect x="41.9619%" y="133" width="0.0836%" height="15" fill="rgb(220,193,23)"/>
+            <text x="42.2119%" y="143.50"></text>
+        </g>
+        <g>
             <title>&amp;alloc::string::String::get_lookup_table (31,800 samples, 5.31%)</title>
-            <rect x="42.0455%" y="133" width="5.3142%" height="15" fill="rgb(228,22,38)"/>
+            <rect x="42.0455%" y="133" width="5.3142%" height="15" fill="rgb(230,90,52)"/>
             <text x="42.2955%" y="143.50">&amp;alloc:..</text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::dictionary::Dictionary&lt;(tree_buf::internal::types::string::Utf8Compressor,)&gt;::compress (48,900 samples, 8.17%)</title>
-            <rect x="39.2045%" y="149" width="8.1718%" height="15" fill="rgb(235,168,5)"/>
+            <rect x="39.2045%" y="149" width="8.1718%" height="15" fill="rgb(252,106,19)"/>
             <text x="39.4545%" y="159.50">tree_buf::i..</text>
         </g>
         <g>
             <title>Final (49,000 samples, 8.19%)</title>
-            <rect x="39.2045%" y="165" width="8.1885%" height="15" fill="rgb(221,155,16)"/>
+            <rect x="39.2045%" y="165" width="8.1885%" height="15" fill="rgb(206,74,20)"/>
             <text x="39.4545%" y="175.50">Final</text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="47.4766%" y="85" width="0.0167%" height="15" fill="rgb(230,138,44)"/>
+            <text x="47.7266%" y="95.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,300 samples, 0.22%)</title>
-            <rect x="47.4933%" y="85" width="0.2172%" height="15" fill="rgb(215,215,53)"/>
+            <rect x="47.4933%" y="85" width="0.2172%" height="15" fill="rgb(235,182,43)"/>
             <text x="47.7433%" y="95.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="47.5936%" y="69" width="0.1170%" height="15" fill="rgb(223,4,10)"/>
+            <rect x="47.5936%" y="69" width="0.1170%" height="15" fill="rgb(242,16,51)"/>
             <text x="47.8436%" y="79.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,600 samples, 0.27%)</title>
-            <rect x="47.4599%" y="101" width="0.2674%" height="15" fill="rgb(234,103,6)"/>
+            <rect x="47.4599%" y="101" width="0.2674%" height="15" fill="rgb(248,9,4)"/>
             <text x="47.7099%" y="111.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (200 samples, 0.03%)</title>
+            <rect x="47.7273%" y="101" width="0.0334%" height="15" fill="rgb(210,31,22)"/>
+            <text x="47.9773%" y="111.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (600 samples, 0.10%)</title>
-            <rect x="47.8443%" y="69" width="0.1003%" height="15" fill="rgb(227,97,0)"/>
+            <rect x="47.8443%" y="69" width="0.1003%" height="15" fill="rgb(239,54,39)"/>
             <text x="48.0943%" y="79.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="47.7607%" y="101" width="0.2005%" height="15" fill="rgb(234,150,53)"/>
+            <rect x="47.7607%" y="101" width="0.2005%" height="15" fill="rgb(230,99,41)"/>
             <text x="48.0107%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,100 samples, 0.18%)</title>
-            <rect x="47.7774%" y="85" width="0.1838%" height="15" fill="rgb(228,201,54)"/>
+            <rect x="47.7774%" y="85" width="0.1838%" height="15" fill="rgb(253,106,12)"/>
             <text x="48.0274%" y="95.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,100 samples, 0.35%)</title>
-            <rect x="47.9612%" y="101" width="0.3509%" height="15" fill="rgb(222,22,37)"/>
+            <rect x="47.9612%" y="101" width="0.3509%" height="15" fill="rgb(213,46,41)"/>
             <text x="48.2112%" y="111.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (5,300 samples, 0.89%)</title>
-            <rect x="47.4432%" y="117" width="0.8857%" height="15" fill="rgb(237,53,32)"/>
+            <rect x="47.4432%" y="117" width="0.8857%" height="15" fill="rgb(215,133,35)"/>
             <text x="47.6932%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="48.5127%" y="101" width="0.1504%" height="15" fill="rgb(233,25,53)"/>
+            <rect x="48.5127%" y="101" width="0.1504%" height="15" fill="rgb(213,28,5)"/>
             <text x="48.7627%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (7,400 samples, 1.24%)</title>
-            <rect x="47.4432%" y="133" width="1.2366%" height="15" fill="rgb(210,40,34)"/>
+            <rect x="47.4432%" y="133" width="1.2366%" height="15" fill="rgb(215,77,49)"/>
             <text x="47.6932%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,100 samples, 0.35%)</title>
-            <rect x="48.3289%" y="117" width="0.3509%" height="15" fill="rgb(241,220,44)"/>
+            <rect x="48.3289%" y="117" width="0.3509%" height="15" fill="rgb(248,100,22)"/>
             <text x="48.5789%" y="127.50"></text>
         </g>
         <g>
             <title>u8::CopyToLowered (700 samples, 0.12%)</title>
-            <rect x="48.6798%" y="133" width="0.1170%" height="15" fill="rgb(235,28,35)"/>
+            <rect x="48.6798%" y="133" width="0.1170%" height="15" fill="rgb(208,67,9)"/>
             <text x="48.9298%" y="143.50"></text>
         </g>
         <g>
+            <title>&amp;alloc::string::String::master_fast_size_for (200 samples, 0.03%)</title>
+            <rect x="48.7968%" y="133" width="0.0334%" height="15" fill="rgb(219,133,21)"/>
+            <text x="49.0468%" y="143.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_fast_size_for (200 samples, 0.03%)</title>
+            <rect x="48.7968%" y="117" width="0.0334%" height="15" fill="rgb(246,46,29)"/>
+            <text x="49.0468%" y="127.50"></text>
+        </g>
+        <g>
             <title>&amp;alloc::string::String::get_lookup_table (8,300 samples, 1.39%)</title>
-            <rect x="48.8302%" y="133" width="1.3870%" height="15" fill="rgb(210,56,17)"/>
+            <rect x="48.8302%" y="133" width="1.3870%" height="15" fill="rgb(246,185,52)"/>
             <text x="49.0802%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::dictionary::Dictionary&lt;(tree_buf::internal::types::string::Utf8Compressor,)&gt;::fast_size_for (16,900 samples, 2.82%)</title>
-            <rect x="47.4098%" y="149" width="2.8242%" height="15" fill="rgb(224,130,29)"/>
+            <rect x="47.4098%" y="149" width="2.8242%" height="15" fill="rgb(252,136,11)"/>
             <text x="47.6598%" y="159.50">tr..</text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="50.2674%" y="117" width="0.0167%" height="15" fill="rgb(219,138,53)"/>
+            <text x="50.5174%" y="127.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="50.2841%" y="117" width="0.2507%" height="15" fill="rgb(235,212,8)"/>
+            <rect x="50.2841%" y="117" width="0.2507%" height="15" fill="rgb(211,51,23)"/>
             <text x="50.5341%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="50.4178%" y="101" width="0.1170%" height="15" fill="rgb(223,33,50)"/>
+            <rect x="50.4178%" y="101" width="0.1170%" height="15" fill="rgb(247,221,28)"/>
             <text x="50.6678%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,700 samples, 0.28%)</title>
-            <rect x="50.2674%" y="133" width="0.2841%" height="15" fill="rgb(219,149,13)"/>
+            <rect x="50.2674%" y="133" width="0.2841%" height="15" fill="rgb(251,222,45)"/>
             <text x="50.5174%" y="143.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (400 samples, 0.07%)</title>
+            <rect x="50.5515%" y="133" width="0.0668%" height="15" fill="rgb(217,162,53)"/>
+            <text x="50.8015%" y="143.50"></text>
+        </g>
+        <g>
+            <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_fast_size_for (100 samples, 0.02%)</title>
+            <rect x="50.6350%" y="117" width="0.0167%" height="15" fill="rgb(229,93,14)"/>
+            <text x="50.8850%" y="127.50"></text>
+        </g>
+        <g>
+            <title>&amp;alloc::string::String::master_fast_size_for (300 samples, 0.05%)</title>
+            <rect x="50.6183%" y="133" width="0.0501%" height="15" fill="rgb(209,67,49)"/>
+            <text x="50.8683%" y="143.50"></text>
+        </g>
+        <g>
             <title>&amp;[&amp;alloc::string::String]::RLE_get_runs (4,400 samples, 0.74%)</title>
-            <rect x="50.6684%" y="133" width="0.7353%" height="15" fill="rgb(250,156,29)"/>
+            <rect x="50.6684%" y="133" width="0.7353%" height="15" fill="rgb(213,87,29)"/>
             <text x="50.9184%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::string::Utf8Compressor,)&gt;::fast_size_for (7,100 samples, 1.19%)</title>
-            <rect x="50.2340%" y="149" width="1.1865%" height="15" fill="rgb(216,193,19)"/>
+            <rect x="50.2340%" y="149" width="1.1865%" height="15" fill="rgb(205,151,52)"/>
             <text x="50.4840%" y="159.50"></text>
         </g>
         <g>
             <title>Samples (24,700 samples, 4.13%)</title>
-            <rect x="47.3930%" y="165" width="4.1277%" height="15" fill="rgb(216,135,14)"/>
+            <rect x="47.3930%" y="165" width="4.1277%" height="15" fill="rgb(253,215,39)"/>
             <text x="47.6430%" y="175.50">Samp..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::string::Utf8Compressor::Utf8_fast_size_for (600 samples, 0.10%)</title>
-            <rect x="51.4205%" y="149" width="0.1003%" height="15" fill="rgb(241,47,5)"/>
+            <rect x="51.4205%" y="149" width="0.1003%" height="15" fill="rgb(221,220,41)"/>
             <text x="51.6705%" y="159.50"></text>
         </g>
         <g>
             <title>&amp;alloc::string::String::master_compress (73,900 samples, 12.35%)</title>
-            <rect x="39.1878%" y="181" width="12.3496%" height="15" fill="rgb(233,42,35)"/>
+            <rect x="39.1878%" y="181" width="12.3496%" height="15" fill="rgb(218,133,21)"/>
             <text x="39.4378%" y="191.50">&amp;alloc::string::St..</text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;&amp;alloc::string::String&gt;::String_EncoderArray::flush (194,200 samples, 32.45%)</title>
-            <rect x="19.1511%" y="197" width="32.4532%" height="15" fill="rgb(231,13,6)"/>
+            <rect x="19.1511%" y="197" width="32.4532%" height="15" fill="rgb(221,193,43)"/>
             <text x="19.4011%" y="207.50">alloc::vec::Vec&lt;&amp;alloc::string::String&gt;::String_Encod..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_compress (10,100 samples, 1.69%)</title>
-            <rect x="51.6377%" y="149" width="1.6878%" height="15" fill="rgb(207,181,40)"/>
+            <rect x="51.6377%" y="149" width="1.6878%" height="15" fill="rgb(240,128,52)"/>
             <text x="51.8877%" y="159.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,800 samples, 0.30%)</title>
-            <rect x="53.0247%" y="133" width="0.3008%" height="15" fill="rgb(254,173,49)"/>
+            <rect x="53.0247%" y="133" width="0.3008%" height="15" fill="rgb(253,114,12)"/>
             <text x="53.2747%" y="143.50"></text>
         </g>
         <g>
             <title>Final (10,200 samples, 1.70%)</title>
-            <rect x="51.6377%" y="165" width="1.7045%" height="15" fill="rgb(221,1,38)"/>
+            <rect x="51.6377%" y="165" width="1.7045%" height="15" fill="rgb(215,223,47)"/>
             <text x="51.8877%" y="175.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="53.3924%" y="117" width="0.0167%" height="15" fill="rgb(248,225,23)"/>
+            <text x="53.6424%" y="127.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="53.4091%" y="117" width="0.2507%" height="15" fill="rgb(206,124,46)"/>
+            <rect x="53.4091%" y="117" width="0.2507%" height="15" fill="rgb(250,108,0)"/>
             <text x="53.6591%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (800 samples, 0.13%)</title>
-            <rect x="53.5261%" y="101" width="0.1337%" height="15" fill="rgb(249,21,11)"/>
+            <rect x="53.5261%" y="101" width="0.1337%" height="15" fill="rgb(228,208,7)"/>
             <text x="53.7761%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,800 samples, 0.30%)</title>
-            <rect x="53.3757%" y="133" width="0.3008%" height="15" fill="rgb(222,201,40)"/>
+            <rect x="53.3757%" y="133" width="0.3008%" height="15" fill="rgb(244,45,10)"/>
             <text x="53.6257%" y="143.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (300 samples, 0.05%)</title>
+            <rect x="53.6765%" y="133" width="0.0501%" height="15" fill="rgb(207,125,25)"/>
+            <text x="53.9265%" y="143.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,000 samples, 0.33%)</title>
-            <rect x="53.7266%" y="117" width="0.3342%" height="15" fill="rgb(235,61,29)"/>
+            <rect x="53.7266%" y="117" width="0.3342%" height="15" fill="rgb(210,195,18)"/>
             <text x="53.9766%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (800 samples, 0.13%)</title>
-            <rect x="53.9271%" y="101" width="0.1337%" height="15" fill="rgb(219,207,3)"/>
+            <rect x="53.9271%" y="101" width="0.1337%" height="15" fill="rgb(249,80,12)"/>
             <text x="54.1771%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (2,100 samples, 0.35%)</title>
-            <rect x="53.7266%" y="133" width="0.3509%" height="15" fill="rgb(222,56,46)"/>
+            <rect x="53.7266%" y="133" width="0.3509%" height="15" fill="rgb(221,65,9)"/>
             <text x="53.9766%" y="143.50"></text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,300 samples, 0.38%)</title>
-            <rect x="54.0775%" y="133" width="0.3844%" height="15" fill="rgb(239,76,54)"/>
+            <rect x="54.0775%" y="133" width="0.3844%" height="15" fill="rgb(235,49,36)"/>
             <text x="54.3275%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (6,800 samples, 1.14%)</title>
-            <rect x="53.3590%" y="149" width="1.1364%" height="15" fill="rgb(231,124,27)"/>
+            <rect x="53.3590%" y="149" width="1.1364%" height="15" fill="rgb(225,32,20)"/>
             <text x="53.6090%" y="159.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,600 samples, 0.43%)</title>
-            <rect x="54.4953%" y="149" width="0.4345%" height="15" fill="rgb(249,195,6)"/>
+            <rect x="54.4953%" y="149" width="0.4345%" height="15" fill="rgb(215,141,46)"/>
             <text x="54.7453%" y="159.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="54.7794%" y="133" width="0.1504%" height="15" fill="rgb(237,174,47)"/>
+            <rect x="54.7794%" y="133" width="0.1504%" height="15" fill="rgb(250,160,47)"/>
             <text x="55.0294%" y="143.50"></text>
         </g>
         <g>
             <title>u8::master_compress (19,900 samples, 3.33%)</title>
-            <rect x="51.6210%" y="181" width="3.3255%" height="15" fill="rgb(206,201,31)"/>
+            <rect x="51.6210%" y="181" width="3.3255%" height="15" fill="rgb(216,222,40)"/>
             <text x="51.8710%" y="191.50">u8:..</text>
         </g>
         <g>
             <title>Samples (9,600 samples, 1.60%)</title>
-            <rect x="53.3422%" y="165" width="1.6043%" height="15" fill="rgb(231,57,52)"/>
+            <rect x="53.3422%" y="165" width="1.6043%" height="15" fill="rgb(234,217,39)"/>
             <text x="53.5922%" y="175.50"></text>
         </g>
         <g>
             <title>u8::CopyToLowered (1,600 samples, 0.27%)</title>
-            <rect x="54.9465%" y="181" width="0.2674%" height="15" fill="rgb(248,177,22)"/>
+            <rect x="54.9465%" y="181" width="0.2674%" height="15" fill="rgb(207,178,40)"/>
             <text x="55.1965%" y="191.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (21,700 samples, 3.63%)</title>
-            <rect x="51.6043%" y="197" width="3.6263%" height="15" fill="rgb(215,211,37)"/>
+            <rect x="51.6043%" y="197" width="3.6263%" height="15" fill="rgb(221,136,13)"/>
             <text x="51.8543%" y="207.50">allo..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::boolean::PackedBoolCompressor::compress_PackedBool (700 samples, 0.12%)</title>
-            <rect x="55.3643%" y="117" width="0.1170%" height="15" fill="rgb(241,128,51)"/>
+            <rect x="55.3643%" y="117" width="0.1170%" height="15" fill="rgb(249,199,10)"/>
             <text x="55.6143%" y="127.50"></text>
         </g>
         <g>
             <title>&amp;[bool]::encode_packed_bool (600 samples, 0.10%)</title>
-            <rect x="55.3810%" y="101" width="0.1003%" height="15" fill="rgb(227,165,31)"/>
+            <rect x="55.3810%" y="101" width="0.1003%" height="15" fill="rgb(249,222,13)"/>
             <text x="55.6310%" y="111.50"></text>
         </g>
         <g>
             <title>Final (900 samples, 0.15%)</title>
-            <rect x="55.3476%" y="133" width="0.1504%" height="15" fill="rgb(228,167,24)"/>
+            <rect x="55.3476%" y="133" width="0.1504%" height="15" fill="rgb(244,185,38)"/>
             <text x="55.5976%" y="143.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="55.5481%" y="101" width="0.0167%" height="15" fill="rgb(236,202,9)"/>
+            <text x="55.7981%" y="111.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,500 samples, 0.25%)</title>
-            <rect x="55.5648%" y="101" width="0.2507%" height="15" fill="rgb(228,143,12)"/>
+            <rect x="55.5648%" y="101" width="0.2507%" height="15" fill="rgb(250,229,37)"/>
             <text x="55.8148%" y="111.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (900 samples, 0.15%)</title>
-            <rect x="55.6651%" y="85" width="0.1504%" height="15" fill="rgb(249,149,8)"/>
+            <rect x="55.6651%" y="85" width="0.1504%" height="15" fill="rgb(206,174,23)"/>
             <text x="55.9151%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,800 samples, 0.30%)</title>
-            <rect x="55.5314%" y="117" width="0.3008%" height="15" fill="rgb(243,35,44)"/>
+            <rect x="55.5314%" y="117" width="0.3008%" height="15" fill="rgb(211,33,43)"/>
             <text x="55.7814%" y="127.50"></text>
         </g>
         <g>
             <title>Samples (4,000 samples, 0.67%)</title>
-            <rect x="55.4980%" y="133" width="0.6684%" height="15" fill="rgb(246,89,9)"/>
+            <rect x="55.4980%" y="133" width="0.6684%" height="15" fill="rgb(245,58,50)"/>
             <text x="55.7480%" y="143.50"></text>
         </g>
         <g>
             <title>u8::CopyToLowered (2,000 samples, 0.33%)</title>
-            <rect x="55.8322%" y="117" width="0.3342%" height="15" fill="rgb(233,213,13)"/>
+            <rect x="55.8322%" y="117" width="0.3342%" height="15" fill="rgb(244,68,36)"/>
             <text x="56.0822%" y="127.50"></text>
         </g>
         <g>
             <title>bool::master_compress (5,100 samples, 0.85%)</title>
-            <rect x="55.3309%" y="149" width="0.8523%" height="15" fill="rgb(233,141,41)"/>
+            <rect x="55.3309%" y="149" width="0.8523%" height="15" fill="rgb(232,229,15)"/>
             <text x="55.5809%" y="159.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;bool&gt;::Boolean_encode_all (9,500 samples, 1.59%)</title>
-            <rect x="55.3309%" y="165" width="1.5876%" height="15" fill="rgb(239,167,4)"/>
+            <rect x="55.3309%" y="165" width="1.5876%" height="15" fill="rgb(254,30,23)"/>
             <text x="55.5809%" y="175.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (2,000 samples, 0.33%)</title>
-            <rect x="60.1437%" y="117" width="0.3342%" height="15" fill="rgb(209,217,16)"/>
+            <rect x="60.1437%" y="117" width="0.3342%" height="15" fill="rgb(235,160,14)"/>
             <text x="60.3937%" y="127.50"></text>
         </g>
         <g>
             <title>Final (21,100 samples, 3.53%)</title>
-            <rect x="56.9686%" y="149" width="3.5261%" height="15" fill="rgb(219,88,35)"/>
+            <rect x="56.9686%" y="149" width="3.5261%" height="15" fill="rgb(212,155,44)"/>
             <text x="57.2186%" y="159.50">Fin..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_compress (21,000 samples, 3.51%)</title>
-            <rect x="56.9853%" y="133" width="3.5094%" height="15" fill="rgb(220,193,23)"/>
+            <rect x="56.9853%" y="133" width="3.5094%" height="15" fill="rgb(226,2,50)"/>
             <text x="57.2353%" y="143.50">tre..</text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (100 samples, 0.02%)</title>
+            <rect x="60.5615%" y="101" width="0.0167%" height="15" fill="rgb(234,177,6)"/>
+            <text x="60.8115%" y="111.50"></text>
+        </g>
+        <g>
             <title>Needless_copy_to_u32 (700 samples, 0.12%)</title>
-            <rect x="60.7286%" y="85" width="0.1170%" height="15" fill="rgb(230,90,52)"/>
+            <rect x="60.7286%" y="85" width="0.1170%" height="15" fill="rgb(217,24,9)"/>
             <text x="60.9786%" y="95.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (1,900 samples, 0.32%)</title>
-            <rect x="60.5448%" y="117" width="0.3175%" height="15" fill="rgb(252,106,19)"/>
+            <rect x="60.5448%" y="117" width="0.3175%" height="15" fill="rgb(220,13,46)"/>
             <text x="60.7948%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,700 samples, 0.28%)</title>
-            <rect x="60.5782%" y="101" width="0.2841%" height="15" fill="rgb(206,74,20)"/>
+            <rect x="60.5782%" y="101" width="0.2841%" height="15" fill="rgb(239,221,27)"/>
             <text x="60.8282%" y="111.50"></text>
         </g>
         <g>
+            <title>u8::CopyToLowered (300 samples, 0.05%)</title>
+            <rect x="60.8623%" y="117" width="0.0501%" height="15" fill="rgb(222,198,25)"/>
+            <text x="61.1123%" y="127.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (15,100 samples, 2.52%)</title>
-            <rect x="60.9291%" y="101" width="2.5234%" height="15" fill="rgb(230,138,44)"/>
+            <rect x="60.9291%" y="101" width="2.5234%" height="15" fill="rgb(211,99,13)"/>
             <text x="61.1791%" y="111.50">tr..</text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (14,700 samples, 2.46%)</title>
-            <rect x="60.9960%" y="85" width="2.4566%" height="15" fill="rgb(235,182,43)"/>
+            <rect x="60.9960%" y="85" width="2.4566%" height="15" fill="rgb(232,111,31)"/>
             <text x="61.2460%" y="95.50">Ne..</text>
         </g>
         <g>
             <title>u8::master_fast_size_for (15,300 samples, 2.56%)</title>
-            <rect x="60.9124%" y="117" width="2.5568%" height="15" fill="rgb(242,16,51)"/>
+            <rect x="60.9124%" y="117" width="2.5568%" height="15" fill="rgb(245,82,37)"/>
             <text x="61.1624%" y="127.50">u8..</text>
         </g>
         <g>
             <title>&amp;[u8]::RLE_get_runs (2,600 samples, 0.43%)</title>
-            <rect x="63.4693%" y="117" width="0.4345%" height="15" fill="rgb(248,9,4)"/>
+            <rect x="63.4693%" y="117" width="0.4345%" height="15" fill="rgb(227,149,46)"/>
             <text x="63.7193%" y="127.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (20,400 samples, 3.41%)</title>
-            <rect x="60.5281%" y="133" width="3.4091%" height="15" fill="rgb(210,31,22)"/>
+            <rect x="60.5281%" y="133" width="3.4091%" height="15" fill="rgb(218,36,50)"/>
             <text x="60.7781%" y="143.50">tre..</text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,200 samples, 0.20%)</title>
-            <rect x="64.1377%" y="117" width="0.2005%" height="15" fill="rgb(239,54,39)"/>
+            <rect x="64.1377%" y="117" width="0.2005%" height="15" fill="rgb(226,80,48)"/>
             <text x="64.3877%" y="127.50"></text>
         </g>
         <g>
             <title>Samples (23,100 samples, 3.86%)</title>
-            <rect x="60.4947%" y="149" width="3.8603%" height="15" fill="rgb(230,99,41)"/>
+            <rect x="60.4947%" y="149" width="3.8603%" height="15" fill="rgb(238,224,15)"/>
             <text x="60.7447%" y="159.50">Samp..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,500 samples, 0.42%)</title>
-            <rect x="63.9372%" y="133" width="0.4178%" height="15" fill="rgb(253,106,12)"/>
+            <rect x="63.9372%" y="133" width="0.4178%" height="15" fill="rgb(241,136,10)"/>
             <text x="64.1872%" y="143.50"></text>
         </g>
         <g>
             <title>u8::master_compress (44,400 samples, 7.42%)</title>
-            <rect x="56.9519%" y="165" width="7.4198%" height="15" fill="rgb(213,46,41)"/>
+            <rect x="56.9519%" y="165" width="7.4198%" height="15" fill="rgb(208,32,45)"/>
             <text x="57.2019%" y="175.50">u8::master..</text>
         </g>
         <g>
             <title>u8::CopyToLowered (3,200 samples, 0.53%)</title>
-            <rect x="64.3717%" y="165" width="0.5348%" height="15" fill="rgb(215,133,35)"/>
+            <rect x="64.3717%" y="165" width="0.5348%" height="15" fill="rgb(207,135,9)"/>
             <text x="64.6217%" y="175.50"></text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (57,600 samples, 9.63%)</title>
-            <rect x="55.2975%" y="181" width="9.6257%" height="15" fill="rgb(213,28,5)"/>
+            <rect x="55.2975%" y="181" width="9.6257%" height="15" fill="rgb(206,86,44)"/>
             <text x="55.5475%" y="191.50">alloc::vec::Ve..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::array::VecArrayEncoder&lt;graphql::schemas::treebuf::BodyShapeTreeBufEncoderArray&gt;::Array_flush (58,400 samples, 9.76%)</title>
-            <rect x="55.2306%" y="197" width="9.7594%" height="15" fill="rgb(215,77,49)"/>
+            <rect x="55.2306%" y="197" width="9.7594%" height="15" fill="rgb(245,177,15)"/>
             <text x="55.4806%" y="207.50">tree_buf::inte..</text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::PrefixVarInt_compress (9,800 samples, 1.64%)</title>
-            <rect x="65.0902%" y="149" width="1.6377%" height="15" fill="rgb(248,100,22)"/>
+            <rect x="65.0902%" y="149" width="1.6377%" height="15" fill="rgb(206,64,50)"/>
             <text x="65.3402%" y="159.50"></text>
         </g>
         <g>
             <title>Final (10,000 samples, 1.67%)</title>
-            <rect x="65.0735%" y="165" width="1.6711%" height="15" fill="rgb(208,67,9)"/>
+            <rect x="65.0735%" y="165" width="1.6711%" height="15" fill="rgb(234,36,40)"/>
             <text x="65.3235%" y="175.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::BytesCompressor)&gt;::fast_size_for (200 samples, 0.03%)</title>
+            <rect x="66.8115%" y="117" width="0.0334%" height="15" fill="rgb(213,64,8)"/>
+            <text x="67.0615%" y="127.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (2,000 samples, 0.33%)</title>
-            <rect x="66.8449%" y="117" width="0.3342%" height="15" fill="rgb(219,133,21)"/>
+            <rect x="66.8449%" y="117" width="0.3342%" height="15" fill="rgb(210,75,36)"/>
             <text x="67.0949%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,100 samples, 0.18%)</title>
-            <rect x="66.9953%" y="101" width="0.1838%" height="15" fill="rgb(246,46,29)"/>
+            <rect x="66.9953%" y="101" width="0.1838%" height="15" fill="rgb(229,88,21)"/>
             <text x="67.2453%" y="111.50"></text>
         </g>
         <g>
             <title>u8::master_fast_size_for (2,300 samples, 0.38%)</title>
-            <rect x="66.8115%" y="133" width="0.3844%" height="15" fill="rgb(246,185,52)"/>
+            <rect x="66.8115%" y="133" width="0.3844%" height="15" fill="rgb(252,204,47)"/>
             <text x="67.0615%" y="143.50"></text>
         </g>
         <g>
             <title>u8::CopyToLowered (600 samples, 0.10%)</title>
-            <rect x="67.1959%" y="133" width="0.1003%" height="15" fill="rgb(252,136,11)"/>
+            <rect x="67.1959%" y="133" width="0.1003%" height="15" fill="rgb(208,77,27)"/>
             <text x="67.4459%" y="143.50"></text>
         </g>
         <g>
+            <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::fast_size_for (400 samples, 0.07%)</title>
+            <rect x="67.2961%" y="117" width="0.0668%" height="15" fill="rgb(221,76,26)"/>
+            <text x="67.5461%" y="127.50"></text>
+        </g>
+        <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,200 samples, 0.20%)</title>
-            <rect x="67.3630%" y="117" width="0.2005%" height="15" fill="rgb(219,138,53)"/>
+            <rect x="67.3630%" y="117" width="0.2005%" height="15" fill="rgb(225,139,18)"/>
             <text x="67.6130%" y="127.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,100 samples, 0.18%)</title>
-            <rect x="67.3797%" y="101" width="0.1838%" height="15" fill="rgb(211,51,23)"/>
+            <rect x="67.3797%" y="101" width="0.1838%" height="15" fill="rgb(230,137,11)"/>
             <text x="67.6297%" y="111.50"></text>
         </g>
         <g>
             <title>u32::master_fast_size_for (1,700 samples, 0.28%)</title>
-            <rect x="67.2961%" y="133" width="0.2841%" height="15" fill="rgb(247,221,28)"/>
+            <rect x="67.2961%" y="133" width="0.2841%" height="15" fill="rgb(212,28,1)"/>
             <text x="67.5461%" y="143.50"></text>
         </g>
         <g>
             <title>&amp;[u32]::RLE_get_runs (2,800 samples, 0.47%)</title>
-            <rect x="67.5802%" y="133" width="0.4679%" height="15" fill="rgb(251,222,45)"/>
+            <rect x="67.5802%" y="133" width="0.4679%" height="15" fill="rgb(248,164,17)"/>
             <text x="67.8302%" y="143.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::encodings::rle::RLE&lt;(tree_buf::internal::types::integer::Simple16Compressor,_tree_buf::internal::types::integer::DeltaZigZagCompressor,_tree_buf::internal::types::integer::PrefixVarIntCompressor)&gt;::fast_size_for (7,900 samples, 1.32%)</title>
-            <rect x="66.7614%" y="149" width="1.3202%" height="15" fill="rgb(217,162,53)"/>
+            <rect x="66.7614%" y="149" width="1.3202%" height="15" fill="rgb(222,171,42)"/>
             <text x="67.0114%" y="159.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::PrefixVarIntCompressor::fast_size_for (2,700 samples, 0.45%)</title>
-            <rect x="68.0816%" y="149" width="0.4512%" height="15" fill="rgb(229,93,14)"/>
+            <rect x="68.0816%" y="149" width="0.4512%" height="15" fill="rgb(243,84,45)"/>
             <text x="68.3316%" y="159.50"></text>
         </g>
         <g>
             <title>tree_buf::internal::types::integer::Simple16Compressor::Simple16_fast_size_for (1,900 samples, 0.32%)</title>
-            <rect x="68.5328%" y="149" width="0.3175%" height="15" fill="rgb(209,67,49)"/>
+            <rect x="68.5328%" y="149" width="0.3175%" height="15" fill="rgb(252,49,23)"/>
             <text x="68.7828%" y="159.50"></text>
         </g>
         <g>
             <title>Needless_copy_to_u32 (1,700 samples, 0.28%)</title>
-            <rect x="68.5662%" y="133" width="0.2841%" height="15" fill="rgb(213,87,29)"/>
+            <rect x="68.5662%" y="133" width="0.2841%" height="15" fill="rgb(215,19,7)"/>
             <text x="68.8162%" y="143.50"></text>
         </g>
         <g>
             <title>Samples (12,700 samples, 2.12%)</title>
-            <rect x="66.7447%" y="165" width="2.1223%" height="15" fill="rgb(205,151,52)"/>
+            <rect x="66.7447%" y="165" width="2.1223%" height="15" fill="rgb(238,81,41)"/>
             <text x="66.9947%" y="175.50">S..</text>
         </g>
         <g>
             <title>u32::master_compress (22,900 samples, 3.83%)</title>
-            <rect x="65.0568%" y="181" width="3.8269%" height="15" fill="rgb(253,215,39)"/>
+            <rect x="65.0568%" y="181" width="3.8269%" height="15" fill="rgb(210,199,37)"/>
             <text x="65.3068%" y="191.50">u32:..</text>
         </g>
         <g>
             <title>u32::CopyToLowered (25,900 samples, 4.33%)</title>
-            <rect x="68.8837%" y="181" width="4.3282%" height="15" fill="rgb(221,220,41)"/>
+            <rect x="68.8837%" y="181" width="4.3282%" height="15" fill="rgb(244,192,49)"/>
             <text x="69.1337%" y="191.50">u32::..</text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;u64&gt;::Integer_encode_all (183,900 samples, 30.73%)</title>
-            <rect x="64.9900%" y="197" width="30.7320%" height="15" fill="rgb(218,133,21)"/>
+            <rect x="64.9900%" y="197" width="30.7320%" height="15" fill="rgb(226,211,11)"/>
             <text x="65.2400%" y="207.50">alloc::vec::Vec&lt;u64&gt;::Integer_encode_all</text>
         </g>
         <g>
             <title>alloc::vec::Vec&lt;graphql::schemas::treebuf::Order&gt;::Array_encode_root (597,800 samples, 99.90%)</title>
-            <rect x="0.0501%" y="213" width="99.8997%" height="15" fill="rgb(221,193,43)"/>
+            <rect x="0.0501%" y="213" width="99.8997%" height="15" fill="rgb(236,162,54)"/>
             <text x="0.3001%" y="223.50">alloc::vec::Vec&lt;graphql::schemas::treebuf::Order&gt;::Array_encode_root</text>
         </g>
         <g>
             <title>all (598,400 samples, 100%)</title>
-            <rect x="0.0000%" y="261" width="100.0000%" height="15" fill="rgb(240,128,52)"/>
+            <rect x="0.0000%" y="261" width="100.0000%" height="15" fill="rgb(220,229,9)"/>
             <text x="0.2500%" y="271.50"></text>
         </g>
         <g>
             <title>GraphQL (598,400 samples, 100.00%)</title>
-            <rect x="0.0000%" y="245" width="100.0000%" height="15" fill="rgb(253,114,12)"/>
+            <rect x="0.0000%" y="245" width="100.0000%" height="15" fill="rgb(250,87,22)"/>
             <text x="0.2500%" y="255.50">GraphQL</text>
         </g>
         <g>
             <title>graphql::schemas::treebuf::Response::encode_with_options (598,300 samples, 99.98%)</title>
-            <rect x="0.0167%" y="229" width="99.9833%" height="15" fill="rgb(215,223,47)"/>
+            <rect x="0.0167%" y="229" width="99.9833%" height="15" fill="rgb(239,43,17)"/>
             <text x="0.2667%" y="239.50">graphql::schemas::treebuf::Response::encode_with_options</text>
         </g>
     </svg>


### PR DESCRIPTION
See also #153. PR #136 changed the semantics of the `--minwidth` option from output pixel width to percentage width (which is effectively the same as pct of total samples), which greatly reduced the default fidelity of flamegraphs as 0.1% of total time is quite coarse, especially once you start zooming in.

This PR reduces the default to 0.01%, which produces pretty much identical output as flamegraph.pl / old inferno at ~1200px wide and includes a much greater number of bars. I think this change is worth making as it makes it reduces friction for people migrating from flamegraph.pl, and in my tests produces much more useful output by default.

I've also updated the description of the option to match the current behaviour, as it still mentioned pixels and that had me confused for a good while.