### PR TITLE
Upgrade to quick-xml 0.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated to [`quick-xml 0.27`](https://github.com/tafia/quick-xml/blob/master/Changelog.md#0270----2022-12-25).
 
 ### Removed
 
@@ -16,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to clap `v4`, which bumped MSRV to 1.64.0. [#267](https://github.com/jonhoo/inferno/pull/267)
 - Updated to [`env_logger 0.10`](https://github.com/rust-cli/env_logger/blob/main/CHANGELOG.md#0100---2022-11-24). [#281](https://github.com/jonhoo/inferno/pull/281)
-- `cargo update`
 
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ indexmap = { version = "1.0", optional = true }
 itoa = "1"
 log = "0.4"
 num-format = { version = "0.4.3", default-features = false }
-quick-xml = { version = "0.26", default-features = false }
+quick-xml = { version = "0.27", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 clap = { version = "4.0.1", optional = true, features = ["derive"] }

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -1,5 +1,5 @@
-use std::io;
 use std::path::{Path, PathBuf};
+use std::{io, sync::Arc};
 
 use clap::builder::TypedValueParser;
 use clap::{ArgAction, Parser};
@@ -343,7 +343,9 @@ fn main() -> quick_xml::Result<()> {
         )?;
     }
 
-    save_consistent_palette_if_needed(&palette_map, PALETTE_MAP_FILE).map_err(quick_xml::Error::Io)
+    save_consistent_palette_if_needed(&palette_map, PALETTE_MAP_FILE)
+        .map_err(Arc::new)
+        .map_err(quick_xml::Error::Io)
 }
 
 fn fetch_consistent_palette_if_needed(

--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::io;
 use std::iter;
+use std::{collections::HashMap, sync::Arc};
 
 use log::warn;
 
@@ -128,10 +128,10 @@ where
         if !suppress_sort_check {
             if let Some(prev_line) = prev_line {
                 if prev_line > line {
-                    return Err(quick_xml::Error::Io(io::Error::new(
+                    return Err(quick_xml::Error::Io(Arc::new(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "unsorted input lines detected",
-                    )));
+                    ))));
                 }
             }
         }


### PR DESCRIPTION
Note that since we have `pub` functions that return `quick_xml` types, this would be a breaking change.

Interestingly enough, we only expose `quick_xml` in the form of `quick_xml::Result` as far as I can tell. Specifically, we're using its error type, which feels like something we can avoid to mitigate this kind of "transitive bump" in the future. In particular, I think we could reasonable start using an opaque error type for these methods instead.

Marking this as a draft so we don't merge it without intending to do a major release.