### PR TITLE
Support multiple `--skip-after`

### DIFF
--- a/src/bin/collapse-perf.rs
+++ b/src/bin/collapse-perf.rs
@@ -82,10 +82,10 @@ struct Opt {
     infile: Option<PathBuf>,
 
     #[clap(long = "skip-after", value_name = "STRING")]
-    /// If set, will omit all the parent stack frames of the frame with matched function name.
+    /// If set, will omit all the parent stack frames of any frame with a matched function name.
     ///
-    /// Has no effect on the stack trace if no function is matched.
-    skip_after: Option<String>,
+    /// Has no effect on the stack trace if no functions are matched.
+    skip_after: Vec<String>,
 }
 
 impl Opt {

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -71,11 +71,11 @@ pub struct Options {
     /// Default is the number of logical cores on your machine.
     pub nthreads: usize,
 
-    /// If a stack function name is equal to the specified string it will omit all the
+    /// If a stack function name is equal to any of the specified strings it will omit all the
     /// following stackframes for that event.
     /// In case no function is matched the whole stack is returned.
-    /// Default is `None`.
-    pub skip_after: Option<String>,
+    /// Default is not omitting any.
+    pub skip_after: Vec<String>,
 }
 
 impl Default for Options {
@@ -88,7 +88,7 @@ impl Default for Options {
             include_pid: false,
             include_tid: false,
             nthreads: *common::DEFAULT_NTHREADS,
-            skip_after: None,
+            skip_after: Vec::default(),
         }
     }
 }
@@ -550,10 +550,13 @@ impl Folder {
                 self.stack.push_front(func);
             }
 
-            if let Some(skip_after) = &self.opt.skip_after {
-                if rawfunc == *skip_after {
-                    self.stack_filter = StackFilter::SkipRemaining;
-                }
+            if self
+                .opt
+                .skip_after
+                .iter()
+                .any(|skip_after| rawfunc == *skip_after)
+            {
+                self.stack_filter = StackFilter::SkipRemaining;
             }
         } else {
             logging::weird_stack_line(line);
@@ -793,7 +796,7 @@ mod tests {
         file.read_to_end(&mut bytes)?;
         let mut folder = {
             let options = Options {
-                skip_after: Some("main.init".to_string()),
+                skip_after: vec!["main.init".to_string()],
                 ..Default::default()
             };
             Folder::from(options)
@@ -848,7 +851,7 @@ mod tests {
                 include_pid: rng.gen(),
                 include_tid: rng.gen(),
                 nthreads: rng.gen_range(2..=32),
-                skip_after: None,
+                skip_after: Vec::default(),
             };
 
             for (path, input) in inputs.iter() {

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -809,7 +809,7 @@ mod tests {
         // go;[unknown];x_cgo_notify_runtime_init_done;runtime.main;main.init;...
         for line in lines {
             if line.contains("main.init") {
-                assert!(line.contains("main.init;")); // we removed the frames above "main.init"
+                assert!(line.starts_with("main.init;")); // we removed the frames above "main.init"
             }
         }
         Ok(())
@@ -833,14 +833,13 @@ mod tests {
         let lines = std::str::from_utf8(&buf_actual[..]).unwrap().lines();
 
         for line in lines {
-            // without `skip_after` some collapsed lines would look like:
-            // go;[unknown];x_cgo_notify_runtime_init_done;runtime.main;main.init;...
-            if line.contains("main.init") {
-                assert!(line.contains("main.init;")); // we removed the frames above "main.init"
-            }
-            // Collapse some other lines too, just to make sure it works.
             if line.contains("regexp.compile") {
-                assert!(line.contains("regexp.compile;")); // we removed the frames above "regexp.compile"
+                // Collapse some other lines too, just to make sure it works.
+                assert!(line.starts_with("regexp.compile;")); // we removed the frames above "regexp.compile"
+            } else if line.contains("main.init") {
+                // without `skip_after` some collapsed lines would look like:
+                // go;[unknown];x_cgo_notify_runtime_init_done;runtime.main;main.init;...
+                assert!(line.starts_with("main.init;")); // we removed the frames above "main.init"
             }
         }
         Ok(())


### PR DESCRIPTION
perf is stopping short on some of my backtraces (I think it's related to
complex C++ code in the stack), which fragments the relevant functions
in the flamegraph. `--skip-after` works great to avoid this, but I want
to do it for multiple functions.