### PR TITLE
Trim reversed stacks to prevent sort check from failing

### DIFF
--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -429,6 +429,7 @@ where
             }
             stack.push(' ');
             stack.push_str(&line[samples_idx..]);
+            let stack = stack.trim();
             reversed.push(&stack);
         }
         let mut reversed: Vec<&str> = reversed.iter().collect();

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -429,6 +429,9 @@ where
             }
             stack.push(' ');
             stack.push_str(&line[samples_idx..]);
+            // Trim to handle the case where functions names internally contain `;`.
+            // This can happen, for example, with types like `[u8; 8]` in Rust.
+            // See https://github.com/jonhoo/inferno/pull/338.
             let stack = stack.trim();
             reversed.push(&stack);
         }

--- a/tests/data/flamegraph/fractional-samples/with-space-reversed.svg
+++ b/tests/data/flamegraph/fractional-samples/with-space-reversed.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="1200" height="246" onload="init(evt)" viewBox="0 0 1200 246" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno">
+    <!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.-->
+    <!--NOTES: -->
+    <defs>
+        <linearGradient id="background" y1="0" y2="1" x1="0" x2="0">
+            <stop stop-color="#eeeeee" offset="5%"/>
+            <stop stop-color="#eeeeb0" offset="95%"/>
+        </linearGradient>
+    </defs>
+    <style type="text/css">
+text { font-family:monospace; font-size:12px }
+#title { text-anchor:middle; font-size:17px; }
+#matched { text-anchor:end; }
+#search { text-anchor:end; opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style>
+    <script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]></script>
+    <rect x="0" y="0" width="100%" height="246" fill="url(#background)"/>
+    <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
+    <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
+    <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
+    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
+    <svg id="frames" x="10" width="1180" total_samples="333">
+        <g>
+            <title>[unknown] (2 samples, 0.60%)</title>
+            <rect x="0.0000%" y="181" width="0.6006%" height="15" fill="rgb(242,180,40)" fg:x="0" fg:w="2"/>
+            <text x="0.2500%" y="191.50"></text>
+        </g>
+        <g>
+            <title>noploop (2 samples, 0.60%)</title>
+            <rect x="0.0000%" y="165" width="0.6006%" height="15" fill="rgb(248,212,47)" fg:x="0" fg:w="2"/>
+            <text x="0.2500%" y="175.50"></text>
+        </g>
+        <g>
+            <title>_]&gt;::default::h67c9877e6f2a615c (19 samples, 5.71%)</title>
+            <rect x="0.6006%" y="181" width="5.7057%" height="15" fill="rgb(228,158,26)" fg:x="2" fg:w="19"/>
+            <text x="0.8506%" y="191.50">_]&gt;::de..</text>
+        </g>
+        <g>
+            <title>core::array::&lt;impl core::default::Default for [T (19 samples, 5.71%)</title>
+            <rect x="0.6006%" y="165" width="5.7057%" height="15" fill="rgb(239,133,37)" fg:x="2" fg:w="19"/>
+            <text x="0.8506%" y="175.50">core::a..</text>
+        </g>
+        <g>
+            <title>main (19 samples, 5.71%)</title>
+            <rect x="0.6006%" y="149" width="5.7057%" height="15" fill="rgb(247,83,46)" fg:x="2" fg:w="19"/>
+            <text x="0.8506%" y="159.50">main</text>
+        </g>
+        <g>
+            <title>cksum (19 samples, 5.71%)</title>
+            <rect x="0.6006%" y="133" width="5.7057%" height="15" fill="rgb(226,95,23)" fg:x="2" fg:w="19"/>
+            <text x="0.8506%" y="143.50">cksum</text>
+        </g>
+        <g>
+            <title>cksum (6 samples, 1.80%)</title>
+            <rect x="6.3063%" y="165" width="1.8018%" height="15" fill="rgb(226,95,23)" fg:x="21" fg:w="6"/>
+            <text x="6.5563%" y="175.50">c..</text>
+        </g>
+        <g>
+            <title>cksum (37 samples, 11.11%)</title>
+            <rect x="6.3063%" y="181" width="11.1111%" height="15" fill="rgb(226,95,23)" fg:x="21" fg:w="37"/>
+            <text x="6.5563%" y="191.50">cksum</text>
+        </g>
+        <g>
+            <title>main (31 samples, 9.31%)</title>
+            <rect x="8.1081%" y="165" width="9.3093%" height="15" fill="rgb(247,83,46)" fg:x="27" fg:w="31"/>
+            <text x="8.3581%" y="175.50">main</text>
+        </g>
+        <g>
+            <title>__libc_start_main (31 samples, 9.31%)</title>
+            <rect x="8.1081%" y="149" width="9.3093%" height="15" fill="rgb(247,154,46)" fg:x="27" fg:w="31"/>
+            <text x="8.3581%" y="159.50">__libc_start_..</text>
+        </g>
+        <g>
+            <title>_start (31 samples, 9.31%)</title>
+            <rect x="8.1081%" y="133" width="9.3093%" height="15" fill="rgb(239,139,37)" fg:x="27" fg:w="31"/>
+            <text x="8.3581%" y="143.50">_start</text>
+        </g>
+        <g>
+            <title>cksum (31 samples, 9.31%)</title>
+            <rect x="8.1081%" y="117" width="9.3093%" height="15" fill="rgb(226,95,23)" fg:x="27" fg:w="31"/>
+            <text x="8.3581%" y="127.50">cksum</text>
+        </g>
+        <g>
+            <title>ext4_file_read_iter (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="181" width="0.3003%" height="15" fill="rgb(236,145,34)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="191.50"></text>
+        </g>
+        <g>
+            <title>__vfs_read (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="165" width="0.3003%" height="15" fill="rgb(236,122,34)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="175.50"></text>
+        </g>
+        <g>
+            <title>vfs_read (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="149" width="0.3003%" height="15" fill="rgb(236,128,34)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="159.50"></text>
+        </g>
+        <g>
+            <title>sys_read (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="133" width="0.3003%" height="15" fill="rgb(236,167,34)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="143.50"></text>
+        </g>
+        <g>
+            <title>entry_SYSCALL_64_fastpath (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="117" width="0.3003%" height="15" fill="rgb(236,196,34)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="127.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_read (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="101" width="0.3003%" height="15" fill="rgb(241,132,40)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="111.50"></text>
+        </g>
+        <g>
+            <title>_IO_file_xsgetn (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="85" width="0.3003%" height="15" fill="rgb(244,132,43)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="95.50"></text>
+        </g>
+        <g>
+            <title>__GI___fread_unlocked (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="69" width="0.3003%" height="15" fill="rgb(245,119,44)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="79.50"></text>
+        </g>
+        <g>
+            <title>cksum (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="53" width="0.3003%" height="15" fill="rgb(226,95,23)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="63.50"></text>
+        </g>
+        <g>
+            <title>cksum (1 samples, 0.30%)</title>
+            <rect x="17.4174%" y="37" width="0.3003%" height="15" fill="rgb(226,95,23)" fg:x="58" fg:w="1"/>
+            <text x="17.6674%" y="47.50"></text>
+        </g>
+        <g>
+            <title>all (333 samples, 100%)</title>
+            <rect x="0.0000%" y="197" width="100.0000%" height="15" fill="rgb(255,230,55)" fg:x="0" fg:w="333"/>
+            <text x="0.2500%" y="207.50"></text>
+        </g>
+        <g>
+            <title>main (274 samples, 82.28%)</title>
+            <rect x="17.7177%" y="181" width="82.2823%" height="15" fill="rgb(247,83,46)" fg:x="59" fg:w="274"/>
+            <text x="17.9677%" y="191.50">main</text>
+        </g>
+        <g>
+            <title>noploop (274 samples, 82.28%)</title>
+            <rect x="17.7177%" y="165" width="82.2823%" height="15" fill="rgb(248,212,47)" fg:x="59" fg:w="274"/>
+            <text x="17.9677%" y="175.50">noploop</text>
+        </g>
+    </svg>
+</svg>

--- a/tests/data/flamegraph/fractional-samples/with-space.txt
+++ b/tests/data/flamegraph/fractional-samples/with-space.txt
@@ -1,0 +1,6 @@
+cksum;_start;__libc_start_main;main;cksum 31.23
+cksum;cksum 6.1
+cksum;cksum;__GI___fread_unlocked;_IO_file_xsgetn;_IO_file_read;entry_SYSCALL_64_fastpath_[k];sys_read_[k];vfs_read_[k];__vfs_read_[k];ext4_file_read_iter_[k] 1.4
+cksum;main;core::array::<impl core::default::Default for [T; _]>::default::h67c9877e6f2a615c 19.0
+noploop;[unknown] 2.567
+noploop;main 274.321

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -807,6 +807,18 @@ fn flamegraph_reversed_stack_ordering_with_fractional_samples() {
 }
 
 #[test]
+fn flamegraph_reversed_stack_ordering_with_space() {
+    let input_file = "./tests/data/flamegraph/fractional-samples/with-space.txt";
+    let expected_result_file = "./tests/data/flamegraph/fractional-samples/with-space-reversed.svg";
+
+    let mut options = flamegraph::Options::default();
+    options.hash = true;
+    options.reverse_stack_order = true;
+
+    test_flamegraph(input_file, expected_result_file, options).unwrap();
+}
+
+#[test]
 fn flamegraph_should_warn_about_no_sort_when_reversing_stack_ordering() {
     let mut options = flamegraph::Options::default();
     options.no_sort = true;


### PR DESCRIPTION
If the last line of the stack starts with a space, then the space is used in sorting. However, the space is removed when the line is then fed into the flamegraph, which makes the sorting invalid. This commit adds a trim to the reverse process to fix this.