### PR TITLE
consider sample count when parsing folded line when using `base` option

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -460,13 +460,16 @@ where
             lines
                 .into_iter()
                 .filter_map(|line| {
-                    let mut cursor = line.len();
-                    for symbol in line.rsplit(';') {
-                        cursor -= symbol.len();
-                        if opt.base.iter().any(|b| b == symbol) {
-                            break;
+                    let mut cursor = 0;
+                    if let Some(symbols) = line.split_whitespace().next() {
+                        cursor = symbols.len();
+                        for symbol in symbols.rsplit(';') {
+                            cursor -= symbol.len();
+                            if opt.base.iter().any(|b| b == symbol) {
+                                break;
+                            }
+                            cursor = cursor.saturating_sub(1);
                         }
-                        cursor = cursor.saturating_sub(1);
                     }
                     if cursor == 0 {
                         None


### PR DESCRIPTION
When filtering lines given the `base` option, the line was parsed using `;` but given that a space-separated sample count could be included the first iterated value was always ignored to consider whether or not it's part of the base. This caused all the base samples that are leaves to be ignored, this PR fixed that by first splitting using a whitespace.