### PR TITLE
Don't quote generic font families in CSS

### DIFF
--- a/tests/data/flamegraph/options/font_type_cursive.svg
+++ b/tests/data/flamegraph/options/font_type_cursive.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="246" onload="init(evt)" viewBox="0 0 1200 246" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:cursive; font-size:12px; fill:rgb(0,0,0); }
+#title { text-anchor:middle; font-size:17px; }
+#search { opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]></script>
+    <rect x="0" y="0" width="100%" height="246" fill="url(#background)"/>
+    <text id="title" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" x="10" y="229.00"> </text>
+    <text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" x="1090" y="24.00">Search</text>
+    <text id="matched" x="1090" y="229.00"> </text>
+    <svg id="frames" x="10" width="1180" total_samples="513">
+        <g>
+            <title>_start (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="165" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="175.50">_start</text>
+        </g>
+        <g>
+            <title>__libc_start_main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="149" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="159.50">__libc_start_main</text>
+        </g>
+        <g>
+            <title>main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="133" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="143.50">main</text>
+        </g>
+        <g>
+            <title>cksum (56 samples, 10.92%; +4.87%)</title>
+            <rect x="0.0000%" y="117" width="10.9162%" height="15" fill="rgb(255,223,223)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="127.50">cksum</text>
+        </g>
+        <g>
+            <title>cksum (5 samples, 0.97%; -0.78%)</title>
+            <rect x="10.9162%" y="165" width="0.9747%" height="15" fill="rgb(245,245,255)" fg:x="56" fg:w="5"/>
+            <text x="11.1662%" y="175.50"></text>
+        </g>
+        <g>
+            <title>__GI___fread_unlocked (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="149" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="159.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_xsgetn (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="133" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="143.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="117" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="127.50"></text>
+        </g>
+        <g>
+            <title>entry_SYSCALL_64_fastpath (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="101" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="111.50"></text>
+        </g>
+        <g>
+            <title>sys_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="85" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="95.50"></text>
+        </g>
+        <g>
+            <title>vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="69" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="79.50"></text>
+        </g>
+        <g>
+            <title>__vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="53" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="63.50"></text>
+        </g>
+        <g>
+            <title>ext4_file_read_iter (3 samples, 0.58%; +0.39%)</title>
+            <rect x="11.3060%" y="37" width="0.5848%" height="15" fill="rgb(255,247,247)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="47.50"></text>
+        </g>
+        <g>
+            <title>cksum (96 samples, 18.71%; 0.00%)</title>
+            <rect x="0.0000%" y="181" width="18.7135%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="96"/>
+            <text x="0.2500%" y="191.50">cksum</text>
+        </g>
+        <g>
+            <title>main (35 samples, 6.82%; 0.00%)</title>
+            <rect x="11.8908%" y="165" width="6.8226%" height="15" fill="rgb(250,250,250)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="175.50">main</text>
+        </g>
+        <g>
+            <title>cksum (35 samples, 6.82%; +3.12%)</title>
+            <rect x="11.8908%" y="149" width="6.8226%" height="15" fill="rgb(255,232,232)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="159.50">cksum</text>
+        </g>
+        <g>
+            <title>[unknown] (2 samples, 0.39%; 0.00%)</title>
+            <rect x="18.7135%" y="165" width="0.3899%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="2"/>
+            <text x="18.9635%" y="175.50"></text>
+        </g>
+        <g>
+            <title>all (513 samples, 100%)</title>
+            <rect x="0.0000%" y="197" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="513"/>
+            <text x="0.2500%" y="207.50"></text>
+        </g>
+        <g>
+            <title>noploop (417 samples, 81.29%; 0.00%)</title>
+            <rect x="18.7135%" y="181" width="81.2865%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="417"/>
+            <text x="18.9635%" y="191.50">noploop</text>
+        </g>
+        <g>
+            <title>main (415 samples, 80.90%; +27.49%)</title>
+            <rect x="19.1033%" y="165" width="80.8967%" height="15" fill="rgb(255,100,100)" fg:x="98" fg:w="415"/>
+            <text x="19.3533%" y="175.50">main</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/data/flamegraph/options/font_type_fantasy.svg
+++ b/tests/data/flamegraph/options/font_type_fantasy.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="246" onload="init(evt)" viewBox="0 0 1200 246" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:fantasy; font-size:12px; fill:rgb(0,0,0); }
+#title { text-anchor:middle; font-size:17px; }
+#search { opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]></script>
+    <rect x="0" y="0" width="100%" height="246" fill="url(#background)"/>
+    <text id="title" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" x="10" y="229.00"> </text>
+    <text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" x="1090" y="24.00">Search</text>
+    <text id="matched" x="1090" y="229.00"> </text>
+    <svg id="frames" x="10" width="1180" total_samples="513">
+        <g>
+            <title>_start (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="165" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="175.50">_start</text>
+        </g>
+        <g>
+            <title>__libc_start_main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="149" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="159.50">__libc_start_main</text>
+        </g>
+        <g>
+            <title>main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="133" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="143.50">main</text>
+        </g>
+        <g>
+            <title>cksum (56 samples, 10.92%; +4.87%)</title>
+            <rect x="0.0000%" y="117" width="10.9162%" height="15" fill="rgb(255,223,223)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="127.50">cksum</text>
+        </g>
+        <g>
+            <title>cksum (5 samples, 0.97%; -0.78%)</title>
+            <rect x="10.9162%" y="165" width="0.9747%" height="15" fill="rgb(245,245,255)" fg:x="56" fg:w="5"/>
+            <text x="11.1662%" y="175.50"></text>
+        </g>
+        <g>
+            <title>__GI___fread_unlocked (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="149" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="159.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_xsgetn (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="133" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="143.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="117" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="127.50"></text>
+        </g>
+        <g>
+            <title>entry_SYSCALL_64_fastpath (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="101" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="111.50"></text>
+        </g>
+        <g>
+            <title>sys_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="85" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="95.50"></text>
+        </g>
+        <g>
+            <title>vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="69" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="79.50"></text>
+        </g>
+        <g>
+            <title>__vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="53" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="63.50"></text>
+        </g>
+        <g>
+            <title>ext4_file_read_iter (3 samples, 0.58%; +0.39%)</title>
+            <rect x="11.3060%" y="37" width="0.5848%" height="15" fill="rgb(255,247,247)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="47.50"></text>
+        </g>
+        <g>
+            <title>cksum (96 samples, 18.71%; 0.00%)</title>
+            <rect x="0.0000%" y="181" width="18.7135%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="96"/>
+            <text x="0.2500%" y="191.50">cksum</text>
+        </g>
+        <g>
+            <title>main (35 samples, 6.82%; 0.00%)</title>
+            <rect x="11.8908%" y="165" width="6.8226%" height="15" fill="rgb(250,250,250)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="175.50">main</text>
+        </g>
+        <g>
+            <title>cksum (35 samples, 6.82%; +3.12%)</title>
+            <rect x="11.8908%" y="149" width="6.8226%" height="15" fill="rgb(255,232,232)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="159.50">cksum</text>
+        </g>
+        <g>
+            <title>[unknown] (2 samples, 0.39%; 0.00%)</title>
+            <rect x="18.7135%" y="165" width="0.3899%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="2"/>
+            <text x="18.9635%" y="175.50"></text>
+        </g>
+        <g>
+            <title>all (513 samples, 100%)</title>
+            <rect x="0.0000%" y="197" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="513"/>
+            <text x="0.2500%" y="207.50"></text>
+        </g>
+        <g>
+            <title>noploop (417 samples, 81.29%; 0.00%)</title>
+            <rect x="18.7135%" y="181" width="81.2865%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="417"/>
+            <text x="18.9635%" y="191.50">noploop</text>
+        </g>
+        <g>
+            <title>main (415 samples, 80.90%; +27.49%)</title>
+            <rect x="19.1033%" y="165" width="80.8967%" height="15" fill="rgb(255,100,100)" fg:x="98" fg:w="415"/>
+            <text x="19.3533%" y="175.50">main</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/data/flamegraph/options/font_type_monospace.svg
+++ b/tests/data/flamegraph/options/font_type_monospace.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="246" onload="init(evt)" viewBox="0 0 1200 246" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:monospace; font-size:12px; fill:rgb(0,0,0); }
+#title { text-anchor:middle; font-size:17px; }
+#search { opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]></script>
+    <rect x="0" y="0" width="100%" height="246" fill="url(#background)"/>
+    <text id="title" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" x="10" y="229.00"> </text>
+    <text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" x="1090" y="24.00">Search</text>
+    <text id="matched" x="1090" y="229.00"> </text>
+    <svg id="frames" x="10" width="1180" total_samples="513">
+        <g>
+            <title>_start (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="165" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="175.50">_start</text>
+        </g>
+        <g>
+            <title>__libc_start_main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="149" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="159.50">__libc_start_main</text>
+        </g>
+        <g>
+            <title>main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="133" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="143.50">main</text>
+        </g>
+        <g>
+            <title>cksum (56 samples, 10.92%; +4.87%)</title>
+            <rect x="0.0000%" y="117" width="10.9162%" height="15" fill="rgb(255,223,223)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="127.50">cksum</text>
+        </g>
+        <g>
+            <title>cksum (5 samples, 0.97%; -0.78%)</title>
+            <rect x="10.9162%" y="165" width="0.9747%" height="15" fill="rgb(245,245,255)" fg:x="56" fg:w="5"/>
+            <text x="11.1662%" y="175.50"></text>
+        </g>
+        <g>
+            <title>__GI___fread_unlocked (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="149" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="159.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_xsgetn (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="133" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="143.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="117" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="127.50"></text>
+        </g>
+        <g>
+            <title>entry_SYSCALL_64_fastpath (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="101" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="111.50"></text>
+        </g>
+        <g>
+            <title>sys_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="85" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="95.50"></text>
+        </g>
+        <g>
+            <title>vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="69" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="79.50"></text>
+        </g>
+        <g>
+            <title>__vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="53" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="63.50"></text>
+        </g>
+        <g>
+            <title>ext4_file_read_iter (3 samples, 0.58%; +0.39%)</title>
+            <rect x="11.3060%" y="37" width="0.5848%" height="15" fill="rgb(255,247,247)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="47.50"></text>
+        </g>
+        <g>
+            <title>cksum (96 samples, 18.71%; 0.00%)</title>
+            <rect x="0.0000%" y="181" width="18.7135%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="96"/>
+            <text x="0.2500%" y="191.50">cksum</text>
+        </g>
+        <g>
+            <title>main (35 samples, 6.82%; 0.00%)</title>
+            <rect x="11.8908%" y="165" width="6.8226%" height="15" fill="rgb(250,250,250)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="175.50">main</text>
+        </g>
+        <g>
+            <title>cksum (35 samples, 6.82%; +3.12%)</title>
+            <rect x="11.8908%" y="149" width="6.8226%" height="15" fill="rgb(255,232,232)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="159.50">cksum</text>
+        </g>
+        <g>
+            <title>[unknown] (2 samples, 0.39%; 0.00%)</title>
+            <rect x="18.7135%" y="165" width="0.3899%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="2"/>
+            <text x="18.9635%" y="175.50"></text>
+        </g>
+        <g>
+            <title>all (513 samples, 100%)</title>
+            <rect x="0.0000%" y="197" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="513"/>
+            <text x="0.2500%" y="207.50"></text>
+        </g>
+        <g>
+            <title>noploop (417 samples, 81.29%; 0.00%)</title>
+            <rect x="18.7135%" y="181" width="81.2865%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="417"/>
+            <text x="18.9635%" y="191.50">noploop</text>
+        </g>
+        <g>
+            <title>main (415 samples, 80.90%; +27.49%)</title>
+            <rect x="19.1033%" y="165" width="80.8967%" height="15" fill="rgb(255,100,100)" fg:x="98" fg:w="415"/>
+            <text x="19.3533%" y="175.50">main</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/data/flamegraph/options/font_type_sans-serif.svg
+++ b/tests/data/flamegraph/options/font_type_sans-serif.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="246" onload="init(evt)" viewBox="0 0 1200 246" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:sans-serif; font-size:12px; fill:rgb(0,0,0); }
+#title { text-anchor:middle; font-size:17px; }
+#search { opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]></script>
+    <rect x="0" y="0" width="100%" height="246" fill="url(#background)"/>
+    <text id="title" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" x="10" y="229.00"> </text>
+    <text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" x="1090" y="24.00">Search</text>
+    <text id="matched" x="1090" y="229.00"> </text>
+    <svg id="frames" x="10" width="1180" total_samples="513">
+        <g>
+            <title>_start (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="165" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="175.50">_start</text>
+        </g>
+        <g>
+            <title>__libc_start_main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="149" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="159.50">__libc_start_main</text>
+        </g>
+        <g>
+            <title>main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="133" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="143.50">main</text>
+        </g>
+        <g>
+            <title>cksum (56 samples, 10.92%; +4.87%)</title>
+            <rect x="0.0000%" y="117" width="10.9162%" height="15" fill="rgb(255,223,223)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="127.50">cksum</text>
+        </g>
+        <g>
+            <title>cksum (5 samples, 0.97%; -0.78%)</title>
+            <rect x="10.9162%" y="165" width="0.9747%" height="15" fill="rgb(245,245,255)" fg:x="56" fg:w="5"/>
+            <text x="11.1662%" y="175.50"></text>
+        </g>
+        <g>
+            <title>__GI___fread_unlocked (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="149" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="159.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_xsgetn (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="133" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="143.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="117" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="127.50"></text>
+        </g>
+        <g>
+            <title>entry_SYSCALL_64_fastpath (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="101" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="111.50"></text>
+        </g>
+        <g>
+            <title>sys_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="85" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="95.50"></text>
+        </g>
+        <g>
+            <title>vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="69" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="79.50"></text>
+        </g>
+        <g>
+            <title>__vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="53" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="63.50"></text>
+        </g>
+        <g>
+            <title>ext4_file_read_iter (3 samples, 0.58%; +0.39%)</title>
+            <rect x="11.3060%" y="37" width="0.5848%" height="15" fill="rgb(255,247,247)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="47.50"></text>
+        </g>
+        <g>
+            <title>cksum (96 samples, 18.71%; 0.00%)</title>
+            <rect x="0.0000%" y="181" width="18.7135%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="96"/>
+            <text x="0.2500%" y="191.50">cksum</text>
+        </g>
+        <g>
+            <title>main (35 samples, 6.82%; 0.00%)</title>
+            <rect x="11.8908%" y="165" width="6.8226%" height="15" fill="rgb(250,250,250)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="175.50">main</text>
+        </g>
+        <g>
+            <title>cksum (35 samples, 6.82%; +3.12%)</title>
+            <rect x="11.8908%" y="149" width="6.8226%" height="15" fill="rgb(255,232,232)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="159.50">cksum</text>
+        </g>
+        <g>
+            <title>[unknown] (2 samples, 0.39%; 0.00%)</title>
+            <rect x="18.7135%" y="165" width="0.3899%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="2"/>
+            <text x="18.9635%" y="175.50"></text>
+        </g>
+        <g>
+            <title>all (513 samples, 100%)</title>
+            <rect x="0.0000%" y="197" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="513"/>
+            <text x="0.2500%" y="207.50"></text>
+        </g>
+        <g>
+            <title>noploop (417 samples, 81.29%; 0.00%)</title>
+            <rect x="18.7135%" y="181" width="81.2865%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="417"/>
+            <text x="18.9635%" y="191.50">noploop</text>
+        </g>
+        <g>
+            <title>main (415 samples, 80.90%; +27.49%)</title>
+            <rect x="19.1033%" y="165" width="80.8967%" height="15" fill="rgb(255,100,100)" fg:x="98" fg:w="415"/>
+            <text x="19.3533%" y="175.50">main</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/data/flamegraph/options/font_type_serif.svg
+++ b/tests/data/flamegraph/options/font_type_serif.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="246" onload="init(evt)" viewBox="0 0 1200 246" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:serif; font-size:12px; fill:rgb(0,0,0); }
+#title { text-anchor:middle; font-size:17px; }
+#search { opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]></script>
+    <rect x="0" y="0" width="100%" height="246" fill="url(#background)"/>
+    <text id="title" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" x="10" y="229.00"> </text>
+    <text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" x="1090" y="24.00">Search</text>
+    <text id="matched" x="1090" y="229.00"> </text>
+    <svg id="frames" x="10" width="1180" total_samples="513">
+        <g>
+            <title>_start (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="165" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="175.50">_start</text>
+        </g>
+        <g>
+            <title>__libc_start_main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="149" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="159.50">__libc_start_main</text>
+        </g>
+        <g>
+            <title>main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="133" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="143.50">main</text>
+        </g>
+        <g>
+            <title>cksum (56 samples, 10.92%; +4.87%)</title>
+            <rect x="0.0000%" y="117" width="10.9162%" height="15" fill="rgb(255,223,223)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="127.50">cksum</text>
+        </g>
+        <g>
+            <title>cksum (5 samples, 0.97%; -0.78%)</title>
+            <rect x="10.9162%" y="165" width="0.9747%" height="15" fill="rgb(245,245,255)" fg:x="56" fg:w="5"/>
+            <text x="11.1662%" y="175.50"></text>
+        </g>
+        <g>
+            <title>__GI___fread_unlocked (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="149" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="159.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_xsgetn (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="133" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="143.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="117" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="127.50"></text>
+        </g>
+        <g>
+            <title>entry_SYSCALL_64_fastpath (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="101" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="111.50"></text>
+        </g>
+        <g>
+            <title>sys_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="85" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="95.50"></text>
+        </g>
+        <g>
+            <title>vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="69" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="79.50"></text>
+        </g>
+        <g>
+            <title>__vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="53" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="63.50"></text>
+        </g>
+        <g>
+            <title>ext4_file_read_iter (3 samples, 0.58%; +0.39%)</title>
+            <rect x="11.3060%" y="37" width="0.5848%" height="15" fill="rgb(255,247,247)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="47.50"></text>
+        </g>
+        <g>
+            <title>cksum (96 samples, 18.71%; 0.00%)</title>
+            <rect x="0.0000%" y="181" width="18.7135%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="96"/>
+            <text x="0.2500%" y="191.50">cksum</text>
+        </g>
+        <g>
+            <title>main (35 samples, 6.82%; 0.00%)</title>
+            <rect x="11.8908%" y="165" width="6.8226%" height="15" fill="rgb(250,250,250)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="175.50">main</text>
+        </g>
+        <g>
+            <title>cksum (35 samples, 6.82%; +3.12%)</title>
+            <rect x="11.8908%" y="149" width="6.8226%" height="15" fill="rgb(255,232,232)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="159.50">cksum</text>
+        </g>
+        <g>
+            <title>[unknown] (2 samples, 0.39%; 0.00%)</title>
+            <rect x="18.7135%" y="165" width="0.3899%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="2"/>
+            <text x="18.9635%" y="175.50"></text>
+        </g>
+        <g>
+            <title>all (513 samples, 100%)</title>
+            <rect x="0.0000%" y="197" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="513"/>
+            <text x="0.2500%" y="207.50"></text>
+        </g>
+        <g>
+            <title>noploop (417 samples, 81.29%; 0.00%)</title>
+            <rect x="18.7135%" y="181" width="81.2865%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="417"/>
+            <text x="18.9635%" y="191.50">noploop</text>
+        </g>
+        <g>
+            <title>main (415 samples, 80.90%; +27.49%)</title>
+            <rect x="19.1033%" y="165" width="80.8967%" height="15" fill="rgb(255,100,100)" fg:x="98" fg:w="415"/>
+            <text x="19.3533%" y="175.50">main</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -682,6 +682,23 @@ fn flamegraph_font_type_with_quote() {
 }
 
 #[test]
+fn flamegraph_font_type_generic_families() {
+    let input_file =
+        "./tests/data/flamegraph/differential/perf-cycles-instructions-01-collapsed-all-diff.txt";
+
+    let generic_families = &["cursive", "fantasy", "monospace", "serif", "sans-serif"];
+    for family in generic_families {
+        let expected_result_file =
+            format!("./tests/data/flamegraph/options/font_type_{}.svg", family);
+
+        let mut options = flamegraph::Options::default();
+        options.font_type = family.to_string();
+
+        test_flamegraph(input_file, &expected_result_file, options).unwrap();
+    }
+}
+
+#[test]
 fn search_color_non_default() {
     let input_file =
         "./tests/data/flamegraph/differential/perf-cycles-instructions-01-collapsed-all-diff.txt";


### PR DESCRIPTION
Fixes #244 

When passing a font type to use for the generated flamegraph,
if it is one of the following we shouldn't put quotes around it:

* cursive
* fantasy
* monospace
* serif
* sans-serif