### PR TITLE
Trim executable name when getting function color

### DIFF
--- a/src/flamegraph/color/palettes.rs
+++ b/src/flamegraph/color/palettes.rs
@@ -129,6 +129,11 @@ pub(super) mod rust {
     use crate::flamegraph::color::BasicPalette;
 
     pub(in super::super) fn resolve(name: &str) -> BasicPalette {
+        let name = if let Some(i) = name.find('`') {
+            &name[i + 1..]
+        } else {
+            name
+        };
         if name.starts_with("core::")
             || name.starts_with("std::")
             || name.starts_with("alloc::")
@@ -600,6 +605,14 @@ mod tests {
             TestData {
                 input: String::from("<std::something something::else"),
                 output: BasicPalette::Orange,
+            },
+            TestData {
+                input: String::from("my-app`std::sys::unix::thread::Thread::new::thread_start"),
+                output: BasicPalette::Orange,
+            },
+            TestData {
+                input: String::from("my-app`foobar::extent::Extent::write"),
+                output: BasicPalette::Aqua,
             },
         ];
         for elem in test_names.iter() {

--- a/src/flamegraph/color/palettes.rs
+++ b/src/flamegraph/color/palettes.rs
@@ -129,11 +129,7 @@ pub(super) mod rust {
     use crate::flamegraph::color::BasicPalette;
 
     pub(in super::super) fn resolve(name: &str) -> BasicPalette {
-        let name = if let Some(i) = name.find('`') {
-            &name[i + 1..]
-        } else {
-            name
-        };
+        let name = name.split_once('`').map(|(_, after)| after).unwrap_or(name);
         if name.starts_with("core::")
             || name.starts_with("std::")
             || name.starts_with("alloc::")


### PR DESCRIPTION
On illumos, the DTrace script prints the library or executable before the function in the stack trace, e.g.

```
libc.so.1`__fdsync+0xa
cru-ds-fdsync-v1`std::fs::File::sync_all::hcd4d0768a77cbc2e+0x14
cru-ds-fdsync-v1`<crucible_downstairs::extent_inner_raw::RawInner as crucible_downstairs::extent::ExtentInner>::flush::h68fcf1774758d74e+0x9c
cru-ds-fdsync-v1`crucible_downstairs::extent::Extent::flush::h0eac5b95dfa4f5f0+0x472
cru-ds-fdsync-v1`std::panicking::try::h7ba6611983f64757+0x4c
cru-ds-fdsync-v1`_$LT$rayon_core..job..HeapJob$LT$BODY$GT$$u20$as$u20$rayon_core..job..Job$GT$::execute::h60b9d586fc4f8a0f (.llvm.8052073739315931670)+0x46
cru-ds-fdsync-v1`rayon_core::registry::WorkerThread::wait_until_cold::haa78671c0e7aa9b1+0x50f
cru-ds-fdsync-v1`rayon_core::registry::ThreadBuilder::run::hf28d413d115bded0+0x398
cru-ds-fdsync-v1`std::sys_common::backtrace::__rust_begin_short_backtrace::hfcd6324a3e87fc1e+0x48
cru-ds-fdsync-v1`core::ops::function::FnOnce::call_once{{vtable.shim}}::hbfa4fc2e086997af+0xb2
cru-ds-fdsync-v1`std::sys::unix::thread::Thread::new::thread_start::h1783cbcbbf061711+0x29
libc.so.1`_thrp_setup+0x77
libc.so.1`_lwp_start
```

This means that tests like `name.starts_with("core::")` don't work.

This PR updates the Rust color selector to drop anything before the backtick, so that calls to `starts_with(..)` correctly classify functions in `core` / `std` / etc.

I only did it for Rust because that's what I'm using; if you want, I can make the equivalent change for Java and Python resolvers (which also use `starts_with`).

Thanks!