### PR TITLE
Identified external dependencies with `js` color palette

### DIFF
--- a/src/flamegraph/color/palettes.rs
+++ b/src/flamegraph/color/palettes.rs
@@ -78,7 +78,9 @@ pub(super) mod js {
         } else if name.contains(':') {
             return BasicPalette::Aqua;
         } else if let Some(ai) = name.find('/') {
-            if (&name[ai..]).contains(".js") {
+            if (&name[ai..]).contains("node_modules/") {
+                return BasicPalette::Purple;
+            } else if (&name[ai..]).contains(".js") {
                 return BasicPalette::Green;
             }
         }
@@ -467,6 +469,10 @@ mod tests {
             TestData {
                 input: String::from("some/ai.js"),
                 output: BasicPalette::Green,
+            },
+            TestData {
+                input: String::from("project/node_modules/dep/index.js"),
+                output: BasicPalette::Purple,
             },
             TestData {
                 input: String::from("someai.js"),


### PR DESCRIPTION
- identifying external dependencies is useful because it enables you to
  differentiate between code in your project, and code that you import
  in
- this commit adds an if-statement to check for the `node_modules/`
  string, and colors it purple if found

---

Hey @jonhoo - ❤️ Inferno 🙂 

I've tested this locally with a tool I'm writing for NodeJS and it produces the following: 

<img width="1508" alt="CleanShot 2022-03-16 at 10 15 20@2x" src="https://user-images.githubusercontent.com/964245/158568499-bf171f1f-22ef-4fac-a067-037267c29248.png">
