### PR TITLE
Add docs for feature flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,12 @@
 //! $ inferno-diff-folded folded2 folded1 | inferno-flamegraph --negate > diff1.svg
 //! ```
 //!
+//! # Feature flags
+//! All features below are enabled by default
+//! - `cli`: Enabled when inferno compiled to a standalone binary and is used from the command line
+//! - `multithreaded`: Enables multithreading aggregating values for [`collapse`]
+//! - `nameattr`: Allows for adding customizing and adding attributes to the svg of [`flamegraph`]. See the `--nameattr` option for the flamegraph cli
+//!
 //! # Development
 //!
 //! This crate was initially developed through [a series of live coding sessions]. If you want to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,8 @@
 //!
 //! # Feature flags
 //! All features below are enabled by default
-//! - `cli`: Enabled when inferno compiled to a standalone binary and is used from the command line
-//! - `multithreaded`: Enables multithreading aggregating values for [`collapse`]
+//! - `cli`: Also builds the `inferno` command-line tools
+//! - `multithreaded`: Enables multithreaded stack-collapsing
 //! - `nameattr`: Allows for adding customizing and adding attributes to the svg of [`flamegraph`]. See the `--nameattr` option for the flamegraph cli
 //!
 //! # Development


### PR DESCRIPTION
Addresses #299.

I've added docs for the feature available feature flags. I believe these are correct but as I haven't used this crate myself I'm only going of the code and documentation. 

The style is inspired by [tracing's feature docs](https://docs.rs/tracing/latest/tracing/#crate-feature-flags) which I consider to be clear and readable. As I understand it there is no standardized format for feature docs yet.

I've not release any crates myself so I'm open to making any changes that would make the docs better or clearer (or correct if I've misunderstood some features).

I picked this up after watching the backlog of streams on the Open Source maintenance and saw that this was yet to be done.