### PR TITLE
Replace deprecated ParameterizedBenchmark in criterion with benchmark_group

### DIFF
--- a/benches/flamegraph.rs
+++ b/benches/flamegraph.rs
@@ -10,20 +10,18 @@ fn flamegraph_benchmark(c: &mut Criterion, id: &str, infile: &str, mut opt: Opti
     let mut bytes = Vec::new();
     f.read_to_end(&mut bytes).expect("Could not read file");
 
-    c.bench(
-        "flamegraph",
-        ParameterizedBenchmark::new(
-            id,
-            move |b, data| {
-                b.iter(|| {
-                    let reader = BufReader::new(data.as_slice());
-                    let _folder = flamegraph::from_reader(&mut opt, reader, io::sink());
-                })
-            },
-            vec![bytes],
-        )
-        .throughput(|bytes| Throughput::Bytes(bytes.len() as u64)),
-    );
+    let mut group = c.benchmark_group(id);
+
+    group
+        .bench_with_input("flamegraph", &bytes, move |b, data| {
+            b.iter(|| {
+                let reader = BufReader::new(data.as_slice());
+                let _folder = flamegraph::from_reader(&mut opt, reader, io::sink());
+            })
+        })
+        .throughput(Throughput::Bytes(bytes.len() as u64));
+
+    group.finish();
 }
 
 macro_rules! flamegraph_benchmarks {

--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -679,7 +679,7 @@ pub(crate) mod testing {
             {
                 let default = folder.nstacks_per_job();
 
-                let (nlines, nstacks) = count_lines_and_stacks(&bytes);
+                let (nlines, nstacks) = count_lines_and_stacks(bytes);
                 if nlines < MIN_LINES {
                     return Ok(None);
                 }
@@ -694,7 +694,7 @@ pub(crate) mod testing {
                     let mut durations = Vec::new();
                     for _ in 0..NSAMPLES {
                         let now = Instant::now();
-                        folder.collapse(&bytes[..], io::sink())?;
+                        folder.collapse(bytes, io::sink())?;
                         durations.push(now.elapsed().as_nanos_compat());
                     }
                     let avg_duration =

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -470,9 +470,14 @@ mod tests {
             input.extend_from_slice(valid_stack.as_bytes());
         }
 
-        let mut folder = Folder::default();
-        folder.nstacks_per_job = 1;
-        folder.opt.nthreads = 12;
+        let mut folder = Folder {
+            nstacks_per_job: 1,
+            opt: Options {
+                nthreads: 12,
+                ..Options::default()
+            },
+            ..Folder::default()
+        };
         <Folder as Collapse>::collapse(&mut folder, &input[..], io::sink()).unwrap();
     }
 


### PR DESCRIPTION
Since v0.3.4 ParameterizedBenchmark was deprecated:
 * https://github.com/bheisler/criterion.rs/commit/226b398ff01256493e71555acd455a2102d04d4e
 * https://github.com/bheisler/criterion.rs/commit/cac59f29a62a9c088213c5d31d7b12a1b7784b2b
