### PR TITLE
Make it more obvious to a new contributor that the `flamegraph` git submodule needs to be initialised before running tests

### DIFF
--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -786,9 +786,9 @@ pub(crate) mod testing {
     }
 
     pub(crate) fn check_flamegraph_git_submodule_initialised() {
-        if !std::path::Path::new("./flamegraph/.git").exists() {
+        if !Path::new("./flamegraph/.git").exists() {
             panic!(
-                "Some tests require the flamegraph submodule to be initialised, but it is not.
+                "Some tests require the flamegraph git submodule to be initialised, but it is not.
 Initialise it with `git submodule update --init flamegraph`."
             );
         }

--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -784,6 +784,15 @@ pub(crate) mod testing {
 
         Ok(())
     }
+
+    pub(crate) fn check_flamegraph_git_submodule_initialised() {
+        if !std::path::Path::new("./flamegraph/.git").exists() {
+            panic!(
+                "Some tests require the flamegraph submodule to be initialised, but it is not.
+Initialise it with `git submodule update --init flamegraph`."
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -483,6 +483,7 @@ mod tests {
 
     #[test]
     fn test_collapse_multi_dtrace_simple() -> io::Result<()> {
+        common::testing::check_flamegraph_git_submodule_initialised();
         let path = "./flamegraph/example-dtrace-stacks.txt";
         let mut file = fs::File::open(path)?;
         let mut bytes = Vec::new();

--- a/src/collapse/dtrace.rs
+++ b/src/collapse/dtrace.rs
@@ -415,6 +415,7 @@ mod tests {
     use crate::collapse::Collapse;
 
     static INPUT: Lazy<Vec<PathBuf>> = Lazy::new(|| {
+        common::testing::check_flamegraph_git_submodule_initialised();
         [
             "./flamegraph/example-dtrace-stacks.txt",
             "./tests/data/collapse-dtrace/flamegraph-bug.txt",

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -779,6 +779,7 @@ mod tests {
 
     #[test]
     fn test_collapse_multi_perf_simple() -> io::Result<()> {
+        common::testing::check_flamegraph_git_submodule_initialised();
         let path = "./flamegraph/test/perf-cycles-instructions-01.txt";
         let mut file = fs::File::open(path)?;
         let mut bytes = Vec::new();

--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -744,6 +744,7 @@ mod tests {
     }
 
     static INPUT: Lazy<Vec<PathBuf>> = Lazy::new(|| {
+        common::testing::check_flamegraph_git_submodule_initialised();
         [
             "./flamegraph/example-perf-stacks.txt.gz",
             "./flamegraph/test/perf-cycles-instructions-01.txt",


### PR DESCRIPTION
Without this change, if a contributor naively clones the repo and runs `cargo test`, they are met with:
```console
...
failures:

---- collapse::dtrace::tests::test_collapse_multi_dtrace stdout ----
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }

---- collapse::dtrace::tests::test_collapse_multi_dtrace_simple stdout ----
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }

---- collapse::perf::tests::test_collapse_multi_perf stdout ----
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }

---- collapse::perf::tests::test_collapse_multi_perf_simple stdout ----
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }


failures:
    collapse::dtrace::tests::test_collapse_multi_dtrace
    collapse::dtrace::tests::test_collapse_multi_dtrace_simple
    collapse::perf::tests::test_collapse_multi_perf
    collapse::perf::tests::test_collapse_multi_perf_simple
```

With this change, they get some (hopefully) more obvious errors:
```console
failures:

---- collapse::dtrace::tests::test_collapse_multi_dtrace stdout ----
thread 'collapse::dtrace::tests::test_collapse_multi_dtrace' panicked at 'Some tests require the flamegraph git submodule to be initialised, but it is not.
Initialise it with `git submodule update --init flamegraph`.', src/collapse/common.rs:790:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
...
```

I have two data points that this or something like it would be handy:
 - https://github.com/jonhoo/inferno/pull/258#issuecomment-1250770285
 - my own experience :)

I haven't added a similar check for integration tests as unit tests run first so this error will be hit first anyway - but would be happy to do so if you wanted!