### PR TITLE
feat: add typed API for flamegraph and collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Overhauled public crate API to be more useful for non-text inputs.
+
 ### Deprecated
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.12.6"
+version = "1.0.0-rc.1"
 dependencies = [
  "ahash",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inferno"
-version = "0.12.6"
+version = "1.0.0-rc.1"
 edition = "2021"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 rust-version = "1.71.0"

--- a/benches/flamegraph.rs
+++ b/benches/flamegraph.rs
@@ -2,9 +2,15 @@ use std::fs::File;
 use std::io::{self, BufReader, Read};
 
 use criterion::*;
-use inferno::flamegraph::{self, Options};
+use inferno::flamegraph::{self, Options, PreProcessingOptions};
 
-fn flamegraph_benchmark(c: &mut Criterion, id: &str, infile: &str, mut opt: Options<'static>) {
+fn flamegraph_benchmark(
+    c: &mut Criterion,
+    id: &str,
+    infile: &str,
+    opt: Options,
+    prep_opt: PreProcessingOptions,
+) {
     let mut f = File::open(infile).expect("file not found");
 
     let mut bytes = Vec::new();
@@ -16,7 +22,7 @@ fn flamegraph_benchmark(c: &mut Criterion, id: &str, infile: &str, mut opt: Opti
         .bench_with_input("flamegraph", &bytes, move |b, data| {
             b.iter(|| {
                 let reader = BufReader::new(data.as_slice());
-                let _folder = flamegraph::from_reader(&mut opt, reader, io::sink());
+                let _folder = flamegraph::from_reader(&opt, &prep_opt, None, reader, io::sink());
             })
         })
         .throughput(Throughput::Bytes(bytes.len() as u64));
@@ -25,11 +31,11 @@ fn flamegraph_benchmark(c: &mut Criterion, id: &str, infile: &str, mut opt: Opti
 }
 
 macro_rules! flamegraph_benchmarks {
-    ($($name:ident : ($infile:expr, $opt:expr)),*) => {
+    ($($name:ident : ($infile:expr, $opt:expr, $prep_opt:expr)),*) => {
         $(
             fn $name(c: &mut Criterion) {
                 let id = stringify!($name);
-                flamegraph_benchmark(c, id, $infile, $opt);
+                flamegraph_benchmark(c, id, $infile, $opt, $prep_opt);
             }
         )*
 
@@ -39,6 +45,9 @@ macro_rules! flamegraph_benchmarks {
 }
 
 flamegraph_benchmarks! {
-    flamegraph: ("tests/data/collapse-perf/results/example-perf-stacks-collapsed.txt",
-                 { let mut opt = Options::default(); opt.reverse_stack_order = true; opt })
+    flamegraph: (
+        "tests/data/collapse-perf/results/example-perf-stacks-collapsed.txt",
+        Options::default(),
+        { let mut t = PreProcessingOptions::default(); t.reverse_stack_order = true; t }
+    )
 }

--- a/src/bin/flamegraph.rs
+++ b/src/bin/flamegraph.rs
@@ -7,7 +7,9 @@ use env_logger::Env;
 use inferno::flamegraph::color::{
     parse_hex_color, BackgroundColor, Color, PaletteMap, SearchColor, StrokeColor,
 };
-use inferno::flamegraph::{self, defaults, Direction, Options, Palette, TextTruncateDirection};
+use inferno::flamegraph::{
+    self, defaults, Direction, Options, Palette, PreProcessingOptions, TextTruncateDirection,
+};
 
 #[cfg(feature = "nameattr")]
 use inferno::flamegraph::FuncFrameAttrsMap;
@@ -235,8 +237,8 @@ struct Opt {
     flame_chart: bool,
 }
 
-impl<'a> Opt {
-    fn into_parts(self) -> (Vec<PathBuf>, Options<'a>) {
+impl Opt {
+    fn into_parts(self) -> (Vec<PathBuf>, Options, PreProcessingOptions) {
         let mut options = Options::default();
         options.title = self.title.clone();
         options.colors = self.colors;
@@ -258,12 +260,14 @@ impl<'a> Opt {
         options.negate_differentials = self.negate;
         options.factor = self.factor;
         options.pretty_xml = self.pretty_xml;
-        options.no_sort = self.no_sort;
         options.no_javascript = self.no_javascript;
         options.color_diffusion = self.color_diffusion;
-        options.reverse_stack_order = self.reverse;
-        options.flame_chart = self.flame_chart;
-        options.base = self.base;
+
+        let mut prep_options = PreProcessingOptions::default();
+        prep_options.no_sort = self.no_sort;
+        prep_options.reverse_stack_order = self.reverse;
+        prep_options.flame_chart = self.flame_chart;
+        prep_options.base = self.base;
 
         if self.flame_chart && self.title == defaults::TITLE {
             options.title = defaults::CHART_TITLE.to_owned();
@@ -287,7 +291,7 @@ impl<'a> Opt {
         options.search_color = self.search_color;
         options.stroke_color = self.stroke_color;
         options.uicolor = self.uicolor;
-        (self.infiles, options)
+        (self.infiles, options, prep_options)
     }
 
     #[cfg(feature = "nameattr")]
@@ -328,15 +332,21 @@ fn main() -> io::Result<()> {
         Err(e) => panic!("Error reading {}: {:?}", PALETTE_MAP_FILE, e),
     };
 
-    let (infiles, mut options) = opt.into_parts();
-
-    options.palette_map = palette_map.as_mut();
+    let (infiles, options, prep_options) = opt.into_parts();
 
     if std::io::stdout().is_terminal() {
-        flamegraph::from_files(&mut options, &infiles, io::stdout().lock())?;
+        flamegraph::from_files(
+            &options,
+            &prep_options,
+            palette_map.as_mut(),
+            &infiles,
+            io::stdout().lock(),
+        )?;
     } else {
         flamegraph::from_files(
-            &mut options,
+            &options,
+            &prep_options,
+            palette_map.as_mut(),
             &infiles,
             io::BufWriter::new(io::stdout().lock()),
         )?;
@@ -384,7 +394,7 @@ mod tests {
     fn default_options() {
         let args = vec!["inferno-flamegraph", "test_infile"];
         let opt = Opt::try_parse_from(args).unwrap();
-        let (_infiles, options) = opt.into_parts();
+        let (_infiles, options, _prep_options) = opt.into_parts();
         assert_eq!(options, Options::default());
     }
 
@@ -434,7 +444,7 @@ mod tests {
             "test_infile2",
         ];
         let opt = Opt::try_parse_from(args).unwrap();
-        let (infiles, options) = opt.into_parts();
+        let (infiles, options, prep_options) = opt.into_parts();
         let mut expected_options = Options::default();
         expected_options.colors = Palette::from_str("purple").unwrap();
         expected_options.search_color = color::SearchColor::from_str("#203040").unwrap();
@@ -456,12 +466,14 @@ mod tests {
         expected_options.direction = Direction::Inverted;
         expected_options.negate_differentials = true;
         expected_options.pretty_xml = true;
-        expected_options.no_sort = false;
-        expected_options.reverse_stack_order = true;
         expected_options.no_javascript = true;
         expected_options.color_diffusion = false;
 
         assert_eq!(options, expected_options);
+
+        assert!(!prep_options.no_sort);
+        assert!(prep_options.reverse_stack_order);
+
         assert_eq!(infiles.len(), 2, "expected 2 input files");
         assert_eq!(infiles[0], PathBuf::from_str("test_infile1").unwrap());
         assert_eq!(infiles[1], PathBuf::from_str("test_infile2").unwrap());

--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -148,10 +148,9 @@ pub trait CollapsePrivate: Send + Sized {
     // ******************** PROVIDED METHODS ********************* //
     // *********************************************************** //
 
-    fn collapse<R, W>(&mut self, mut reader: R, writer: W) -> io::Result<()>
+    fn collapse_to_occurrences<R>(&mut self, mut reader: R) -> io::Result<Occurrences>
     where
         R: io::BufRead,
-        W: io::Write,
     {
         let mut occurrences = Occurrences::new(self.nthreads());
 
@@ -165,6 +164,16 @@ pub trait CollapsePrivate: Send + Sized {
         } else {
             self.collapse_single_threaded(reader, &mut occurrences)?;
         }
+
+        Ok(occurrences)
+    }
+
+    fn collapse<R, W>(&mut self, reader: R, writer: W) -> io::Result<()>
+    where
+        R: io::BufRead,
+        W: io::Write,
+    {
+        let mut occurrences = self.collapse_to_occurrences(reader)?;
 
         // Write results.
         occurrences.write_and_clear(writer)
@@ -422,6 +431,44 @@ impl Occurrences {
             SingleThreaded(_) => false,
             #[cfg(feature = "multithreaded")]
             MultiThreaded(_) => true,
+        }
+    }
+
+    /// Drain the occurrences into a sorted vector of `(stack, count, delta)` tuples.
+    ///
+    /// The delta is always `None` because `Occurrences` does not track per-stack deltas, only
+    /// accumulates total counts.
+    ///
+    /// This is used internally by `FoldedStacks` construction.
+    pub(crate) fn drain_sorted_entries(&mut self) -> Vec<(String, u64, Option<isize>)> {
+        use self::Occurrences::*;
+        match self {
+            SingleThreaded(ref mut map) => {
+                let mut entries: Vec<_> = map.drain().map(|(s, c)| (s, c, None)).collect();
+                entries.sort_unstable();
+                entries
+            }
+            #[cfg(feature = "multithreaded")]
+            MultiThreaded(ref mut arc) => {
+                let map = match Arc::get_mut(arc) {
+                    Some(map) => map,
+                    None => panic!(
+                        "Attempting to drain the contents of a concurrent HashMap \
+                         when more than one thread has access to it, which is \
+                         not allowed."
+                    ),
+                };
+                let map = mem::replace(
+                    map,
+                    DashMap::with_capacity_and_hasher(
+                        CAPACITY_HASHMAP,
+                        ahash::RandomState::default(),
+                    ),
+                );
+                let mut entries: Vec<_> = map.into_iter().map(|(s, c)| (s, c, None)).collect();
+                entries.sort_unstable();
+                entries
+            }
         }
     }
 

--- a/src/collapse/mod.rs
+++ b/src/collapse/mod.rs
@@ -84,6 +84,83 @@ use std::io::{self, IsTerminal};
 use std::path::Path;
 
 use self::common::{CollapsePrivate, CAPACITY_READER};
+use crate::flamegraph;
+
+/// Collapsed stack data, ready for flamegraph rendering.
+///
+/// Produced by [`Collapse::collapse_to_stacks`]. Can be passed to
+/// [`flamegraph::from_sorted_stacks`] via [`samples()`](Self::samples), or rendered directly via
+/// [`flame_graph()`](Self::flame_graph).
+///
+/// This wrapper performs no sorting or sort validation. When constructing this type, take care to
+/// order the stack entries correctly (usually: sorted) such that `samples` and `flame_graph`
+/// uphold the expected sorting.
+#[derive(Debug, Clone, Default)]
+pub struct FoldedStacks {
+    /// `(stack_string, count, delta)` tuples.
+    ///
+    /// Stacks use `;` as the frame delimiter internally (kept for storage efficiency).
+    ///
+    /// The delta is `Some` for differential flamegraph data.
+    entries: Vec<(String, u64, Option<isize>)>,
+}
+
+impl FoldedStacks {
+    /// Iterate over the stack entries as [`flamegraph::Sample`] values.
+    pub fn samples(
+        &self,
+    ) -> impl ExactSizeIterator<Item = flamegraph::Sample<std::str::Split<'_, char>>> + '_ {
+        self.entries.iter().map(|(stack, count, delta)| {
+            let mut sample = flamegraph::Sample::new(stack.split(';'), *count);
+            sample.delta = *delta;
+            sample
+        })
+    }
+
+    /// Render the collapsed stacks directly to SVG.
+    ///
+    /// Note that this function assumes that the stack entries are in sorted order.
+    pub fn flame_graph<W: io::Write>(
+        &self,
+        opt: &flamegraph::Options,
+        palette_map: Option<&mut flamegraph::color::PaletteMap>,
+        writer: W,
+    ) -> io::Result<()> {
+        flamegraph::from_sorted_stacks(opt, palette_map, self.samples(), writer)
+    }
+
+    /// Returns the number of distinct stacks.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if there are no stacks.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Construct `FoldedStacks` from an iterator of `(stack, count, delta)` tuples.
+///
+/// The caller is responsible for providing entries in sorted order (by stack
+/// string). No runtime sort is performed.
+impl FromIterator<(String, u64, Option<isize>)> for FoldedStacks {
+    fn from_iter<I: IntoIterator<Item = (String, u64, Option<isize>)>>(iter: I) -> Self {
+        FoldedStacks {
+            entries: iter.into_iter().collect(),
+        }
+    }
+}
+
+/// Extend `FoldedStacks` with additional `(stack, count, delta)` tuples.
+///
+/// The caller is responsible for maintaining sorted order across the
+/// combined entries. No runtime re-sort is performed.
+impl Extend<(String, u64, Option<isize>)> for FoldedStacks {
+    fn extend<I: IntoIterator<Item = (String, u64, Option<isize>)>>(&mut self, iter: I) {
+        self.entries.extend(iter);
+    }
+}
 
 /// The abstract behavior of stack collapsing.
 ///
@@ -146,6 +223,51 @@ pub trait Collapse {
     /// - `Some(false)` means "no, this implementation definitely won't work"
     #[allow(clippy::wrong_self_convention)]
     fn is_applicable(&mut self, input: &str) -> Option<bool>;
+
+    /// Collapses the contents of the provided `reader` into structured [`FoldedStacks`], bypassing
+    /// text serialization.
+    ///
+    /// The returned `FoldedStacks` can be rendered directly via [`FoldedStacks::flame_graph`] or
+    /// iterated as typed [`flamegraph::Sample`] values via [`FoldedStacks::samples`].
+    ///
+    /// The default implementation collapses to an intermediate text buffer and then parses it.
+    /// This is useful for collapser types that implement `Collapse` directly without going through
+    /// `CollapsePrivate`. Implementations that use `CollapsePrivate` get a more efficient override
+    /// via the blanket impl.
+    fn collapse_to_stacks<R>(&mut self, reader: R) -> io::Result<FoldedStacks>
+    where
+        R: io::BufRead,
+    {
+        // Collapse to a text buffer using the standard `collapse` path, then
+        // parse the "stack count" lines back into sorted `FoldedStacks` entries.
+        //
+        // Each line is either:
+        //   "<stack> <count>"                  (normal)
+        //   "<stack> <original_count> <count>" (differential)
+        let mut buf = Vec::new();
+        self.collapse(reader, &mut buf)?;
+        let text =
+            String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let mut entries: Vec<_> = text
+            .lines()
+            .filter_map(|line| {
+                let (stack, last_num) = line.trim_end().rsplit_once(' ')?;
+                let last_num = last_num.parse::<u64>().ok()?;
+
+                // Check for a second trailing number (differential format).
+                if let Some((stack, penul_num)) = stack.trim_end().rsplit_once(' ') {
+                    if let Ok(penul_num) = penul_num.parse::<u64>() {
+                        let delta = last_num as i64 - penul_num as i64;
+                        return Some((stack.to_owned(), last_num, Some(delta as isize)));
+                    }
+                }
+
+                Some((stack.to_owned(), last_num, None))
+            })
+            .collect();
+        entries.sort_unstable();
+        Ok(FoldedStacks { entries })
+    }
 }
 
 impl<T> Collapse for T
@@ -162,5 +284,14 @@ where
 
     fn is_applicable(&mut self, input: &str) -> Option<bool> {
         <Self as CollapsePrivate>::is_applicable(self, input)
+    }
+
+    fn collapse_to_stacks<R>(&mut self, reader: R) -> io::Result<FoldedStacks>
+    where
+        R: io::BufRead,
+    {
+        let mut occurrences = <Self as CollapsePrivate>::collapse_to_occurrences(self, reader)?;
+        let entries = occurrences.drain_sorted_entries();
+        Ok(FoldedStacks { entries })
     }
 }

--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -1,8 +1,11 @@
 use std::collections::HashMap;
 use std::io;
 use std::iter;
+use std::mem;
 
 use log::warn;
+
+use super::Sample;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(super) struct Frame<'a> {
@@ -113,77 +116,84 @@ pub(super) fn frames<'a, I>(
 where
     I: IntoIterator<Item = &'a str>,
 {
+    let mut parser = LineParser::default();
+    let samples = lines
+        .into_iter()
+        .filter_map(|line| parser.parse(line))
+        .map(|s| Sample {
+            stack: s.stack.split(';'),
+            count: s.count,
+            delta: s.delta,
+        });
+    let (frames, time, delta_max) = frames_from_stacks(samples, suppress_sort_check)?;
+    Ok((frames, time, parser.ignored, delta_max))
+}
+
+/// Parses folded stack text lines into [`Sample`] values.
+///
+/// Tracks state across lines: the `ignored` count and whether a
+/// fractional-samples warning has already been emitted.
+#[derive(Default)]
+pub(super) struct LineParser {
+    pub(super) ignored: usize,
+    stripped_fractional_samples: bool,
+}
+
+/// Merge pre-parsed stack samples into timed frames for SVG rendering.
+///
+/// The caller must provide sorted samples (unless `check_sort` is false).
+pub(super) fn frames_from_stacks<'a, I, S>(
+    stacks: I,
+    suppress_sort_check: bool,
+) -> io::Result<(Vec<TimedFrame<'a>>, u64, usize)>
+where
+    I: IntoIterator<Item = Sample<S>>,
+    S: IntoIterator<Item = &'a str>,
+{
     let mut time = 0;
-    let mut ignored = 0;
-    let mut last = "";
     let mut tmp = Default::default();
     let mut frames = Default::default();
     let mut delta_max = 1;
-    let mut prev_line = None;
-    let mut stripped_fractional_samples = false;
-    for line in lines {
-        let mut line = line.trim();
 
-        // NOTE: delta has to be per-line so it doesn't bleed across lines
-        let mut delta = None;
+    // Two reusable buffers for stack frames
+    let mut last: Vec<&'a str> = Vec::new();
+    let mut stack: Vec<&'a str> = Vec::new();
 
-        if !suppress_sort_check {
-            if let Some(prev_line) = prev_line {
-                if prev_line > line {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "unsorted input lines detected",
-                    ));
-                }
-            }
+    for sample in stacks {
+        stack.clear();
+        stack.extend(sample.stack);
+
+        if !suppress_sort_check && !last.is_empty() && last > stack {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unsorted input samples detected",
+            ));
         }
 
-        // Parse the number of samples for the purpose of computing overall time passed.
-        // Usually there will only be one samples column at the end of a line,
-        // but for differentials there will be two. When there are two we compute the
-        // delta between them and use the second one.
-        let nsamples =
-            if let Some(samples) = parse_nsamples(&mut line, &mut stripped_fractional_samples) {
-                // See if there's also a differential column present
-                if let Some(original_samples) =
-                    parse_nsamples(&mut line, &mut stripped_fractional_samples)
-                {
-                    delta = Some(samples as isize - original_samples as isize);
-                    delta_max = std::cmp::max(delta.unwrap().unsigned_abs(), delta_max);
-                }
-                samples
-            } else {
-                ignored += 1;
-                continue;
-            };
-
-        if line.is_empty() {
-            ignored += 1;
-            continue;
+        if let Some(d) = sample.delta {
+            delta_max = std::cmp::max(d.unsigned_abs(), delta_max);
         }
-        let stack = line;
 
         // inject empty first-level stack frame to capture "all"
-        let this = iter::once("").chain(stack.split(';'));
+        let this = iter::once("").chain(stack.iter().copied());
         if last.is_empty() {
             // need to special-case this, because otherwise iter("") + "".split(';') == ["", ""]
             //eprintln!("flow(_, {}, {})", stack, time);
-            flow(&mut tmp, &mut frames, None, this, time, delta);
+            flow(&mut tmp, &mut frames, None, this, time, sample.delta);
         } else {
             //eprintln!("flow({}, {}, {})", last, stack, time);
             flow(
                 &mut tmp,
                 &mut frames,
-                iter::once("").chain(last.split(';')),
+                iter::once("").chain(last.iter().copied()),
                 this,
                 time,
-                delta,
+                sample.delta,
             );
         }
 
-        last = stack;
-        time += nsamples;
-        prev_line = Some(line);
+        mem::swap(&mut stack, &mut last);
+        time += sample.count;
     }
 
     if !last.is_empty() {
@@ -194,14 +204,53 @@ where
         flow(
             &mut tmp,
             &mut frames,
-            iter::once("").chain(last.split(';')),
+            iter::once("").chain(last.iter().copied()),
             None,
             time,
             None,
         );
     }
 
-    Ok((frames, time, ignored, delta_max))
+    Ok((frames, time, delta_max))
+}
+
+impl LineParser {
+    /// Parse a single folded stack line into a `Sample`.
+    ///
+    /// Returns `None` for lines with invalid format (increments
+    /// `self.ignored`). The returned `Sample`'s stack is a `&str`
+    /// (the semicolon-delimited stack portion of the line), not yet
+    /// split into frames; the caller is responsible for splitting.
+    pub(super) fn parse<'line>(&mut self, line: &'line str) -> Option<Sample<&'line str>> {
+        let mut line = line.trim();
+
+        // Parse the number of samples.
+        // Usually there will only be one samples column at the end of a line,
+        // but for differentials there will be two. When there are two we compute the
+        // delta between them and use the second one.
+        let nsamples = if let Some(samples) =
+            parse_nsamples(&mut line, &mut self.stripped_fractional_samples)
+        {
+            // See if there's also a differential column present
+            let delta = parse_nsamples(&mut line, &mut self.stripped_fractional_samples)
+                .map(|original| samples as isize - original as isize);
+            (samples, delta)
+        } else {
+            self.ignored += 1;
+            return None;
+        };
+
+        if line.is_empty() {
+            self.ignored += 1;
+            return None;
+        }
+
+        Some(Sample {
+            stack: line,
+            count: nsamples.0,
+            delta: nsamples.1,
+        })
+    }
 }
 
 // Parse and remove the number of samples from the end of a line.

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -35,6 +35,71 @@ pub use self::color::Palette;
 use self::color::{Color, SearchColor, StrokeColor};
 use self::svg::{Dimension, StyleOptions};
 
+/// A pre-collapsed stack sample for flamegraph rendering.
+///
+/// The type parameter `S` is the stack frame iterator/collection type.
+/// For most callers this is inferred and never needs to be named.
+///
+/// # Examples
+///
+/// ```
+/// use inferno::flamegraph::Sample;
+///
+/// let frames = ["main", "handle_request", "parse_json"];
+/// let sample = Sample::new(frames.into_iter(), 42);
+///
+/// // Differential: 120 "after" samples, delta of +20 vs "before"
+/// let diff = Sample::with_delta(["main", "handle_request", "parse_json"].into_iter(), 120, 20);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sample<S> {
+    /// Stack frames from root (outermost) to leaf (innermost).
+    pub stack: S,
+    /// Number of times this stack was observed.
+    pub count: u64,
+    /// For differential flamegraphs: `after_count - before_count`.
+    /// `None` for non-differential.
+    pub delta: Option<isize>,
+}
+
+impl<S> Sample<S> {
+    /// Create a new non-differential sample.
+    pub fn new(stack: S, count: u64) -> Self {
+        Sample {
+            stack,
+            count,
+            delta: None,
+        }
+    }
+
+    /// Create a differential sample with a delta value.
+    pub fn with_delta(stack: S, count: u64, delta: isize) -> Self {
+        Sample {
+            stack,
+            count,
+            delta: Some(delta),
+        }
+    }
+
+    /// Borrow the stack, preserving count and delta.
+    pub fn borrow_stack(&self) -> Sample<&S> {
+        Sample {
+            stack: &self.stack,
+            count: self.count,
+            delta: self.delta,
+        }
+    }
+
+    /// Transform the stack, preserving count and delta.
+    pub fn map_stack<T>(self, f: impl FnOnce(S) -> T) -> Sample<T> {
+        Sample {
+            stack: f(self.stack),
+            count: self.count,
+            delta: self.delta,
+        }
+    }
+}
+
 const XPAD: usize = 10; // pad left and right
 const FRAMEPAD: usize = 1; // vertical padding for frames
 
@@ -94,7 +159,7 @@ pub mod defaults {
 /// Configure the flame graph.
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
-pub struct Options<'a> {
+pub struct Options {
     /// The color palette to use when plotting.
     pub colors: color::Palette,
 
@@ -114,18 +179,6 @@ pub struct Options<'a> {
     /// Choose names based on the hashes of function names, without the weighting scheme that
     /// `hash` uses.
     pub deterministic: bool,
-
-    /// Store the choice of color for each function so that later invocations use the same colors.
-    ///
-    /// With this option enabled, a file called `palette.map` will be created the first time a
-    /// flame graph is generated, and the color chosen for each function will be written into it.
-    /// On subsequent invocations, functions that already have a color registered in that file will
-    /// be given the stored color rather than be assigned a new one. New functions will have their
-    /// colors persisted for future runs.
-    ///
-    /// This feature was first implemented [by Shawn
-    /// Sterling](https://github.com/brendangregg/FlameGraph/pull/25).
-    pub palette_map: Option<&'a mut color::PaletteMap>,
 
     /// Assign extra attributes to particular functions.
     ///
@@ -225,22 +278,6 @@ pub struct Options<'a> {
     /// Pretty print XML with newlines and indentation.
     pub pretty_xml: bool,
 
-    /// Don't sort the input lines.
-    ///
-    /// If you know for sure that your folded stack lines are sorted you can set this flag to get
-    /// a performance boost. If you have multiple input files, the lines will be merged and sorted
-    /// regardless.
-    ///
-    /// Note that if you use `from_lines` directly, the it is always your responsibility to make
-    /// sure the lines are sorted.
-    pub no_sort: bool,
-
-    /// Generate stack-reversed flame graph.
-    ///
-    /// Note that stack lines must always be sorted after reversing the stacks so the `no_sort`
-    /// option will be ignored.
-    pub reverse_stack_order: bool,
-
     /// Don't include static JavaScript in flame graph.
     /// This is only meant to be used in tests.
     #[doc(hidden)]
@@ -253,17 +290,44 @@ pub struct Options<'a> {
     /// useful visual cue of what to focus on, especially if you are showing
     /// flamegraphs to someone for the first time.
     pub color_diffusion: bool,
+}
 
-    /// Produce a flame chart (sort by time, do not merge stacks)
+/// Text-processing options that control how input stack lines are interpreted.
+///
+/// These options only affect the parsing and ordering of the folded stack input,
+/// not the visual appearance of the resulting flame graph.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct PreProcessingOptions {
+    /// Don't sort the input lines.
     ///
-    /// Note that stack is not sorted and will be reversed
+    /// If you know for sure that your folded stack lines are sorted you can set this flag to get
+    /// a performance boost. If you have multiple input files, the lines will be merged and sorted
+    /// regardless.
+    ///
+    /// Note that if you use `from_lines` directly, it is always your responsibility to make
+    /// sure the lines are sorted.
+    pub no_sort: bool,
+
+    /// Generate stack-reversed flame graph.
+    ///
+    /// Note that stack lines must always be sorted after reversing the stacks so the `no_sort`
+    /// option will be ignored.
+    pub reverse_stack_order: bool,
+
+    /// Produce a flame chart (sort by time, do not merge stacks).
+    ///
+    /// Note that the stack is not sorted and will be reversed.
     pub flame_chart: bool,
 
-    /// Base symbols
+    /// Base symbols.
+    ///
+    /// Omit samples whose stacks do not contain one of these symbols. When a symbol is found,
+    /// the call stack is truncated so that the matching symbol becomes the bottom-most frame.
     pub base: Vec<String>,
 }
 
-impl Options<'_> {
+impl Options {
     /// Calculate pad top, including title and subtitle
     pub(super) fn ypad1(&self) -> usize {
         let subtitle_height = if self.subtitle.is_some() {
@@ -293,7 +357,7 @@ impl Options<'_> {
     }
 }
 
-impl Default for Options<'_> {
+impl Default for Options {
     fn default() -> Self {
         Options {
             colors: Palette::from_str(defaults::COLORS).unwrap(),
@@ -316,16 +380,11 @@ impl Default for Options<'_> {
             uicolor: Default::default(),
             hash: Default::default(),
             deterministic: Default::default(),
-            palette_map: Default::default(),
             direction: Default::default(),
             negate_differentials: Default::default(),
             pretty_xml: Default::default(),
-            no_sort: Default::default(),
-            reverse_stack_order: Default::default(),
             no_javascript: Default::default(),
             color_diffusion: Default::default(),
-            flame_chart: Default::default(),
-            base: Default::default(),
 
             #[cfg(feature = "nameattr")]
             func_frameattrs: Default::default(),
@@ -393,19 +452,25 @@ impl Rectangle {
 ///
 /// [differential flame graph]: http://www.brendangregg.com/blog/2014-11-09/differential-flame-graphs.html
 #[allow(clippy::cognitive_complexity)]
-pub fn from_lines<'a, I, W>(opt: &mut Options<'_>, lines: I, writer: W) -> io::Result<()>
+pub fn from_lines<'a, I, W>(
+    opt: &Options,
+    prep_opt: &PreProcessingOptions,
+    palette_map: Option<&mut color::PaletteMap>,
+    lines: I,
+    writer: W,
+) -> io::Result<()>
 where
     I: IntoIterator<Item = &'a str>,
     W: Write,
 {
-    let mut reversed = StrStack::new();
     let lines = lines
         .into_iter()
         .map(|line| line.trim())
         .filter(|line| !(line.is_empty() || line.starts_with("# ")));
 
-    let (mut frames, time, ignored, delta_max) = if opt.reverse_stack_order {
-        if opt.no_sort {
+    let mut reversed = StrStack::new();
+    let (frames, time, ignored, delta_max) = if prep_opt.reverse_stack_order {
+        if prep_opt.no_sort {
             warn!(
                 "Input lines are always sorted when `reverse_stack_order` is `true`. \
                  The `no_sort` option is being ignored."
@@ -438,17 +503,17 @@ where
         let mut reversed: Vec<&str> = reversed.iter().collect();
         reversed.sort_unstable();
         merge::frames(reversed, false)?
-    } else if opt.flame_chart {
+    } else if prep_opt.flame_chart {
         // In flame chart mode, just reverse the data so time moves from left to right.
         let mut lines: Vec<&str> = lines.into_iter().collect();
         lines.reverse();
         merge::frames(lines, true)?
-    } else if opt.no_sort {
+    } else if prep_opt.no_sort {
         // Lines don't need sorting.
         merge::frames(lines, false)?
     } else {
         // Sort lines by default.
-        let mut lines: Vec<&str> = if opt.base.is_empty() {
+        let mut lines: Vec<&str> = if prep_opt.base.is_empty() {
             lines.into_iter().collect()
         } else {
             lines
@@ -457,7 +522,7 @@ where
                     let mut cursor = line.len();
                     for symbol in line.rsplit(';') {
                         cursor -= symbol.len();
-                        if opt.base.iter().any(|b| b == symbol) {
+                        if prep_opt.base.iter().any(|b| b == symbol) {
                             break;
                         }
                         cursor = cursor.saturating_sub(1);
@@ -478,6 +543,134 @@ where
         warn!("Ignored {} lines with invalid format", ignored);
     }
 
+    render_svg(opt, palette_map, frames, time, delta_max, writer)
+}
+
+/// Produce a flame graph from pre-sorted, pre-collapsed stack samples.
+///
+/// Each [`Sample`] provides a stack (root-to-leaf frame iterator) and a
+/// sample count.  Samples **must** be sorted lexicographically by their
+/// stack frames; an error is returned if unsorted input is detected.
+///
+/// This is the primary typed entry point. Use [`from_stacks`] if your
+/// data is not already sorted.
+///
+/// # Examples
+///
+/// ```
+/// use inferno::flamegraph::{self, Options, Sample};
+///
+/// let samples = vec![
+///     Sample::new(["main", "alpha"].into_iter(), 3),
+///     Sample::new(["main", "beta"].into_iter(), 5),
+/// ];
+/// let mut buf = Vec::new();
+/// flamegraph::from_sorted_stacks(&Options::default(), None, samples, &mut buf).unwrap();
+/// assert!(!buf.is_empty());
+/// ```
+pub fn from_sorted_stacks<'a, I, S, W>(
+    opt: &Options,
+    palette_map: Option<&mut color::PaletteMap>,
+    stacks: I,
+    writer: W,
+) -> io::Result<()>
+where
+    I: IntoIterator<Item = Sample<S>>,
+    S: IntoIterator<Item = &'a str>,
+    W: Write,
+{
+    let (frames, time, delta_max) = merge::frames_from_stacks(stacks, false)?;
+    render_svg(opt, palette_map, frames, time, delta_max, writer)
+}
+
+/// Produce a flame graph from unsorted, pre-collapsed stack samples.
+///
+/// Like [`from_sorted_stacks`], but accepts samples in any order.
+/// Internally collects and sorts the stacks before rendering.
+///
+/// # Examples
+///
+/// ```
+/// use inferno::flamegraph::{self, Options, Sample};
+///
+/// let samples = vec![
+///     Sample::new(["main", "beta"].into_iter(), 5),
+///     Sample::new(["main", "alpha"].into_iter(), 3),
+/// ];
+/// let mut buf = Vec::new();
+/// flamegraph::from_stacks(&Options::default(), None, samples, &mut buf).unwrap();
+/// assert!(!buf.is_empty());
+/// ```
+pub fn from_stacks<'a, I, S, W>(
+    opt: &Options,
+    palette_map: Option<&mut color::PaletteMap>,
+    stacks: I,
+    writer: W,
+) -> io::Result<()>
+where
+    I: IntoIterator<Item = Sample<S>>,
+    S: IntoIterator<Item = &'a str>,
+    W: Write,
+{
+    let mut samples: Vec<Sample<Vec<&'a str>>> = stacks
+        .into_iter()
+        .map(|s| s.map_stack(|stack| stack.into_iter().collect()))
+        .collect();
+    samples.sort_unstable_by(|a, b| a.stack.cmp(&b.stack));
+    // We just sorted so skip the redundant O(n) sort check.
+    let sorted = samples
+        .iter()
+        .map(|s| s.borrow_stack().map_stack(|stack| stack.iter().copied()));
+    let (frames, time, delta_max) = merge::frames_from_stacks(sorted, true)?;
+    render_svg(opt, palette_map, frames, time, delta_max, writer)
+}
+
+/// Produce a flame chart from pre-collapsed stack samples.
+///
+/// Unlike [`from_sorted_stacks`], this preserves time ordering and does
+/// not merge identical stacks.  Samples are rendered in reverse order
+/// (newest on the left) to match flame chart conventions.
+///
+/// # Examples
+///
+/// ```
+/// use inferno::flamegraph::{self, Options, Sample};
+///
+/// // Samples in time order so identical stacks are kept separate.
+/// let samples = vec![
+///     Sample::new(["main", "handle_request"].into_iter(), 10),
+///     Sample::new(["main", "idle"].into_iter(), 5),
+///     Sample::new(["main", "handle_request"].into_iter(), 8),
+/// ];
+/// let mut buf = Vec::new();
+/// flamegraph::flame_chart_from_stacks(&Options::default(), None, samples, &mut buf).unwrap();
+/// assert!(!buf.is_empty());
+/// ```
+pub fn flame_chart_from_stacks<'a, I, S, W>(
+    opt: &Options,
+    palette_map: Option<&mut color::PaletteMap>,
+    stacks: I,
+    writer: W,
+) -> io::Result<()>
+where
+    I: IntoIterator<Item = Sample<S>>,
+    I::IntoIter: DoubleEndedIterator,
+    S: IntoIterator<Item = &'a str>,
+    W: Write,
+{
+    let (frames, time, delta_max) = merge::frames_from_stacks(stacks.into_iter().rev(), true)?;
+    // Flame charts preserve time ordering so skip the sort check.
+    render_svg(opt, palette_map, frames, time, delta_max, writer)
+}
+
+fn render_svg<W: Write>(
+    opt: &Options,
+    mut palette_map: Option<&mut color::PaletteMap>,
+    mut frames: Vec<merge::TimedFrame<'_>>,
+    time: u64,
+    delta_max: usize,
+    writer: W,
+) -> io::Result<()> {
     let mut buffer = StrStack::new();
 
     // let's start writing the svg!
@@ -603,7 +796,7 @@ where
         //     `sprintf "%.0f", 1.5` produces "2"
         //     `sprintf "%.0f", 2.5` produces "2"
         //     `sprintf "%.0f", 3.5` produces "4"
-        let samples = ((frame.end_time - frame.start_time) as f64 * opt.factor).round() as usize;
+        let samples = ((frame.end_time - frame.start_time) as f64 * opt.factor).round() as u64;
 
         // add thousands separators to `samples`
         let _ = samples_txt_buffer.write_formatted(&samples, &Locale::en);
@@ -670,7 +863,7 @@ where
                 delta = -delta;
             }
             color::color_scale(delta, delta_max)
-        } else if let Some(ref mut palette_map) = opt.palette_map {
+        } else if let Some(ref mut palette_map) = palette_map {
             let colors = opt.colors;
             let hash = opt.hash;
             let deterministic = opt.deterministic;
@@ -744,7 +937,7 @@ where
 
 #[cfg(feature = "nameattr")]
 fn write_container_start<'a, W: Write>(
-    opt: &'a Options<'a>,
+    opt: &'a Options,
     svg: &mut Writer<W>,
     cache_a: &mut Event<'_>,
     cache_g: &mut Event<'_>,
@@ -778,7 +971,7 @@ fn write_container_start<'a, W: Write>(
 
 #[cfg(not(feature = "nameattr"))]
 fn write_container_start<'a, W: Write>(
-    _opt: &Options<'_>,
+    _opt: &Options,
     svg: &mut Writer<W>,
     _cache_a: &mut Event<'_>,
     cache_g: &mut Event<'_>,
@@ -814,12 +1007,18 @@ fn write_container_attributes(event: &mut Event<'_>, frame_attributes: &FrameAtt
 /// See [`from_lines`] for the expected format of each line.
 ///
 /// The resulting flame graph will be written out to `writer` in SVG format.
-pub fn from_reader<R, W>(opt: &mut Options<'_>, reader: R, writer: W) -> io::Result<()>
+pub fn from_reader<R, W>(
+    opt: &Options,
+    prep_opt: &PreProcessingOptions,
+    palette_map: Option<&mut color::PaletteMap>,
+    reader: R,
+    writer: W,
+) -> io::Result<()>
 where
     R: Read,
     W: Write,
 {
-    from_readers(opt, iter::once(reader), writer)
+    from_readers(opt, prep_opt, palette_map, iter::once(reader), writer)
 }
 
 /// Produce a flame graph from a set of readers that contain folded stack lines.
@@ -827,7 +1026,13 @@ where
 /// See [`from_lines`] for the expected format of each line.
 ///
 /// The resulting flame graph will be written out to `writer` in SVG format.
-pub fn from_readers<R, W>(opt: &mut Options<'_>, readers: R, writer: W) -> io::Result<()>
+pub fn from_readers<R, W>(
+    opt: &Options,
+    prep_opt: &PreProcessingOptions,
+    palette_map: Option<&mut color::PaletteMap>,
+    readers: R,
+    writer: W,
+) -> io::Result<()>
 where
     R: IntoIterator,
     R::Item: Read,
@@ -837,21 +1042,27 @@ where
     for mut reader in readers {
         reader.read_to_string(&mut input)?;
     }
-    from_lines(opt, input.lines(), writer)
+    from_lines(opt, prep_opt, palette_map, input.lines(), writer)
 }
 
 /// Produce a flame graph from files that contain folded stack lines
 /// and write the result to provided `writer`.
 ///
 /// If files is empty, STDIN will be used as input.
-pub fn from_files<W: Write>(opt: &mut Options<'_>, files: &[PathBuf], writer: W) -> io::Result<()> {
+pub fn from_files<W: Write>(
+    opt: &Options,
+    prep_opt: &PreProcessingOptions,
+    palette_map: Option<&mut color::PaletteMap>,
+    files: &[PathBuf],
+    writer: W,
+) -> io::Result<()> {
     if files.is_empty() || files.len() == 1 && files[0].to_str() == Some("-") {
         let stdin = io::stdin();
         let r = BufReader::with_capacity(128 * 1024, stdin.lock());
-        from_reader(opt, r, writer)
+        from_reader(opt, prep_opt, palette_map, r, writer)
     } else if files.len() == 1 {
         let r = File::open(&files[0])?;
-        from_reader(opt, r, writer)
+        from_reader(opt, prep_opt, palette_map, r, writer)
     } else {
         let stdin = io::stdin();
         let mut stdin_added = false;
@@ -869,7 +1080,7 @@ pub fn from_files<W: Write>(opt: &mut Options<'_>, files: &[PathBuf], writer: W)
             }
         }
 
-        from_readers(opt, readers, writer)
+        from_readers(opt, prep_opt, palette_map, readers, writer)
     }
 }
 

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -58,7 +58,7 @@ pub(super) struct StyleOptions<'a> {
 pub(super) fn write_header<W>(
     svg: &mut Writer<W>,
     imageheight: usize,
-    opt: &Options<'_>,
+    opt: &Options,
 ) -> io::Result<()>
 where
     W: Write,
@@ -90,7 +90,7 @@ where
 pub(super) fn write_prelude<W>(
     svg: &mut Writer<W>,
     style_options: &StyleOptions,
-    opt: &Options<'_>,
+    opt: &Options,
 ) -> io::Result<()>
 where
     W: Write,

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -7,7 +7,9 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 
 use inferno::flamegraph::color::{BackgroundColor, PaletteMap};
-use inferno::flamegraph::{self, Direction, Options, Palette, TextTruncateDirection};
+use inferno::flamegraph::{
+    self, Direction, Options, Palette, PreProcessingOptions, TextTruncateDirection,
+};
 use log::Level;
 use pretty_assertions::assert_eq;
 use testing_logger::CapturedLog;
@@ -15,19 +17,51 @@ use testing_logger::CapturedLog;
 fn test_flamegraph(
     input_file: &str,
     expected_result_file: &str,
-    options: Options<'_>,
+    options: Options,
 ) -> io::Result<()> {
-    test_flamegraph_multiple_files(
+    test_flamegraph_with_prep_opts(
+        input_file,
+        expected_result_file,
+        options,
+        PreProcessingOptions::default(),
+    )
+}
+
+fn test_flamegraph_with_prep_opts(
+    input_file: &str,
+    expected_result_file: &str,
+    options: Options,
+    prep_options: PreProcessingOptions,
+) -> io::Result<()> {
+    test_flamegraph_multiple_files_with_prep_opts(
         vec![PathBuf::from_str(input_file).unwrap()],
         expected_result_file,
         options,
+        prep_options,
+        None,
     )
 }
 
 fn test_flamegraph_multiple_files(
     input_files: Vec<PathBuf>,
     expected_result_file: &str,
-    mut options: Options<'_>,
+    options: Options,
+) -> io::Result<()> {
+    test_flamegraph_multiple_files_with_prep_opts(
+        input_files,
+        expected_result_file,
+        options,
+        PreProcessingOptions::default(),
+        None,
+    )
+}
+
+fn test_flamegraph_multiple_files_with_prep_opts(
+    input_files: Vec<PathBuf>,
+    expected_result_file: &str,
+    mut options: Options,
+    prep_options: PreProcessingOptions,
+    mut palette_map: Option<&mut PaletteMap>,
 ) -> io::Result<()> {
     // Always pretty print XML to make it easier to find differences when tests fail.
     options.pretty_xml = true;
@@ -41,7 +75,13 @@ fn test_flamegraph_multiple_files(
             if e.kind() == io::ErrorKind::NotFound {
                 // be nice to the dev and make the file
                 let mut f = File::create(expected_result_file).unwrap();
-                flamegraph::from_files(&mut options, &input_files, &mut f)?;
+                flamegraph::from_files(
+                    &options,
+                    &prep_options,
+                    palette_map.as_deref_mut(),
+                    &input_files,
+                    &mut f,
+                )?;
                 fs::metadata(expected_result_file).unwrap()
             } else {
                 return Err(e);
@@ -51,7 +91,13 @@ fn test_flamegraph_multiple_files(
 
     let expected_len = metadata.len() as usize;
     let mut result = Cursor::new(Vec::with_capacity(expected_len));
-    flamegraph::from_files(&mut options, &input_files, &mut result)?;
+    flamegraph::from_files(
+        &options,
+        &prep_options,
+        palette_map,
+        &input_files,
+        &mut result,
+    )?;
     let expected = BufReader::new(File::open(expected_result_file).unwrap());
     // write out the expected result to /tmp for easy restoration
     result.set_position(0);
@@ -112,17 +158,25 @@ where
     test_flamegraph_logs_with_options(input_file, asserter, Default::default());
 }
 
-fn test_flamegraph_logs_with_options<F>(
+fn test_flamegraph_logs_with_options<F>(input_file: &str, asserter: F, options: flamegraph::Options)
+where
+    F: Fn(&Vec<CapturedLog>),
+{
+    test_flamegraph_logs_full(input_file, asserter, options, Default::default());
+}
+
+fn test_flamegraph_logs_full<F>(
     input_file: &str,
     asserter: F,
-    mut options: flamegraph::Options<'_>,
+    options: flamegraph::Options,
+    prep_options: flamegraph::PreProcessingOptions,
 ) where
     F: Fn(&Vec<CapturedLog>),
 {
     testing_logger::setup();
     let r = File::open(input_file).unwrap();
     let sink = io::sink();
-    let _ = flamegraph::from_reader(&mut options, r, sink);
+    let _ = flamegraph::from_reader(&options, &prep_options, None, r, sink);
     testing_logger::validate(asserter);
 }
 
@@ -387,10 +441,16 @@ fn flamegraph_palette_map() {
     let mut palette_map = load_palette_map_file(palette_file);
 
     let mut options = flamegraph::Options::default();
-    options.palette_map = Some(&mut palette_map);
     options.hash = true;
 
-    test_flamegraph(input_file, expected_result_file, options).unwrap();
+    test_flamegraph_multiple_files_with_prep_opts(
+        vec![PathBuf::from_str(input_file).unwrap()],
+        expected_result_file,
+        options,
+        PreProcessingOptions::default(),
+        Some(&mut palette_map),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -515,10 +575,16 @@ fn flamegraph_example_perf_stacks() {
     let palette_file = "./tests/data/flamegraph/example-perf-stacks/palette.map";
     let mut palette_map = load_palette_map_file(palette_file);
 
-    let mut options = flamegraph::Options::default();
-    options.palette_map = Some(&mut palette_map);
+    let options = flamegraph::Options::default();
 
-    test_flamegraph(input_file, expected_result_file, options).unwrap();
+    test_flamegraph_multiple_files_with_prep_opts(
+        vec![PathBuf::from_str(input_file).unwrap()],
+        expected_result_file,
+        options,
+        PreProcessingOptions::default(),
+        Some(&mut palette_map),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -773,10 +839,17 @@ fn flamegraph_no_sort_should_return_error_on_unsorted_input() {
     let expected_result_file =
         "./tests/data/flamegraph/perf-vertx-stacks/perf-vertx-stacks-01-collapsed-all.svg";
 
-    let mut options = flamegraph::Options::default();
-    options.no_sort = true;
+    let options = flamegraph::Options::default();
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.no_sort = true;
 
-    assert!(test_flamegraph(input_file, expected_result_file, options).is_err());
+    assert!(test_flamegraph_with_prep_opts(
+        input_file,
+        expected_result_file,
+        options,
+        prep_options
+    )
+    .is_err());
 }
 
 #[test]
@@ -788,9 +861,11 @@ fn flamegraph_reversed_stack_ordering() {
 
     let mut options = flamegraph::Options::default();
     options.hash = true;
-    options.reverse_stack_order = true;
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.reverse_stack_order = true;
 
-    test_flamegraph(input_file, expected_result_file, options).unwrap();
+    test_flamegraph_with_prep_opts(input_file, expected_result_file, options, prep_options)
+        .unwrap();
 }
 
 #[test]
@@ -800,9 +875,11 @@ fn flamegraph_reversed_stack_ordering_with_fractional_samples() {
 
     let mut options = flamegraph::Options::default();
     options.hash = true;
-    options.reverse_stack_order = true;
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.reverse_stack_order = true;
 
-    test_flamegraph(input_file, expected_result_file, options).unwrap();
+    test_flamegraph_with_prep_opts(input_file, expected_result_file, options, prep_options)
+        .unwrap();
 }
 
 #[test]
@@ -812,18 +889,20 @@ fn flamegraph_reversed_stack_ordering_with_space() {
 
     let mut options = flamegraph::Options::default();
     options.hash = true;
-    options.reverse_stack_order = true;
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.reverse_stack_order = true;
 
-    test_flamegraph(input_file, expected_result_file, options).unwrap();
+    test_flamegraph_with_prep_opts(input_file, expected_result_file, options, prep_options)
+        .unwrap();
 }
 
 #[test]
 fn flamegraph_should_warn_about_no_sort_when_reversing_stack_ordering() {
-    let mut options = flamegraph::Options::default();
-    options.no_sort = true;
-    options.reverse_stack_order = true;
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.no_sort = true;
+    prep_options.reverse_stack_order = true;
 
-    test_flamegraph_logs_with_options(
+    test_flamegraph_logs_full(
         "./flamegraph/test/results/perf-funcab-cmd-01-collapsed-all.txt",
         |captured_logs| {
             let nwarnings = captured_logs
@@ -836,16 +915,17 @@ fn flamegraph_should_warn_about_no_sort_when_reversing_stack_ordering() {
                 nwarnings
             );
         },
-        options,
+        Default::default(),
+        prep_options,
     );
 }
 
 #[test]
 fn flamegraph_should_warn_about_bad_input_lines_with_reversed_stack_ordering() {
-    let mut options = flamegraph::Options::default();
-    options.reverse_stack_order = true;
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.reverse_stack_order = true;
 
-    test_flamegraph_logs_with_options(
+    test_flamegraph_logs_full(
         "./tests/data/flamegraph/bad-lines/bad-lines.txt",
         |captured_logs| {
             let nwarnings = captured_logs
@@ -862,7 +942,8 @@ fn flamegraph_should_warn_about_bad_input_lines_with_reversed_stack_ordering() {
                 nwarnings
             );
         },
-        options,
+        Default::default(),
+        prep_options,
     );
 }
 
@@ -936,10 +1017,11 @@ fn flamegraph_flamechart() {
 
     let mut opts = flamegraph::Options::default();
     opts.title = flamegraph::defaults::CHART_TITLE.to_owned();
-    opts.flame_chart = true;
     opts.hash = true;
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.flame_chart = true;
 
-    test_flamegraph(input_file, expected_result_file, opts).unwrap();
+    test_flamegraph_with_prep_opts(input_file, expected_result_file, opts, prep_options).unwrap();
 }
 
 #[test]
@@ -949,9 +1031,10 @@ fn flamegraph_base_symbol() {
 
     let mut opts = flamegraph::Options::default();
     opts.title = flamegraph::defaults::CHART_TITLE.to_owned();
-    opts.base = vec!["Final".to_string()];
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.base = vec!["Final".to_string()];
 
-    test_flamegraph(input_file, expected_result_file, opts).unwrap();
+    test_flamegraph_with_prep_opts(input_file, expected_result_file, opts, prep_options).unwrap();
 }
 
 #[test]
@@ -961,9 +1044,10 @@ fn flamegraph_multiple_base_symbol() {
 
     let mut opts = flamegraph::Options::default();
     opts.title = flamegraph::defaults::CHART_TITLE.to_owned();
-    opts.base = vec!["Final".to_string(), "Samples".to_string()];
+    let mut prep_options = flamegraph::PreProcessingOptions::default();
+    prep_options.base = vec!["Final".to_string(), "Samples".to_string()];
 
-    test_flamegraph(input_file, expected_result_file, opts).unwrap();
+    test_flamegraph_with_prep_opts(input_file, expected_result_file, opts, prep_options).unwrap();
 }
 
 #[test]
@@ -972,4 +1056,175 @@ fn flamegraph_austin() {
     let expected_result_file = "./tests/data/flamegraph/austin/flame.svg";
     let opts = flamegraph::Options::default();
     test_flamegraph(input_file, expected_result_file, opts).unwrap();
+}
+
+// ==============================================================================
+// Typed API Tests
+// ==============================================================================
+
+#[test]
+fn typed_api_matches_text_path() {
+    // Deliberately unsorted samples to exercise from_stacks' internal sorting.
+    let folded = "main;alpha 3\nmain;alpha;alloc 1\nmain;beta 5\nmain;gamma 2\n";
+    let samples = vec![
+        flamegraph::Sample::new(vec!["main", "gamma"], 2),
+        flamegraph::Sample::new(vec!["main", "alpha"], 3),
+        flamegraph::Sample::new(vec!["main", "beta"], 5),
+        flamegraph::Sample::new(vec!["main", "alpha", "alloc"], 1),
+    ];
+
+    let mut options = flamegraph::Options::default();
+    options.pretty_xml = true;
+    options.no_javascript = true;
+    options.hash = true;
+
+    // Text path
+    let mut text_result = Cursor::new(Vec::new());
+    flamegraph::from_lines(
+        &options,
+        &flamegraph::PreProcessingOptions::default(),
+        None,
+        folded.lines(),
+        &mut text_result,
+    )
+    .unwrap();
+
+    // Typed path
+    let mut typed_result = Cursor::new(Vec::new());
+    flamegraph::from_stacks(&options, None, samples, &mut typed_result).unwrap();
+
+    assert_eq!(
+        String::from_utf8(text_result.into_inner()).unwrap(),
+        String::from_utf8(typed_result.into_inner()).unwrap(),
+        "typed API (from_stacks) should produce identical SVG to text API (from_lines)"
+    );
+}
+
+#[test]
+fn typed_api_sorted_matches_text_path() {
+    // Pre-sorted samples for from_sorted_stacks.
+    let folded = "main;alpha 3\nmain;alpha;alloc 1\nmain;beta 5\nmain;gamma 2\n";
+    let samples = vec![
+        flamegraph::Sample::new(vec!["main", "alpha"], 3),
+        flamegraph::Sample::new(vec!["main", "alpha", "alloc"], 1),
+        flamegraph::Sample::new(vec!["main", "beta"], 5),
+        flamegraph::Sample::new(vec!["main", "gamma"], 2),
+    ];
+
+    let mut options = flamegraph::Options::default();
+    options.pretty_xml = true;
+    options.no_javascript = true;
+    options.hash = true;
+
+    // Text path
+    let mut text_result = Cursor::new(Vec::new());
+    flamegraph::from_lines(
+        &options,
+        &flamegraph::PreProcessingOptions::default(),
+        None,
+        folded.lines(),
+        &mut text_result,
+    )
+    .unwrap();
+
+    // Typed path
+    let mut typed_result = Cursor::new(Vec::new());
+    flamegraph::from_sorted_stacks(&options, None, samples, &mut typed_result).unwrap();
+
+    assert_eq!(
+        String::from_utf8(text_result.into_inner()).unwrap(),
+        String::from_utf8(typed_result.into_inner()).unwrap(),
+        "from_sorted_stacks should produce identical SVG to from_lines for sorted input"
+    );
+}
+
+#[test]
+fn typed_api_sort_check_error() {
+    // Unsorted input to from_sorted_stacks should return an error
+    let samples = vec![
+        flamegraph::Sample::new(["main", "beta"].iter().copied(), 5),
+        flamegraph::Sample::new(["main", "alpha"].iter().copied(), 3),
+    ];
+    let options = flamegraph::Options::default();
+    let mut buf = Vec::new();
+    let result = flamegraph::from_sorted_stacks(&options, None, samples, &mut buf);
+    assert!(result.is_err(), "unsorted input should produce an error");
+    let err = result.unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("unsorted"),
+        "error message should mention 'unsorted', got: {}",
+        err
+    );
+}
+
+#[test]
+fn typed_api_differential() {
+    // Varied deltas: grow (+5), shrink (-8), unchanged (0), grow (+5).
+    let folded = "main;alpha 10 15\nmain;beta 20 12\nmain;gamma 5 5\nmain;gamma;inner 3 8\n";
+    let samples = vec![
+        flamegraph::Sample::with_delta(vec!["main", "alpha"], 15, 5),
+        flamegraph::Sample::with_delta(vec!["main", "beta"], 12, -8),
+        flamegraph::Sample::with_delta(vec!["main", "gamma"], 5, 0),
+        flamegraph::Sample::with_delta(vec!["main", "gamma", "inner"], 8, 5),
+    ];
+
+    let mut options = flamegraph::Options::default();
+    options.pretty_xml = true;
+    options.no_javascript = true;
+    // No hash since differential uses delta-based red/blue coloring.
+
+    // Text path
+    let mut text_result = Cursor::new(Vec::new());
+    flamegraph::from_lines(
+        &options,
+        &flamegraph::PreProcessingOptions::default(),
+        None,
+        folded.lines(),
+        &mut text_result,
+    )
+    .unwrap();
+
+    // Typed path
+    let mut typed_result = Cursor::new(Vec::new());
+    flamegraph::from_sorted_stacks(&options, None, samples, &mut typed_result).unwrap();
+
+    assert_eq!(
+        String::from_utf8(text_result.into_inner()).unwrap(),
+        String::from_utf8(typed_result.into_inner()).unwrap(),
+        "typed API should produce identical SVG for differential flamegraphs"
+    );
+}
+
+#[test]
+fn typed_flame_chart_matches_text_path() {
+    // Duplicate stacks exercise the "no merge" flame-chart behavior.
+    let folded = "main;handle_request 10\nmain;idle 5\nmain;handle_request 8\nmain;log_metrics 3\n";
+    let samples = vec![
+        flamegraph::Sample::new(vec!["main", "handle_request"], 10),
+        flamegraph::Sample::new(vec!["main", "idle"], 5),
+        flamegraph::Sample::new(vec!["main", "handle_request"], 8),
+        flamegraph::Sample::new(vec!["main", "log_metrics"], 3),
+    ];
+
+    let mut options = flamegraph::Options::default();
+    options.pretty_xml = true;
+    options.no_javascript = true;
+    options.hash = true;
+
+    // Text path with flame_chart: true
+    let mut prep_opts = flamegraph::PreProcessingOptions::default();
+    prep_opts.flame_chart = true;
+    let mut text_result = Cursor::new(Vec::new());
+    flamegraph::from_lines(&options, &prep_opts, None, folded.lines(), &mut text_result).unwrap();
+
+    // Typed path
+    let mut typed_result = Cursor::new(Vec::new());
+    flamegraph::flame_chart_from_stacks(&options, None, samples, &mut typed_result).unwrap();
+
+    assert_eq!(
+        String::from_utf8(text_result.into_inner()).unwrap(),
+        String::from_utf8(typed_result.into_inner()).unwrap(),
+        "flame_chart_from_stacks should produce identical SVG to from_lines with flame_chart=true"
+    );
 }


### PR DESCRIPTION
Inferno's library API was purely text-based: collapsers produce `"stack;frames count\n"` lines, and flamegraph parses them back. Downstream tools with structured stack data had to round-trip through text, causing escaping issues, wasted work, and loss of type safety (issues #30, #164, #270).

This commit adds a typed API alongside the existing text path. The core type is `Sample<S>`, generic over the stack iterator, which replaces the text line `"main;foo;bar 42"`. Three new entry points accept iterators of `Sample`: `from_sorted_stacks` (requires pre-sorted input), `from_stacks` (sorts internally), and `flame_chart_from_stacks` (preserves time ordering). On the collapse side,
`Collapse::collapse_to_stacks` returns a `FoldedStacks` wrapper whose `samples()` method yields typed `Sample` values for direct rendering without text serialization. `CollapsePrivate` implementors get an efficient override that skips text entirely; other `Collapse` implementors get a default that round-trips through text that they can override if able.

`Options` is now `Clone` and has no lifetime parameter. The mutable `palette_map` reference moves to a separate parameter on all public functions, and text-processing fields (`no_sort`, `reverse_stack_order`, `flame_chart`, `base`) move to a new `PreProcessingOptions` struct that is only needed by the text-based entry points.

This is a breaking API change, hence the version bump to `1.0.0-rc.1`.