### PR TITLE
Strip symbols of inferno binaries to decrease size by 24x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- By default, make `cargo install` strip all binaries. [#310](https://github.com/jonhoo/inferno/pull/310)
+
 ### Removed
 
 ## [0.11.18] - 2023-11-11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ license = "CDDL-1.0"
 
 exclude = ["/tests/**", "/flamegraph/**", "/*.perf"]
 
+[profile.release]
+strip = true   # To use flamegraph on inferno binaries, comment this line
+# debug = true # and uncomment this line.
+
 [features]
 default = ["cli", "multithreaded", "nameattr"]
 cli = ["clap", "env_logger"]
@@ -64,9 +68,6 @@ regex = { version = "1.6", default-features = false, features = ["std"] }
 # by our minimum supported rust version of 1.59.0, being on >= 1.0.145 is fine
 serde = { version = "1.0.145" }
 testing_logger = "0.1.1"
-
-[profile.release]
-debug = true
 
 [lib]
 name = "inferno"


### PR DESCRIPTION
After running `cargo install --path .` to install all `inferno` binaries, here's what I noticed:

```sh
 ~ du -hc .cargo/bin/inferno-*
28M .cargo/bin/inferno-collapse-dtrace
25M .cargo/bin/inferno-collapse-ghcprof
30M .cargo/bin/inferno-collapse-guess
29M .cargo/bin/inferno-collapse-perf
27M .cargo/bin/inferno-collapse-recursive
25M .cargo/bin/inferno-collapse-sample
25M .cargo/bin/inferno-collapse-vsprof
25M .cargo/bin/inferno-collapse-vtune
24M .cargo/bin/inferno-diff-folded
28M .cargo/bin/inferno-flamegraph
263M    total
```

Files were extremely large due to this `debug` value:
```toml
[profile.release]
debug = true
```

Here are the values after stripping (with `strip` binary or key in manifest file):
```sh
 ~ du -hc .cargo/bin/inferno-*
1.2M    .cargo/bin/inferno-collapse-dtrace
1.1M    .cargo/bin/inferno-collapse-ghcprof
1.4M    .cargo/bin/inferno-collapse-guess
1.2M    .cargo/bin/inferno-collapse-perf
1.1M    .cargo/bin/inferno-collapse-recursive
1012K   .cargo/bin/inferno-collapse-sample
1000K   .cargo/bin/inferno-collapse-vsprof
1020K   .cargo/bin/inferno-collapse-vtune
932K    .cargo/bin/inferno-diff-folded
1.4M    .cargo/bin/inferno-flamegraph
11M total
```

And here's what you get by not using `debug` or `strip`:

```sh
 ~ du -hc .cargo/bin/inferno-*
5.6M    .cargo/bin/inferno-collapse-dtrace
5.4M    .cargo/bin/inferno-collapse-ghcprof
5.8M    .cargo/bin/inferno-collapse-guess
5.6M    .cargo/bin/inferno-collapse-perf
5.5M    .cargo/bin/inferno-collapse-recursive
5.4M    .cargo/bin/inferno-collapse-sample
5.3M    .cargo/bin/inferno-collapse-vsprof
5.4M    .cargo/bin/inferno-collapse-vtune
5.3M    .cargo/bin/inferno-diff-folded
5.8M    .cargo/bin/inferno-flamegraph
55M total
```

## TLDR

| debug (current) | none | strip |
|---|---|---|
|263M|55M|11M|

So I added `strip = true`