### PR TITLE
Fix `cargo clippy --all-targets` lints

### DIFF
--- a/src/differential/mod.rs
+++ b/src/differential/mod.rs
@@ -103,7 +103,7 @@ where
         if let Some((stack, count)) =
             parse_line(&l, opt.strip_hex, &mut stripped_fractional_samples)
         {
-            let mut counts = stack_counts.entry(stack).or_default();
+            let counts = stack_counts.entry(stack).or_default();
             if is_first {
                 counts.first += count;
             } else {

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -42,9 +42,10 @@ const GRAY_GRADIENT: (&str, &str) = ("#f8f8f8", "#e8e8e8");
 ///  - All other [`MultiPalette`] variants default to [`BackgroundColor::Yellow`].
 ///
 /// `BackgroundColor::default()` is `Yellow`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum BackgroundColor {
     /// A yellow gradient from `#EEEEEE` to `#EEEEB0`.
+    #[default]
     Yellow,
     /// A blue gradient from `#EEEEEE` to `#E0E0FF`.
     Blue,
@@ -56,12 +57,6 @@ pub enum BackgroundColor {
     ///
     /// Expressed in string form as `#RRGGBB` where each component is written in hexadecimal.
     Flat(Color),
-}
-
-impl Default for BackgroundColor {
-    fn default() -> Self {
-        BackgroundColor::Yellow
-    }
 }
 
 /// A flame graph color palette.

--- a/src/flamegraph/color/palettes.rs
+++ b/src/flamegraph/color/palettes.rs
@@ -106,9 +106,9 @@ pub(super) mod js {
         } else if name.contains(':') {
             return BasicPalette::Aqua;
         } else if let Some(ai) = name.find('/') {
-            if (&name[ai..]).contains("node_modules/") {
+            if name[ai..].contains("node_modules/") {
                 return BasicPalette::Purple;
-            } else if (&name[ai..]).contains(".js") {
+            } else if name[ai..].contains(".js") {
                 return BasicPalette::Green;
             }
         }

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -334,11 +334,12 @@ impl<'a> Default for Options<'a> {
 }
 
 /// The direction the plot should grow.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum Direction {
     /// Stacks grow from the bottom to the top.
     ///
     /// The `(all)` meta frame will be at the bottom.
+    #[default]
     Straight,
 
     /// Stacks grow from the top to the bottom.
@@ -347,26 +348,15 @@ pub enum Direction {
     Inverted,
 }
 
-impl Default for Direction {
-    fn default() -> Self {
-        Direction::Straight
-    }
-}
-
 /// The direction text is truncated when it's too long.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum TextTruncateDirection {
     /// Truncate text on the left.
+    #[default]
     Left,
 
     /// Truncate text on the right.
     Right,
-}
-
-impl Default for TextTruncateDirection {
-    fn default() -> Self {
-        TextTruncateDirection::Left
-    }
 }
 
 struct Rectangle {
@@ -694,7 +684,7 @@ where
         };
         filled_rectangle(&mut svg, &mut buffer, &rect, color, &mut cache_rect)?;
 
-        let fitchars = (rect.width_pct() as f64
+        let fitchars = (rect.width_pct()
             / (100.0 * opt.font_size as f64 * opt.font_width / image_width))
             .trunc() as usize;
         let text: svg::TextArgument<'_> = if fitchars >= 3 {

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -87,9 +87,9 @@ where
     Ok(())
 }
 
-pub(super) fn write_prelude<'a, W>(
+pub(super) fn write_prelude<W>(
     svg: &mut Writer<W>,
-    style_options: &StyleOptions<'a>,
+    style_options: &StyleOptions,
     opt: &Options<'_>,
 ) -> quick_xml::Result<()>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@
 #![deny(missing_docs)]
 #![warn(unreachable_pub)]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
+#![allow(clippy::disallowed_names)]
 
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;

--- a/tests/common/collapse.rs
+++ b/tests/common/collapse.rs
@@ -15,7 +15,7 @@ where
     let mut line_num = 1;
     for line in result.lines() {
         let line = if strip_quotes {
-            line.unwrap().replace('\"', "").replace('\'', "")
+            line.unwrap().replace(['\"', '\''], "")
         } else {
             line.unwrap()
         };

--- a/tests/diff-folded.rs
+++ b/tests/diff-folded.rs
@@ -22,7 +22,7 @@ fn test_diff_folded(
             if e.kind() == io::ErrorKind::NotFound {
                 // be nice to the dev and make the file
                 let mut f = File::create(expected_result_file).unwrap();
-                differential::from_files(options, &infile1, &infile2, &mut f)?;
+                differential::from_files(options, infile1, infile2, &mut f)?;
                 fs::metadata(expected_result_file).unwrap()
             } else {
                 return Err(e);


### PR DESCRIPTION
`clippy::disallowed_names` was complaining about variables named `foo` in a test, it seemed a silly thing to complain about so I just disabled it instead.
Happy to instead rename those variables if desired.

The rest all seem uncontroversial to me.