### PR TITLE
Update from structopt to clap v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ codecov = { repository = "jonhoo/inferno", branch = "master", service = "github"
 
 [features]
 default = ["cli", "multithreaded", "nameattr"]
-cli = ["structopt", "env_logger"]
+cli = ["clap", "env_logger"]
 multithreaded = ["dashmap", "crossbeam-utils", "crossbeam-channel", "num_cpus"]
 nameattr = ["indexmap"]
 
@@ -42,7 +42,7 @@ num-format = { version = "0.4", default-features = false }
 quick-xml = { version = "0.22", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
-structopt = { version = "0.3", optional = true }
+clap = { version = "3.0.1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ jobs:
  - template: default.yml@templates
    parameters:
      codecov_token: $(CODECOV_TOKEN_SECRET)
-     minrust: 1.46.0
+     minrust: 1.54.0
      env:
        RUST_BACKTRACE: 1
      setup:

--- a/src/bin/collapse-dtrace.rs
+++ b/src/bin/collapse-dtrace.rs
@@ -1,18 +1,18 @@
 use std::io;
 use std::path::PathBuf;
 
+use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::dtrace::{Folder, Options};
 use inferno::collapse::{Collapse, DEFAULT_NTHREADS};
 use lazy_static::lazy_static;
-use structopt::StructOpt;
 
 lazy_static! {
     static ref NTHREADS: String = format!("{}", *DEFAULT_NTHREADS);
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "inferno-collapse-dtrace",
     about,
     after_help = "\
@@ -27,23 +27,23 @@ struct Opt {
     // *** FLAGS *** //
     // ************* //
     /// Include offsets
-    #[structopt(long = "includeoffset")]
+    #[clap(long = "includeoffset")]
     includeoffset: bool,
 
     /// Silence all log output
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Verbose logging mode (-v, -vv, -vvv)
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: usize,
 
     // *************** //
     // *** OPTIONS *** //
     // *************** //
     /// Number of threads to use.
-    #[structopt(
-        short = "n",
+    #[clap(
+        short = 'n',
         long = "nthreads",
         default_value = &NTHREADS,
         value_name = "UINT"
@@ -53,7 +53,7 @@ struct Opt {
     // ************ //
     // *** ARGS *** //
     // ************ //
-    #[structopt(value_name = "PATH")]
+    #[clap(value_name = "PATH")]
     /// Dtrace script output file, or STDIN if not specified
     infile: Option<PathBuf>,
 }
@@ -68,7 +68,7 @@ impl Opt {
 }
 
 fn main() -> io::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger
     if !opt.quiet {

--- a/src/bin/collapse-guess.rs
+++ b/src/bin/collapse-guess.rs
@@ -1,18 +1,18 @@
 use std::io;
 use std::path::PathBuf;
 
+use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::guess::{Folder, Options};
 use inferno::collapse::{Collapse, DEFAULT_NTHREADS};
 use lazy_static::lazy_static;
-use structopt::StructOpt;
 
 lazy_static! {
     static ref NTHREADS: String = format!("{}", *DEFAULT_NTHREADS);
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "inferno-collapse-guess",
     about,
     after_help = "\
@@ -24,19 +24,19 @@ struct Opt {
     // *** FLAGS *** //
     // ************* //
     /// Silence all log output
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Verbose logging mode (-v, -vv, -vvv)
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: usize,
 
     // *************** //
     // *** OPTIONS *** //
     // *************** //
     /// Number of threads to use
-    #[structopt(
-        short = "n",
+    #[clap(
+        short = 'n',
         long = "nthreads",
         default_value = &NTHREADS,
         value_name = "UINT"
@@ -47,7 +47,7 @@ struct Opt {
     // *** ARGS *** //
     // ************ //
     /// Input file, or STDIN if not specified
-    #[structopt(value_name = "PATH")]
+    #[clap(value_name = "PATH")]
     infile: Option<PathBuf>,
 }
 
@@ -60,7 +60,7 @@ impl Opt {
 }
 
 fn main() -> io::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger
     if !opt.quiet {

--- a/src/bin/collapse-perf.rs
+++ b/src/bin/collapse-perf.rs
@@ -1,18 +1,18 @@
 use std::io;
 use std::path::PathBuf;
 
+use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::perf::{Folder, Options};
 use inferno::collapse::{Collapse, DEFAULT_NTHREADS};
 use lazy_static::lazy_static;
-use structopt::StructOpt;
 
 lazy_static! {
     static ref NTHREADS: String = format!("{}", *DEFAULT_NTHREADS);
 }
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "inferno-collapse-perf",
     about,
     after_help = "\
@@ -27,47 +27,47 @@ struct Opt {
     // *** FLAGS *** //
     // ************* //
     /// Include raw addresses where symbols can't be found
-    #[structopt(long = "addrs")]
+    #[clap(long = "addrs")]
     addrs: bool,
 
     /// All annotations (--kernel --jit)
-    #[structopt(long = "all")]
+    #[clap(long = "all")]
     all: bool,
 
     /// Annotate jit functions with a `_[j]`
-    #[structopt(long = "jit")]
+    #[clap(long = "jit")]
     jit: bool,
 
     /// Annotate kernel functions with a `_[k]`
-    #[structopt(long = "kernel")]
+    #[clap(long = "kernel")]
     kernel: bool,
 
     /// Include PID with process names
-    #[structopt(long = "pid")]
+    #[clap(long = "pid")]
     pid: bool,
 
     /// Include TID and PID with process names
-    #[structopt(long = "tid")]
+    #[clap(long = "tid")]
     tid: bool,
 
     /// Silence all log output
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Verbose logging mode (-v, -vv, -vvv)
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: usize,
 
     // *************** //
     // *** OPTIONS *** //
     // *************** //
     /// Event filter [default: first encountered event]
-    #[structopt(long = "event-filter", value_name = "STRING")]
+    #[clap(long = "event-filter", value_name = "STRING")]
     event_filter: Option<String>,
 
     /// Number of threads to use
-    #[structopt(
-        short = "n",
+    #[clap(
+        short = 'n',
         long = "nthreads",
         default_value = &NTHREADS,
         value_name = "UINT"
@@ -77,11 +77,11 @@ struct Opt {
     // ************ //
     // *** ARGS *** //
     // ************ //
-    #[structopt(value_name = "PATH")]
+    #[clap(value_name = "PATH")]
     /// Perf script output file, or STDIN if not specified
     infile: Option<PathBuf>,
 
-    #[structopt(long = "skip-after", value_name = "STRING")]
+    #[clap(long = "skip-after", value_name = "STRING")]
     /// If set, will omit all the parent stack frames of the frame with matched function name.
     ///
     /// Has no effect on the stack trace if no function is matched.
@@ -104,7 +104,7 @@ impl Opt {
 }
 
 fn main() -> io::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger
     if !opt.quiet {

--- a/src/bin/collapse-sample.rs
+++ b/src/bin/collapse-sample.rs
@@ -1,13 +1,13 @@
 use std::io;
 use std::path::PathBuf;
 
+use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::sample::{Folder, Options};
 use inferno::collapse::Collapse;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "inferno-collapse-sample",
     about,
     after_help = "\
@@ -19,22 +19,22 @@ struct Opt {
     // *** FLAGS *** //
     // ************* //
     /// Don't include modules with function names
-    #[structopt(long = "no-modules")]
+    #[clap(long = "no-modules")]
     no_modules: bool,
 
     /// Silence all log output
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Verbose logging mode (-v, -vv, -vvv)
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: usize,
 
     // ************ //
     // *** ARGS *** //
     // ************ //
     /// sample output file, or STDIN if not specified
-    #[structopt(value_name = "PATH")]
+    #[clap(value_name = "PATH")]
     infile: Option<PathBuf>,
 }
 
@@ -47,7 +47,7 @@ impl Opt {
 }
 
 fn main() -> io::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger
     if !opt.quiet {

--- a/src/bin/collapse-vtune.rs
+++ b/src/bin/collapse-vtune.rs
@@ -1,13 +1,13 @@
 use std::io;
 use std::path::PathBuf;
 
+use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::vtune::{Folder, Options};
 use inferno::collapse::Collapse;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "inferno-collapse-vtune",
     about,
     after_help = "\
@@ -21,22 +21,22 @@ struct Opt {
     // *** FLAGS *** //
     // ************* //
     /// Don't include modules with function names
-    #[structopt(long = "no-modules")]
+    #[clap(long = "no-modules")]
     no_modules: bool,
 
     /// Silence all log output
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Verbose logging mode (-v, -vv, -vvv)
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: usize,
 
     // ************ //
     // *** ARGS *** //
     // ************ //
     /// VTune CSV output file, or STDIN if not specified
-    #[structopt(value_name = "PATH")]
+    #[clap(value_name = "PATH")]
     infile: Option<PathBuf>,
 }
 
@@ -49,7 +49,7 @@ impl Opt {
 }
 
 fn main() -> io::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger
     if !opt.quiet {

--- a/src/bin/diff-folded.rs
+++ b/src/bin/diff-folded.rs
@@ -1,12 +1,12 @@
 use std::io;
 use std::path::PathBuf;
 
+use clap::Parser;
 use env_logger::Env;
 use inferno::differential::{self, Options};
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[clap(
     name = "inferno-diff-folded",
     about,
     after_help = "\
@@ -31,30 +31,30 @@ struct Opt {
     // *** FLAGS *** //
     // ************* //
     /// Normalize sample counts
-    #[structopt(short = "n", long = "normalize")]
+    #[clap(short = 'n', long = "normalize")]
     normalize: bool,
 
     /// Strip hex numbers (addresses)
-    #[structopt(short = "s", long = "strip-hex")]
+    #[clap(short = 's', long = "strip-hex")]
     strip_hex: bool,
 
     /// Silence all log output
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Verbose logging mode (-v, -vv, -vvv)
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: usize,
 
     // ************ //
     // *** ARGS *** //
     // ************ //
     /// Path to folded stack profile 1
-    #[structopt(value_name = "PATH1")]
+    #[clap(value_name = "PATH1")]
     path1: PathBuf,
 
     /// Path to folded stack profile 2
-    #[structopt(value_name = "PATH2")]
+    #[clap(value_name = "PATH2")]
     path2: PathBuf,
 }
 
@@ -72,7 +72,7 @@ impl Opt {
 }
 
 fn main() -> io::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger
     if !opt.quiet {

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -8,78 +8,78 @@ use inferno::flamegraph::{self, defaults, Direction, Options, Palette, TextTrunc
 #[cfg(feature = "nameattr")]
 use inferno::flamegraph::FuncFrameAttrsMap;
 
-use structopt::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "inferno-flamegraph", about)]
+#[derive(Debug, Parser)]
+#[clap(name = "inferno-flamegraph", about)]
 struct Opt {
     // ************* //
     // *** FLAGS *** //
     // ************* //
     /// Use consistent palette (palette.map)
-    #[structopt(long = "cp")]
+    #[clap(long = "cp")]
     cp: bool,
 
     /// Colors are selected by hashing the function name, weighting earlier characters more
     /// heavily
-    #[structopt(long = "hash", conflicts_with = "deterministic")]
+    #[clap(long = "hash", conflicts_with = "deterministic")]
     hash: bool,
 
     /// Colors are selected such that the color of a function does not change between runs
-    #[structopt(long = "deterministic", conflicts_with = "hash")]
+    #[clap(long = "deterministic", conflicts_with = "hash")]
     deterministic: bool,
 
     /// Plot the flame graph up-side-down
-    #[structopt(short = "i", long = "inverted")]
+    #[clap(short = 'i', long = "inverted")]
     inverted: bool,
 
     /// If text doesn't fit in frame, truncate right side.
-    #[structopt(long = "truncate-text-right")]
+    #[clap(long = "truncate-text-right")]
     truncate_text_right: bool,
 
     /// Switch differential hues (green<->red)
-    #[structopt(long = "negate")]
+    #[clap(long = "negate")]
     negate: bool,
 
     /// Don't include static JavaScript in flame graph.
     /// This flag is hidden since it's only meant to be used in
     /// tests so we don't have to include the same static
     /// JavaScript in all of the test files
-    #[structopt(hidden = true, long = "no-javascript")]
+    #[clap(hide = true, long = "no-javascript")]
     no_javascript: bool,
 
     /// Don't sort the input lines.
     /// If you set this flag you need to be sure your
     /// input stack lines are already sorted
-    #[structopt(name = "no-sort", long = "no-sort")]
+    #[clap(name = "no-sort", long = "no-sort")]
     no_sort: bool,
 
     /// Pretty print XML with newlines and indentation.
-    #[structopt(long = "pretty-xml")]
+    #[clap(long = "pretty-xml")]
     pretty_xml: bool,
 
     /// Silence all log output
-    #[structopt(short = "q", long = "quiet")]
+    #[clap(short = 'q', long = "quiet")]
     quiet: bool,
 
     /// Generate stack-reversed flame graph
-    #[structopt(long = "reverse", conflicts_with = "no-sort")]
+    #[clap(long = "reverse", conflicts_with = "no-sort")]
     reverse: bool,
 
     /// Verbose logging mode (-v, -vv, -vvv)
-    #[structopt(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: usize,
 
     // *************** //
     // *** OPTIONS *** //
     // *************** //
     /// Set background colors. Gradient choices are yellow (default), blue, green, grey; flat colors use "#rrggbb"
-    #[structopt(long = "bgcolors", value_name = "STRING")]
+    #[clap(long = "bgcolors", value_name = "STRING")]
     bgcolors: Option<BackgroundColor>,
 
     /// Set color palette
-    #[structopt(
-        short = "c",
+    #[clap(
+        short = 'c',
         long = "colors",
         default_value = defaults::COLORS,
         possible_values = &["aqua","blue","green","hot","io","java","js","mem","orange","perl","purple","red","rust","wakeup","yellow"],
@@ -88,11 +88,11 @@ struct Opt {
     colors: Palette,
 
     /// Color frames based on their width, highlighting expensive codepaths
-    #[structopt(long = "colordiffusion", conflicts_with = "colors")]
+    #[clap(long = "colordiffusion", conflicts_with = "colors")]
     color_diffusion: bool,
 
     /// Count type label
-    #[structopt(
+    #[clap(
         long = "countname",
         default_value = defaults::COUNT_NAME,
         value_name = "STRING"
@@ -100,7 +100,7 @@ struct Opt {
     countname: String,
 
     /// Factor to scale sample counts by
-    #[structopt(
+    #[clap(
         long = "factor",
         default_value = &defaults::str::FACTOR,
         value_name = "FLOAT"
@@ -108,7 +108,7 @@ struct Opt {
     factor: f64,
 
     /// Font size
-    #[structopt(
+    #[clap(
         long = "fontsize",
         default_value = &defaults::str::FONT_SIZE,
         value_name = "UINT"
@@ -116,7 +116,7 @@ struct Opt {
     fontsize: usize,
 
     /// Font type
-    #[structopt(
+    #[clap(
         long = "fonttype",
         default_value = defaults::FONT_TYPE,
         value_name = "STRING"
@@ -124,7 +124,7 @@ struct Opt {
     fonttype: String,
 
     /// Font width
-    #[structopt(
+    #[clap(
         long = "fontwidth",
         default_value = &defaults::str::FONT_WIDTH,
         value_name = "FLOAT"
@@ -132,7 +132,7 @@ struct Opt {
     fontwidth: f64,
 
     /// Height of each frame
-    #[structopt(
+    #[clap(
         long = "height",
         default_value = &defaults::str::FRAME_HEIGHT,
         value_name = "UINT"
@@ -140,7 +140,7 @@ struct Opt {
     height: usize,
 
     /// Omit functions smaller than <FLOAT> percent
-    #[structopt(
+    #[clap(
         long = "minwidth",
         default_value = &defaults::str::MIN_WIDTH,
         value_name = "FLOAT"
@@ -151,11 +151,11 @@ struct Opt {
     /// Each line in the file should be a function name followed by a tab,
     /// then a sequence of tab separated name=value pairs
     #[cfg(feature = "nameattr")]
-    #[structopt(long = "nameattr", value_name = "PATH")]
+    #[clap(long = "nameattr", value_name = "PATH")]
     nameattr: Option<PathBuf>,
 
     /// Name type label
-    #[structopt(
+    #[clap(
         long = "nametype",
         default_value = defaults::NAME_TYPE,
         value_name = "STRING"
@@ -163,11 +163,11 @@ struct Opt {
     nametype: String,
 
     /// Set embedded notes in SVG
-    #[structopt(long = "notes", value_name = "STRING")]
+    #[clap(long = "notes", value_name = "STRING")]
     notes: Option<String>,
 
     /// Search color
-    #[structopt(
+    #[clap(
         long = "search-color",
         default_value = defaults::SEARCH_COLOR,
         value_name = "STRING"
@@ -175,11 +175,11 @@ struct Opt {
     search_color: SearchColor,
 
     /// Second level title (optional)
-    #[structopt(long = "subtitle", value_name = "STRING")]
+    #[clap(long = "subtitle", value_name = "STRING")]
     subtitle: Option<String>,
 
     /// Change title text
-    #[structopt(
+    #[clap(
         long = "title",
         default_value = defaults::TITLE,
         value_name = "STRING"
@@ -187,18 +187,18 @@ struct Opt {
     title: String,
 
     /// Width of image
-    #[structopt(long = "width", value_name = "UINT")]
+    #[clap(long = "width", value_name = "UINT")]
     width: Option<usize>,
 
     // ************ //
     // *** ARGS *** //
     // ************ //
     /// Collapsed perf output files. With no PATH, or PATH is -, read STDIN.
-    #[structopt(name = "PATH", parse(from_os_str))]
+    #[clap(name = "PATH", parse(from_os_str))]
     infiles: Vec<PathBuf>,
 
     /// Produce a flame chart (sort by time, do not merge stacks)
-    #[structopt(
+    #[clap(
         long = "flamechart",
         conflicts_with = "no-sort",
         conflicts_with = "reverse"
@@ -277,7 +277,7 @@ impl<'a> Opt {
 const PALETTE_MAP_FILE: &str = "palette.map"; // default name for the palette map file
 
 fn main() -> quick_xml::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Initialize logger
     if !opt.quiet {
@@ -342,16 +342,16 @@ fn save_consistent_palette_if_needed(
 #[cfg(test)]
 mod tests {
     use super::Opt;
+    use clap::Parser;
     use inferno::flamegraph::{color, Direction, Options, Palette, TextTruncateDirection};
     use pretty_assertions::assert_eq;
     use std::path::PathBuf;
     use std::str::FromStr;
-    use structopt::StructOpt;
 
     #[test]
     fn default_options() {
         let args = vec!["inferno-flamegraph", "test_infile"];
-        let opt = Opt::from_iter_safe(args).unwrap();
+        let opt = Opt::try_parse_from(args).unwrap();
         let (_infiles, options) = opt.into_parts();
         assert_eq!(options, Options::default());
     }
@@ -401,7 +401,7 @@ mod tests {
             "test_infile1",
             "test_infile2",
         ];
-        let opt = Opt::from_iter_safe(args).unwrap();
+        let opt = Opt::try_parse_from(args).unwrap();
         let (infiles, options) = opt.into_parts();
         let mut expected_options = Options::default();
         expected_options.colors = Palette::from_str("purple").unwrap();


### PR DESCRIPTION
Clap v3 has merged structopt directly into clap, and structopt itself is now in maintenance-only mode.

This PR switches all use of structopt over to clap's new `#[derive(Parser)]`.