### PR TITLE
Color user-defined async functions correctly for Rust coloring

### DIFF
--- a/src/flamegraph/color/palettes.rs
+++ b/src/flamegraph/color/palettes.rs
@@ -106,7 +106,11 @@ pub(super) mod rust {
         if name.starts_with("core::")
             || name.starts_with("std::")
             || name.starts_with("alloc::")
-            || name.starts_with("<core::")
+            || (name.starts_with("<core::") 
+                // Rust user-defined async functions are desugared into 
+                // GenFutures so we don't want to include those as Rust 
+                // system functions
+                && !name.starts_with("<core::future::from_generator::GenFuture<T>"))
             || name.starts_with("<std::")
             || name.starts_with("<alloc::")
         {
@@ -511,6 +515,12 @@ mod tests {
             TestData {
                 input: String::from("<core::something as something::else"),
                 output: BasicPalette::Orange,
+            },
+            TestData {
+                input: String::from(
+                    "<core::future::from_generator::GenFuture<T> as something::else",
+                ),
+                output: BasicPalette::Aqua,
             },
             TestData {
                 input: String::from("<std::something something::else"),


### PR DESCRIPTION
The current Rust coloring is a little confusing because it colors desugared user-defined async functions in the same color as system functions.  This change will cause the Rust coloring to use the user coloring instead of the system coloring for those functions.

Before:

![before](https://user-images.githubusercontent.com/1026237/119574279-5975af80-bd6a-11eb-8ba0-e98ebcdb26dc.png)

After:

![after](https://user-images.githubusercontent.com/1026237/119574289-5bd80980-bd6a-11eb-8c3c-f047f5555c11.png)
