### PR TITLE
Bump ahash to 0.8.7 for -Zminimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ multithreaded = ["dashmap", "crossbeam-utils", "crossbeam-channel"]
 nameattr = ["indexmap"]
 
 [dependencies]
-ahash = "0.8"
+ahash = "0.8.7"
 crossbeam-utils = { version = "0.8", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 dashmap = { version = "6.0.1", optional = true }


### PR DESCRIPTION
Hi,

Thanks a lot for writing and maintaining inferno!

What do you think about this trivial patch that will fix the build with nightly Cargo's `-Zminimal-versions` mode? I routinely try to do this for my own projects, and an `ahash` -> `inferno` -> `tracing-subscriber` dependency chain led me here :) Of course, it is entirely up to you whether you want to support such whims.

Now, in theory one might say that a nightly-toolchain `-Zminimal-versions` build might even be added to the GitHub workflows or some such; let me know if you want me to try to do that, although I have to admit I am not overly familiar with GitHub workflows.

Thanks in advance, and keep up the great work!

G'luck,
Peter