### PR TITLE
Bump quick-xml to 0.37.0 and remove it from public APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Remove `quick_xml::Error` from the public API. [#332](https://github.com/jonhoo/inferno/pull/332)
+
 ### Removed
 
 ## [0.11.21] - 2024-08-03

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.26.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+checksum = "ffbfb3ddf5364c9cfcd65549a1e7b801d0e8d1b14c1a1590a6408aa93cfbfa84"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ indexmap = { version = "2.0", optional = true }
 itoa = "1"
 log = "0.4"
 num-format = { version = "0.4.3", default-features = false }
-quick-xml = { version = "0.26", default-features = false }
+quick-xml = { version = "0.37", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 clap = { version = "4.0.1", optional = true, features = ["derive"] }

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -309,7 +309,7 @@ impl<'a> Opt {
 
 const PALETTE_MAP_FILE: &str = "palette.map"; // default name for the palette map file
 
-fn main() -> quick_xml::Result<()> {
+fn main() -> io::Result<()> {
     let opt = Opt::parse();
 
     // Initialize logger
@@ -343,7 +343,7 @@ fn main() -> quick_xml::Result<()> {
         )?;
     }
 
-    save_consistent_palette_if_needed(&palette_map, PALETTE_MAP_FILE).map_err(quick_xml::Error::Io)
+    save_consistent_palette_if_needed(&palette_map, PALETTE_MAP_FILE)
 }
 
 fn fetch_consistent_palette_if_needed(

--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -109,7 +109,7 @@ fn flow<'a, LI, TI>(
 pub(super) fn frames<'a, I>(
     lines: I,
     suppress_sort_check: bool,
-) -> quick_xml::Result<(Vec<TimedFrame<'a>>, usize, usize, usize)>
+) -> io::Result<(Vec<TimedFrame<'a>>, usize, usize, usize)>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -128,10 +128,10 @@ where
         if !suppress_sort_check {
             if let Some(prev_line) = prev_line {
                 if prev_line > line {
-                    return Err(quick_xml::Error::Io(io::Error::new(
+                    return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "unsorted input lines detected",
-                    )));
+                    ));
                 }
             }
         }

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::io::prelude::*;
+use std::io::{self, prelude::*};
 use std::iter;
 
 use quick_xml::events::{BytesCData, BytesDecl, BytesEnd, BytesStart, BytesText, Event};
@@ -59,7 +59,7 @@ pub(super) fn write_header<W>(
     svg: &mut Writer<W>,
     imageheight: usize,
     opt: &Options<'_>,
-) -> quick_xml::Result<()>
+) -> io::Result<()>
 where
     W: Write,
 {
@@ -91,7 +91,7 @@ pub(super) fn write_prelude<W>(
     svg: &mut Writer<W>,
     style_options: &StyleOptions,
     opt: &Options<'_>,
-) -> quick_xml::Result<()>
+) -> io::Result<()>
 where
     W: Write,
 {
@@ -261,7 +261,7 @@ pub(super) fn write_str<'a, W, I>(
     svg: &mut Writer<W>,
     buf: &mut StrStack,
     item: TextItem<'a, I>,
-) -> quick_xml::Result<()>
+) -> std::io::Result<()>
 where
     W: Write,
     I: IntoIterator<Item = (&'a str, &'a str)>,
@@ -290,7 +290,7 @@ where
             unreachable!("cache wrapper was of wrong type: {:?}", start_event);
         }
 
-        svg.write_event(&*start_event.borrow())
+        svg.write_event(start_event.borrow().borrow())
     })?;
     let s = match text {
         TextArgument::String(ref s) => s,

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -17,7 +17,7 @@ fn test_flamegraph(
     input_file: &str,
     expected_result_file: &str,
     options: Options<'_>,
-) -> quick_xml::Result<()> {
+) -> io::Result<()> {
     test_flamegraph_multiple_files(
         vec![PathBuf::from_str(input_file).unwrap()],
         expected_result_file,
@@ -29,7 +29,7 @@ fn test_flamegraph_multiple_files(
     input_files: Vec<PathBuf>,
     expected_result_file: &str,
     mut options: Options<'_>,
-) -> quick_xml::Result<()> {
+) -> io::Result<()> {
     // Always pretty print XML to make it easier to find differences when tests fail.
     options.pretty_xml = true;
     // Never include static JavaScript in tests so we don't have to have it duplicated
@@ -45,7 +45,7 @@ fn test_flamegraph_multiple_files(
                 flamegraph::from_files(&mut options, &input_files, &mut f)?;
                 fs::metadata(expected_result_file).unwrap()
             } else {
-                return Err(e.into());
+                return Err(e);
             }
         }
     };


### PR DESCRIPTION
This addresses #325.

The `quick_xml::Writer` used in inferno can only ever return `std::io::Error` but wrapped in `quick_xml::Error`. To fix this a small helper function has been added to "unwrap" this io error and return that as the public API.

I'm going to submit a PR to quick-xml to only give out `std::io::Error` from their `Writer` to make this behavior clear. There might be a good reason that I don't see.

I'm happy to make any other changes, like making a custom Error type if that's nicer for the public API.