### PR TITLE
Move from lazy_static to once_cell::Lazy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ dashmap = { version = "5", optional = true }
 env_logger = { version = "0.9", default-features = false, optional = true }
 indexmap = { version = "1.0", optional = true }
 itoa = "1"
-lazy_static = "1.3.0"
 log = "0.4"
 num_cpus = { version = "1.10", optional = true }
 num-format = { version = "0.4", default-features = false }
@@ -38,6 +37,7 @@ quick-xml = { version = "0.23", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 clap = { version = "3.0.1", optional = true, features = ["derive"] }
+once_cell = "1.12.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/benches/collapse.rs
+++ b/benches/collapse.rs
@@ -3,17 +3,15 @@ use std::io::{self, Read};
 
 use criterion::*;
 use inferno::collapse::{dtrace, perf, sample, Collapse};
-use lazy_static::lazy_static;
 use libflate::gzip::Decoder;
+use once_cell::sync::Lazy;
 
 const INFILE_DTRACE: &str = "flamegraph/example-dtrace-stacks.txt";
 const INFILE_PERF: &str = "flamegraph/example-perf-stacks.txt.gz";
 const INFILE_SAMPLE: &str = "tests/data/collapse-sample/large.txt.gz";
 const SAMPLE_SIZE: usize = 100;
 
-lazy_static! {
-    static ref NTHREADS: usize = num_cpus::get();
-}
+static NTHREADS: Lazy<usize> = Lazy::new(num_cpus::get);
 
 fn read_infile(infile: &str, buf: &mut Vec<u8>) -> io::Result<()> {
     let mut f = File::open(infile)?;

--- a/src/bin/collapse-dtrace.rs
+++ b/src/bin/collapse-dtrace.rs
@@ -5,11 +5,9 @@ use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::dtrace::{Folder, Options};
 use inferno::collapse::{Collapse, DEFAULT_NTHREADS};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    static ref NTHREADS: String = format!("{}", *DEFAULT_NTHREADS);
-}
+static NTHREADS: Lazy<String> = Lazy::new(|| format!("{}", *DEFAULT_NTHREADS));
 
 #[derive(Debug, Parser)]
 #[clap(

--- a/src/bin/collapse-guess.rs
+++ b/src/bin/collapse-guess.rs
@@ -5,11 +5,9 @@ use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::guess::{Folder, Options};
 use inferno::collapse::{Collapse, DEFAULT_NTHREADS};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    static ref NTHREADS: String = format!("{}", *DEFAULT_NTHREADS);
-}
+static NTHREADS: Lazy<String> = Lazy::new(|| format!("{}", *DEFAULT_NTHREADS));
 
 #[derive(Debug, Parser)]
 #[clap(

--- a/src/bin/collapse-perf.rs
+++ b/src/bin/collapse-perf.rs
@@ -5,11 +5,9 @@ use clap::Parser;
 use env_logger::Env;
 use inferno::collapse::perf::{Folder, Options};
 use inferno::collapse::{Collapse, DEFAULT_NTHREADS};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    static ref NTHREADS: String = format!("{}", *DEFAULT_NTHREADS);
-}
+static NTHREADS: Lazy<String> = Lazy::new(|| format!("{}", *DEFAULT_NTHREADS));
 
 #[derive(Debug, Parser)]
 #[clap(

