### PR TITLE
Make behavior of skip_after more consistent.

### DIFF
--- a/src/bin/collapse-perf.rs
+++ b/src/bin/collapse-perf.rs
@@ -82,8 +82,9 @@ struct Opt {
     infile: Option<PathBuf>,
 
     #[structopt(long = "skip-after", value_name = "STRING")]
-    /// If set, will omit all the stack frames that follow the frame with matched function name.
-    /// Has not effect on the stack trace if no function is matched.
+    /// If set, will omit all the parent stack frames of the frame with matched function name.
+    ///
+    /// Has no effect on the stack trace if no function is matched.
     skip_after: Option<String>,
 }
 

--- a/src/bin/collapse-perf.rs
+++ b/src/bin/collapse-perf.rs
@@ -80,6 +80,11 @@ struct Opt {
     #[structopt(value_name = "PATH")]
     /// Perf script output file, or STDIN if not specified
     infile: Option<PathBuf>,
+
+    #[structopt(long = "skip-after", value_name = "STRING")]
+    /// If set, will omit all the stack frames that follow the frame with matched function name.
+    /// Has not effect on the stack trace if no function is matched.
+    skip_after: Option<String>,
 }
 
 impl Opt {
@@ -92,6 +97,7 @@ impl Opt {
         options.annotate_kernel = self.kernel || self.all;
         options.event_filter = self.event_filter;
         options.nthreads = self.nthreads;
+        options.skip_after = self.skip_after;
         (self.infile, options)
     }
 }

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -568,13 +568,19 @@ impl Folder {
                 self.pname.len() + self.stack.iter().fold(0, |a, s| a + s.len() + 1),
             );
 
-            // add the comm name
-            stack_str.push_str(&self.pname);
-            // add the other stack entries (if any)
-            for e in self.stack.drain(..) {
+            // If we skip remaining frames we want to skip pname as well.
+            if self.stack_filter != StackFilter::SkipRemaining {
+                // add the comm name
+                stack_str.push_str(&self.pname);
                 stack_str.push(';');
-                stack_str.push_str(&e);
             }
+            for e in self.stack.drain(..) {
+                stack_str.push_str(&e);
+                stack_str.push(';');
+            }
+
+            // self.stack is not empty, therefore stack_str has at least one frame followed by ';'
+            stack_str.pop();
 
             // count it!
             occurrences.insert_or_add(stack_str, 1);
@@ -800,7 +806,7 @@ mod tests {
         // go;[unknown];x_cgo_notify_runtime_init_done;runtime.main;main.init;...
         for line in lines {
             if line.contains("main.init") {
-                assert!(line.contains("go;main.init;")); // we removed the frames above "main.init"
+                assert!(line.contains("main.init;")); // we removed the frames above "main.init"
             }
         }
         Ok(())


### PR DESCRIPTION
Specifically, omits process name as a root frame if `skip_after` condition was trigerred.
Also, I added "skip-after" flag to collapse-perf.rs in order to actually be able to use
and test this flag on real stack traces.