### PR TITLE
Improve differential flame graph by delta width

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -875,7 +875,9 @@ fn filled_rectangle<W: Write>(
             "height" => &buffer[height],
             "fill" => &buffer[color],
             "fg:x" => &buffer[x_samples],
-            "fg:w" => &buffer[width_samples]
+            "fg:w" => &buffer[width_samples],
+            "rx" => "2",
+            "ry" => "2"
         ));
     } else {
         unreachable!("cache wrapper was of wrong type: {:?}", cache_rect);


### PR DESCRIPTION
Hi, all: 

I change the way generate differential flame graph by using delta as frame's width, and wrote an article to explain the new diff-graph, you can see it below:
https://unpluggedcoder.me/2021/05/22/Improved%20Differential%20Flame%20Graph/

⚠️NOTICE: This PR may have a big impact on current differential flame graph.

And round the rect of frame for better view.