### PR TITLE
Upgrade num-format to 0.4.3 and criterion to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "rand",
  "regex",
  "rgb",
+ "serde",
  "str_stack",
  "testing_logger",
 ]
@@ -804,18 +805,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "num-format"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2a6559322ec7c5b7188ac5ca85865b187a46b03d30b00f0c0e3549eecadb1e"
+checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
 dependencies = [
  "arrayvec",
  "itoa 1.0.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "pretty_assertions",
  "quick-xml",
  "rand",
+ "regex",
  "rgb",
  "str_stack",
  "testing_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,7 +77,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -99,14 +104,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
 dependencies = [
- "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -123,7 +144,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap 0.15.1",
+ "textwrap",
 ]
 
 [[package]]
@@ -159,15 +180,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -176,7 +198,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -185,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -236,28 +257,6 @@ checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -371,14 +370,14 @@ dependencies = [
  "ahash",
  "assert_cmd",
  "atty",
- "clap 3.2.22",
+ "clap",
  "criterion",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
  "env_logger",
  "indexmap",
- "itoa 1.0.4",
+ "itoa",
  "libflate",
  "log",
  "maplit",
@@ -401,12 +400,6 @@ checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
 dependencies = [
  "either",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -502,7 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
 dependencies = [
  "arrayvec",
- "itoa 1.0.4",
+ "itoa",
 ]
 
 [[package]]
@@ -813,15 +806,8 @@ name = "serde"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
- "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -841,7 +827,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -901,15 +887,6 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
@@ -929,12 +906,6 @@ name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,12 +21,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "assert_cmd"
@@ -381,7 +378,7 @@ dependencies = [
  "dashmap",
  "env_logger",
  "indexmap",
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "libflate",
  "log",
  "maplit",
@@ -413,9 +410,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -499,19 +496,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "num-format"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+checksum = "cc2a6559322ec7c5b7188ac5ca85865b187a46b03d30b00f0c0e3549eecadb1e"
 dependencies = [
  "arrayvec",
- "itoa 0.4.8",
+ "itoa 1.0.4",
 ]
 
 [[package]]
@@ -850,7 +841,7 @@ version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ pretty_assertions = "1"
 rand = { version = "0.8", features = ["small_rng"] }
 # Force criterion to pull in regex 1.6 instead of 1.5 during minimal version CI
 regex = { version = "1.6", default-features = false, features = ["std"] }
+# Force criterion to pull in serde 1.0.145 instead of 1.0.0 during minimal version CI
+serde = { version = "1.0.145" }
 testing_logger = "0.1.1"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ once_cell = "1.12.0"
 
 [dev-dependencies]
 assert_cmd = "2"
-criterion = "0.3"
+criterion = "0.4"
 libflate = "1"
 maplit = "1.0.1"
 pretty_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ libflate = "1"
 maplit = "1.0.1"
 pretty_assertions = "1"
 rand = { version = "0.8", features = ["small_rng"] }
+# Force criterion to pull in regex 1.6 instead of 1.5 during minimal version CI
+regex = { version = "1.6", default-features = false, features = ["std"] }
 testing_logger = "0.1.1"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ indexmap = { version = "1.0", optional = true }
 itoa = "1"
 log = "0.4"
 num_cpus = { version = "1.10", optional = true }
-num-format = { version = "0.4", default-features = false }
+num-format = { version = "0.4.3", default-features = false }
 quick-xml = { version = "0.23", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,23 @@ libflate = "1"
 maplit = "1.0.1"
 pretty_assertions = "1"
 rand = { version = "0.8", features = ["small_rng"] }
-# Force criterion to pull in regex 1.6 instead of 1.5 during minimal version CI
+# Force criterion to pull in regex 1.6 instead of 1.5 during minimal version CI;
+# otherwise compilation fails with...
+# ```
+# error[E0433]: failed to resolve: use of undeclared crate or module `syntax`
+#  --> <$HOME>/.cargo/registry/src/github.com-1ecc6299db9ec823/regex-1.5.0/src/literal/mod.rs:9:9
+#   |
+# 9 |     use syntax::hir::literal::Literals;
+#   |         ^^^^^^ use of undeclared crate or module `syntax`
+# ```
+# Forcing >= 1.5.1 would be enough to solve this issue, but since regex 1.6.0
+# supports our minimum supported rust version of 1.59.0, regex 1.6.x is fine
 regex = { version = "1.6", default-features = false, features = ["std"] }
-# Force criterion to pull in serde 1.0.145 instead of 1.0.0 during minimal version CI
+# Force criterion to pull in serde 1.0.145 instead of 1.0.0 during minimal version CI;
+# otherwise compilation fails with many errors (since serde 1.0.0 is such an old
+# crate). There is likely a lower version of serde than 1.0.145 that would also
+# successfully compile in minimal version CI, but since serde 1.0.145 is supported
+# by our minimum supported rust version of 1.59.0, being on >= 1.0.145 is fine
 serde = { version = "1.0.145" }
 testing_logger = "0.1.1"
 


### PR DESCRIPTION
I neglected to maintain `num-format` (a dependency of `inferno`) for a long time (years, basically); so it was sorely out-of-date. I intend to start maintaining it going forward.

I just published an updated version of `num-format` to crates.io. It's public API remains the same, but under the hood the following dependencies have been updated...

* arrayvec 0.4 -> 0.7.2
* itoa 0.4 -> 1.0.4

This diff ensures `inferno` is using at least `num-format` 0.4.3.