--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use ahash::AHashMap;
 #[cfg(feature = "multithreaded")]
 use dashmap::DashMap;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 
 macro_rules! invalid_data_error {
     ($($arg:tt)*) => {{
@@ -39,16 +39,11 @@ const NBYTES_PER_STACK_GUESS: usize = 1024;
 const RUST_HASH_LENGTH: usize = 17;
 
 #[cfg(feature = "multithreaded")]
-lazy_static! {
-    #[doc(hidden)]
-    pub static ref DEFAULT_NTHREADS: usize = num_cpus::get();
-}
-
+#[doc(hidden)]
+pub static DEFAULT_NTHREADS: Lazy<usize> = Lazy::new(|| num_cpus::get());
 #[cfg(not(feature = "multithreaded"))]
-lazy_static! {
-    #[doc(hidden)]
-    pub static ref DEFAULT_NTHREADS: usize = 1;
-}
+#[doc(hidden)]
+pub static DEFAULT_NTHREADS: Lazy<usize> = Lazy::new(|| 1);
 
 /// Private trait for internal library authors.
 ///

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -406,7 +406,7 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
     use rand::prelude::*;
 
@@ -414,21 +414,19 @@ mod tests {
     use crate::collapse::common;
     use crate::collapse::Collapse;
 
-    lazy_static! {
-        static ref INPUT: Vec<PathBuf> = {
-            [
-                "./flamegraph/example-dtrace-stacks.txt",
-                "./tests/data/collapse-dtrace/flamegraph-bug.txt",
-                "./tests/data/collapse-dtrace/hex-addresses.txt",
-                "./tests/data/collapse-dtrace/java.txt",
-                "./tests/data/collapse-dtrace/only-header-lines.txt",
-                "./tests/data/collapse-dtrace/scope_with_no_argument_list.txt",
-            ]
-            .iter()
-            .map(PathBuf::from)
-            .collect::<Vec<_>>()
-        };
-    }
+    static INPUT: Lazy<Vec<PathBuf>> = Lazy::new(|| {
+        [
+            "./flamegraph/example-dtrace-stacks.txt",
+            "./tests/data/collapse-dtrace/flamegraph-bug.txt",
+            "./tests/data/collapse-dtrace/hex-addresses.txt",
+            "./tests/data/collapse-dtrace/java.txt",
+            "./tests/data/collapse-dtrace/only-header-lines.txt",
+            "./tests/data/collapse-dtrace/scope_with_no_argument_list.txt",
+        ]
+        .iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>()
+    });
 
     #[test]
     fn cpp_test() {

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -703,7 +703,7 @@ mod tests {
     use std::io::Read;
     use std::path::PathBuf;
 
-    use lazy_static::lazy_static;
+    use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
     use rand::prelude::*;
 
@@ -743,34 +743,32 @@ mod tests {
         }
     }
 
-    lazy_static! {
-        static ref INPUT: Vec<PathBuf> = {
-            [
-                "./flamegraph/example-perf-stacks.txt.gz",
-                "./flamegraph/test/perf-cycles-instructions-01.txt",
-                "./flamegraph/test/perf-dd-stacks-01.txt",
-                "./flamegraph/test/perf-funcab-cmd-01.txt",
-                "./flamegraph/test/perf-funcab-pid-01.txt",
-                "./flamegraph/test/perf-iperf-stacks-pidtid-01.txt",
-                "./flamegraph/test/perf-java-faults-01.txt",
-                "./flamegraph/test/perf-java-stacks-01.txt",
-                "./flamegraph/test/perf-java-stacks-02.txt",
-                "./flamegraph/test/perf-js-stacks-01.txt",
-                "./flamegraph/test/perf-mirageos-stacks-01.txt",
-                "./flamegraph/test/perf-numa-stacks-01.txt",
-                "./flamegraph/test/perf-rust-Yamakaky-dcpu.txt",
-                "./flamegraph/test/perf-vertx-stacks-01.txt",
-                "./tests/data/collapse-perf/empty-line.txt",
-                "./tests/data/collapse-perf/go-stacks.txt",
-                "./tests/data/collapse-perf/java-inline.txt",
-                "./tests/data/collapse-perf/weird-stack-line.txt",
-                "./tests/data/collapse-perf/cpp-stacks-std-function.txt",
-            ]
-            .iter()
-            .map(PathBuf::from)
-            .collect::<Vec<_>>()
-        };
-    }
+    static INPUT: Lazy<Vec<PathBuf>> = Lazy::new(|| {
+        [
+            "./flamegraph/example-perf-stacks.txt.gz",
+            "./flamegraph/test/perf-cycles-instructions-01.txt",
+            "./flamegraph/test/perf-dd-stacks-01.txt",
+            "./flamegraph/test/perf-funcab-cmd-01.txt",
+            "./flamegraph/test/perf-funcab-pid-01.txt",
+            "./flamegraph/test/perf-iperf-stacks-pidtid-01.txt",
+            "./flamegraph/test/perf-java-faults-01.txt",
+            "./flamegraph/test/perf-java-stacks-01.txt",
+            "./flamegraph/test/perf-java-stacks-02.txt",
+            "./flamegraph/test/perf-js-stacks-01.txt",
+            "./flamegraph/test/perf-mirageos-stacks-01.txt",
+            "./flamegraph/test/perf-numa-stacks-01.txt",
+            "./flamegraph/test/perf-rust-Yamakaky-dcpu.txt",
+            "./flamegraph/test/perf-vertx-stacks-01.txt",
+            "./tests/data/collapse-perf/empty-line.txt",
+            "./tests/data/collapse-perf/go-stacks.txt",
+            "./tests/data/collapse-perf/java-inline.txt",
+            "./tests/data/collapse-perf/weird-stack-line.txt",
+            "./tests/data/collapse-perf/cpp-stacks-std-function.txt",
+        ]
+        .iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>()
+    });
 
     #[test]
     fn test_collapse_multi_perf() -> io::Result<()> {

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -62,13 +62,12 @@ pub mod defaults {
                 );
             )*
 
+
             #[doc(hidden)]
             pub mod str {
-                use lazy_static::lazy_static;
+            use once_cell::sync::Lazy;
             $(
-                lazy_static! {
-                    pub static ref $name: String = ($val).to_string();
-                }
+                    pub static $name: Lazy<String> = Lazy::new(|| ($val).to_string());
             )*
             }
         }


### PR DESCRIPTION
`lazy_static` is only passively maintained. Also, `once_cell` is faster (1-5% across `cargo bench`).