### PR TITLE
Fix remaining cargo warnings

### DIFF
--- a/src/collapse/perf.rs
+++ b/src/collapse/perf.rs
@@ -549,10 +549,9 @@ impl Folder {
                 } else if self.opt.annotate_jit
                     && ((module.starts_with("/tmp/perf-") && module.ends_with(".map"))
                         || (module.contains("/jitted-") && module.ends_with(".so")))
+                    && !func.contains("_[j]")
                 {
-                    if !func.contains("_[j]") {
-                        func.push_str("_[j]"); // jitted
-                    }
+                    func.push_str("_[j]"); // jitted
                 }
 
                 self.cache_line.push(func);

--- a/src/flamegraph/attrs.rs
+++ b/src/flamegraph/attrs.rs
@@ -186,7 +186,7 @@ mod test {
 
     #[test]
     fn func_frame_attrs_map_from_reader() {
-        let foo = vec![
+        let foo = [
             "foo",
             // Without quotes
             "title=foo title",
@@ -201,7 +201,7 @@ mod test {
         ]
         .join("\t");
 
-        let bar = vec![
+        let bar = [
             "bar",
             "class=bar class",
             "href=bar href",
@@ -211,7 +211,7 @@ mod test {
         ]
         .join("\t");
 
-        let s = vec![foo, bar].join("\n");
+        let s = [foo, bar].join("\n");
         let r = s.as_bytes();
 
         let mut expected_inner = AHashMap::default();

--- a/src/flamegraph/color/mod.rs
+++ b/src/flamegraph/color/mod.rs
@@ -384,15 +384,15 @@ pub(super) fn color(
             hash ^= *byte as u64;
             hash = hash.wrapping_mul(0x100000001b3);
         }
-        let hash1 = (hash as f64 / std::u64::MAX as f64) as f32;
+        let hash1 = (hash as f64 / u64::MAX as f64) as f32;
 
         // Rotate hash so we get two more distinct numbers
         hash ^= 0;
         hash = hash.wrapping_mul(0x100000001b3);
-        let hash2 = (hash as f64 / std::u64::MAX as f64) as f32;
+        let hash2 = (hash as f64 / u64::MAX as f64) as f32;
         hash ^= 0;
         hash = hash.wrapping_mul(0x100000001b3);
-        let hash3 = (hash as f64 / std::u64::MAX as f64) as f32;
+        let hash3 = (hash as f64 / u64::MAX as f64) as f32;
 
         (hash1, hash2, hash3)
     } else {
@@ -489,7 +489,7 @@ mod tests {
 
     macro_rules! test_hash {
         ($name:expr, $expected:expr) => {
-            assert!((dbg!(namehash($name.bytes())) - $expected).abs() < std::f32::EPSILON);
+            assert!((dbg!(namehash($name.bytes())) - $expected).abs() < f32::EPSILON);
         };
     }
 

--- a/src/flamegraph/color/palette_map.rs
+++ b/src/flamegraph/color/palette_map.rs
@@ -101,7 +101,11 @@ impl PaletteMap {
     ///
     /// The file content will follow the format described in [`from_reader`](Self::from_reader).
     pub fn save_to_file(&self, path: &dyn AsRef<Path>) -> io::Result<()> {
-        let mut file = OpenOptions::new().write(true).create(true).open(path)?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            // TODO changes behaviour .truncate(true)
+            .open(path)?;
         self.to_writer(&mut file)
     }
 

--- a/src/flamegraph/color/palette_map.rs
+++ b/src/flamegraph/color/palette_map.rs
@@ -104,7 +104,7 @@ impl PaletteMap {
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)
-            // TODO changes behaviour .truncate(true)
+            .truncate(true)
             .open(path)?;
         self.to_writer(&mut file)
     }

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -617,7 +617,7 @@ where
                     function, samples_txt, opt.count_name, pct
                 ),
                 // Special case delta == 0 so we don't format percentage with a + sign.
-                Some(delta) if delta == 0 => write!(
+                Some(0) => write!(
                     buffer,
                     "{} ({} {}, {:.2}%; 0.00%)",
                     function, samples_txt, opt.count_name, pct,
@@ -755,18 +755,18 @@ fn write_container_start<'a, W: Write>(
     if let Some(frame_attributes) = frame_attributes {
         if frame_attributes.attrs.contains_key("xlink:href") {
             write_container_attributes(cache_a, frame_attributes);
-            svg.write_event(&cache_a)?;
+            svg.write_event(cache_a)?;
             has_href = true;
         } else {
             write_container_attributes(cache_g, frame_attributes);
-            svg.write_event(&cache_g)?;
+            svg.write_event(cache_g)?;
         }
         if let Some(ref t) = frame_attributes.title {
             title = t.as_str();
         }
     } else if let Event::Start(ref mut c) = cache_g {
         c.clear_attributes();
-        svg.write_event(&cache_g)?;
+        svg.write_event(cache_g)?;
     }
 
     Ok((has_href, title))
@@ -916,7 +916,7 @@ fn filled_rectangle<W: Write>(
     } else {
         unreachable!("cache wrapper was of wrong type: {:?}", cache_rect);
     }
-    svg.write_event(&cache_rect)
+    svg.write_event(cache_rect)
 }
 
 fn write_usize(buffer: &mut StrStack, value: usize) -> usize {

--- a/tests/collapse-ghcprof.rs
+++ b/tests/collapse-ghcprof.rs
@@ -113,5 +113,5 @@ fn collapse_ghcprof_cli() {
         .arg("--bytes")
         .output()
         .expect("failed to execute process");
-    assert_eq!(output.status.success(), false);
+    assert!(!output.status.success());
 }


### PR DESCRIPTION
This PR fixes all warnings reported by `cargo clippy` without further settings.

There is one more warning on this line, due to the experimental lint, which is not supported on stable Rust. This occurs in `cargo test` and `cargo doc`.
https://github.com/jonhoo/inferno/blob/726e7f3631a9e986c60417cc09d53a90dced5e91/src/lib.rs#L145

The fix in the second commit changes behaviour, though arguably, that was the intended behaviour. Alternatively, using `.truncate(false)` would explicitly preserve the current behaviour.