### PR TITLE
Add frame stroke option

### DIFF
--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use env_logger::Env;
-use inferno::flamegraph::color::{BackgroundColor, PaletteMap, SearchColor};
+use inferno::flamegraph::color::{BackgroundColor, PaletteMap, SearchColor, StrokeColor};
 use inferno::flamegraph::{self, defaults, Direction, Options, Palette, TextTruncateDirection};
 
 #[cfg(feature = "nameattr")]
@@ -174,6 +174,14 @@ struct Opt {
     )]
     search_color: SearchColor,
 
+    /// Adds an outline to every frame
+    #[clap(
+        long = "stroke-color",
+        default_value = defaults::STROKE_COLOR,
+        value_name = "STRING"
+    )]
+    stroke_color: StrokeColor,
+
     /// Second level title (optional)
     #[clap(long = "subtitle", value_name = "STRING")]
     subtitle: Option<String>,
@@ -255,6 +263,7 @@ impl<'a> Opt {
         options.negate_differentials = self.negate;
         options.factor = self.factor;
         options.search_color = self.search_color;
+        options.stroke_color = self.stroke_color;
         (self.infiles, options)
     }
 

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -186,6 +186,28 @@ impl fmt::Display for SearchColor {
     }
 }
 
+/// `StrokeColor::default()` is `None`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StrokeColor {
+    /// Color of the stroke
+    Color(Color),
+    /// No color for the stroke
+    None,
+}
+
+impl FromStr for StrokeColor {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "none" {
+            return Ok(StrokeColor::None);
+        }
+        parse_flat_bgcolor(s)
+            .map(|c| StrokeColor::Color(c))
+            .ok_or_else(|| format!("unknown color: {}", s))
+    }
+}
+
 impl FromStr for Palette {
     type Err = String;
 

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -32,7 +32,7 @@ use self::attrs::FrameAttrs;
 pub use self::attrs::FuncFrameAttrsMap;
 
 pub use self::color::Palette;
-use self::color::{Color, SearchColor};
+use self::color::{Color, SearchColor, StrokeColor};
 use self::svg::{Dimension, StyleOptions};
 
 const XPAD: usize = 10; // pad left and right
@@ -76,6 +76,7 @@ pub mod defaults {
     define! {
         COLORS: &str = "hot",
         SEARCH_COLOR: &str = "#e600e6",
+        STROKE_COLOR: &str = "none",
         TITLE: &str = "Flame Graph",
         CHART_TITLE: &str = "Flame Chart",
         FRAME_HEIGHT: usize = 16,
@@ -136,6 +137,11 @@ pub struct Options<'a> {
     ///
     /// [Default value](defaults::SEARCH_COLOR).
     pub search_color: SearchColor,
+
+    /// The stroke color for flame graph.
+    ///
+    /// [Default value](defaults::STROKE_COLOR).
+    pub stroke_color: StrokeColor,
 
     /// The title for the flame graph.
     ///
@@ -285,6 +291,7 @@ impl<'a> Default for Options<'a> {
         Options {
             colors: Palette::from_str(defaults::COLORS).unwrap(),
             search_color: SearchColor::from_str(defaults::SEARCH_COLOR).unwrap(),
+            stroke_color: StrokeColor::from_str(defaults::STROKE_COLOR).unwrap(),
             title: defaults::TITLE.to_string(),
             frame_height: defaults::FRAME_HEIGHT,
             min_width: defaults::MIN_WIDTH,
@@ -500,10 +507,15 @@ where
     svg::write_header(&mut svg, imageheight, opt)?;
 
     let (bgcolor1, bgcolor2) = color::bgcolor_for(opt.bgcolors, opt.colors);
+    let strokecolor = match opt.stroke_color {
+        StrokeColor::Color(c) => Some(c.to_string()),
+        StrokeColor::None => None,
+    };
     let style_options = StyleOptions {
         imageheight,
         bgcolor1,
         bgcolor2,
+        strokecolor,
     };
 
     svg::write_prelude(&mut svg, &style_options, opt)?;

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -51,6 +51,7 @@ pub(super) struct StyleOptions<'a> {
     pub(super) imageheight: usize,
     pub(super) bgcolor1: Cow<'a, str>,
     pub(super) bgcolor2: Cow<'a, str>,
+    pub(super) strokecolor: Option<String>,
 }
 
 pub fn write_header<W>(
@@ -130,11 +131,17 @@ where
         "
 text {{ font-family:{}; font-size:{}px; fill:rgb(0,0,0); }}
 #title {{ text-anchor:middle; font-size:{}px; }}
-{}",
-        font_type,
-        &opt.font_size,
-        titlesize,
-        include_str!("flamegraph.css")
+",
+        font_type, &opt.font_size, titlesize,
+    ))))?;
+    if let Some(strokecolor) = &style_options.strokecolor {
+        svg.write_event(Event::Text(BytesText::from_escaped_str(&format!(
+            "#frames > g > rect {{ stroke:{}; stroke-width:1; }}\n",
+            strokecolor
+        ))))?;
+    }
+    svg.write_event(Event::Text(BytesText::from_escaped_str(include_str!(
+        "flamegraph.css"
     ))))?;
     svg.write_event(Event::End(BytesEnd::borrowed(b"style")))?;
 

--- a/tests/data/flamegraph/options/stroke_color.svg
+++ b/tests/data/flamegraph/options/stroke_color.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="246" onload="init(evt)" viewBox="0 0 1200 246" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:"Verdana"; font-size:12px; fill:rgb(0,0,0); }
+#title { text-anchor:middle; font-size:17px; }
+#frames > g > rect { stroke:rgb(125,125,125); stroke-width:1; }
+#search { opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]></script>
+    <rect x="0" y="0" width="100%" height="246" fill="url(#background)"/>
+    <text id="title" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" x="10" y="229.00"> </text>
+    <text id="unzoom" class="hide" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" x="1090" y="24.00">Search</text>
+    <text id="matched" x="1090" y="229.00"> </text>
+    <svg id="frames" x="10" width="1180" total_samples="513">
+        <g>
+            <title>_start (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="165" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="175.50">_start</text>
+        </g>
+        <g>
+            <title>__libc_start_main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="149" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="159.50">__libc_start_main</text>
+        </g>
+        <g>
+            <title>main (56 samples, 10.92%; 0.00%)</title>
+            <rect x="0.0000%" y="133" width="10.9162%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="143.50">main</text>
+        </g>
+        <g>
+            <title>cksum (56 samples, 10.92%; +4.87%)</title>
+            <rect x="0.0000%" y="117" width="10.9162%" height="15" fill="rgb(255,223,223)" fg:x="0" fg:w="56"/>
+            <text x="0.2500%" y="127.50">cksum</text>
+        </g>
+        <g>
+            <title>cksum (5 samples, 0.97%; -0.78%)</title>
+            <rect x="10.9162%" y="165" width="0.9747%" height="15" fill="rgb(245,245,255)" fg:x="56" fg:w="5"/>
+            <text x="11.1662%" y="175.50"></text>
+        </g>
+        <g>
+            <title>__GI___fread_unlocked (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="149" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="159.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_xsgetn (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="133" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="143.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="117" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="127.50"></text>
+        </g>
+        <g>
+            <title>entry_SYSCALL_64_fastpath (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="101" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="111.50"></text>
+        </g>
+        <g>
+            <title>sys_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="85" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="95.50"></text>
+        </g>
+        <g>
+            <title>vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="69" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="79.50"></text>
+        </g>
+        <g>
+            <title>__vfs_read (3 samples, 0.58%; 0.00%)</title>
+            <rect x="11.3060%" y="53" width="0.5848%" height="15" fill="rgb(250,250,250)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="63.50"></text>
+        </g>
+        <g>
+            <title>ext4_file_read_iter (3 samples, 0.58%; +0.39%)</title>
+            <rect x="11.3060%" y="37" width="0.5848%" height="15" fill="rgb(255,247,247)" fg:x="58" fg:w="3"/>
+            <text x="11.5560%" y="47.50"></text>
+        </g>
+        <g>
+            <title>cksum (96 samples, 18.71%; 0.00%)</title>
+            <rect x="0.0000%" y="181" width="18.7135%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="96"/>
+            <text x="0.2500%" y="191.50">cksum</text>
+        </g>
+        <g>
+            <title>main (35 samples, 6.82%; 0.00%)</title>
+            <rect x="11.8908%" y="165" width="6.8226%" height="15" fill="rgb(250,250,250)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="175.50">main</text>
+        </g>
+        <g>
+            <title>cksum (35 samples, 6.82%; +3.12%)</title>
+            <rect x="11.8908%" y="149" width="6.8226%" height="15" fill="rgb(255,232,232)" fg:x="61" fg:w="35"/>
+            <text x="12.1408%" y="159.50">cksum</text>
+        </g>
+        <g>
+            <title>[unknown] (2 samples, 0.39%; 0.00%)</title>
+            <rect x="18.7135%" y="165" width="0.3899%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="2"/>
+            <text x="18.9635%" y="175.50"></text>
+        </g>
+        <g>
+            <title>all (513 samples, 100%)</title>
+            <rect x="0.0000%" y="197" width="100.0000%" height="15" fill="rgb(250,250,250)" fg:x="0" fg:w="513"/>
+            <text x="0.2500%" y="207.50"></text>
+        </g>
+        <g>
+            <title>noploop (417 samples, 81.29%; 0.00%)</title>
+            <rect x="18.7135%" y="181" width="81.2865%" height="15" fill="rgb(250,250,250)" fg:x="96" fg:w="417"/>
+            <text x="18.9635%" y="191.50">noploop</text>
+        </g>
+        <g>
+            <title>main (415 samples, 80.90%; +27.49%)</title>
+            <rect x="19.1033%" y="165" width="80.8967%" height="15" fill="rgb(255,100,100)" fg:x="98" fg:w="415"/>
+            <text x="19.3533%" y="175.50">main</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -711,6 +711,18 @@ fn search_color_non_default() {
 }
 
 #[test]
+fn stroke_color_non_default() {
+    let input_file =
+        "./tests/data/flamegraph/differential/perf-cycles-instructions-01-collapsed-all-diff.txt";
+    let expected_result_file = "./tests/data/flamegraph/options/stroke_color.svg";
+
+    let mut options = flamegraph::Options::default();
+    options.stroke_color = "#7d7d7d".parse().unwrap();
+
+    test_flamegraph(input_file, expected_result_file, options).unwrap();
+}
+
+#[test]
 fn flamegraph_sorted_input_file() {
     let input_file = "./flamegraph/test/results/perf-vertx-stacks-01-collapsed-all.txt";
     let expected_result_file =


### PR DESCRIPTION
This was proposed by `@nagisa` in https://github.com/jonhoo/inferno/issues/248.

The new option will be `--stroke-color` and default to `none` and accept any color.
It use a non-configurable stroke width of 1.

Fixes https://github.com/jonhoo/inferno/issues/248