### PR TITLE
Make the sealed `CollapsePrivate` trait public again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+### Fixed
+ - Reverted an internal cleanup from 0.11.8 to fix compilation. [#265](https://github.com/jonhoo/inferno/pull/265)
+
 ## [0.11.8] - 2022-09-27
 ### Changed
  - Revert broken Firefox canvas height computation change. [#263](https://github.com/jonhoo/inferno/pull/263)

--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -45,13 +45,13 @@ pub static DEFAULT_NTHREADS: Lazy<usize> = Lazy::new(num_cpus::get);
 #[doc(hidden)]
 pub static DEFAULT_NTHREADS: Lazy<usize> = Lazy::new(|| 1);
 
-/// Private trait for internal library authors.
+/// Sealed trait for internal library authors.
 ///
 /// If you implement this trait, your type will implement the public-facing
 /// `Collapse` trait as well. Implementing this trait gives you parallelism
 /// for free as long as you adhere to the requirements described in the
 /// comments below.
-pub(crate) trait CollapsePrivate: Send + Sized {
+pub trait CollapsePrivate: Send + Sized {
     // *********************************************************** //
     // ********************* REQUIRED METHODS ******************** //
     // *********************************************************** //
@@ -351,8 +351,11 @@ pub(crate) trait CollapsePrivate: Send + Sized {
 /// Occurrences is a HashMap, which uses:
 /// * AHashMap if single-threaded
 /// * DashMap if multi-threaded
+///
+/// This is public because it is part of the sealed `CollapsePrivate` trait's API, but it
+/// is in a crate-private module so is not nameable by downstream library users.
 #[derive(Clone, Debug)]
-pub(crate) enum Occurrences {
+pub enum Occurrences {
     SingleThreaded(AHashMap<String, usize>),
     #[cfg(feature = "multithreaded")]
     MultiThreaded(Arc<DashMap<String, usize, ahash::RandomState>>),


### PR DESCRIPTION
It needs to be in the public API due to the blanket implementation of `Collapse` for `T: CollapsePrivate`. The `inferno::collapse::common` module is crate-private, ensuring that `CollapsePrivate` and `Occurrences` cannot be named by downstream library users.

Closes jonhoo/inferno#264.