### PR TITLE
Use vec instead of HashMap for tmp frames

### DIFF
--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::io;
 use std::iter;
+use std::mem;
 
 use log::warn;
 
@@ -24,83 +24,63 @@ pub(super) struct FrameTime {
     pub(super) delta: Option<isize>,
 }
 
-fn flow<'a, LI, TI>(
-    tmp: &mut HashMap<Frame<'a>, FrameTime>,
+fn flow<'a>(
+    tmp: &mut Vec<(Frame<'a>, FrameTime)>,
     frames: &mut Vec<TimedFrame<'a>>,
-    last: LI,
-    this: TI,
+    last: &[&'a str],
+    this: &[&'a str],
     time: u64,
     delta: Option<isize>,
-) where
-    LI: IntoIterator<Item = &'a str>,
-    TI: IntoIterator<Item = &'a str>,
-{
-    let mut this = this.into_iter().peekable();
-    let mut last = last.into_iter().peekable();
-
-    // remove common prefix
+) {
+    // find common prefix
     let mut shared_depth = 0;
-    while last.peek() == this.peek() {
-        // they must both be None, so let's stop looping
-        if last.peek().is_none() {
+    let max_depth = last.len().min(this.len());
+    while shared_depth < max_depth {
+        if last[shared_depth] != this[shared_depth] {
             break;
         }
-
-        // move along prefix iterators
-        last.next();
-        this.next();
         shared_depth += 1;
     }
 
-    // TODO: document this..
+    // take the frames that are no longer shared
+    frames.extend(
+        tmp.drain(shared_depth..)
+            .map(|(key, frame_time)| TimedFrame {
+                location: key,
+                start_time: frame_time.start_time,
+                end_time: time,
+                delta: frame_time.delta,
+            }),
+    );
 
-    for (i, func) in last.enumerate() {
-        let key = Frame {
-            function: func,
-            depth: shared_depth + i,
-        };
+    // push new frames
+    if shared_depth < this.len() {
+        let last = this.len() - shared_depth - 1;
+        let new_frames = this[shared_depth..]
+            .iter()
+            .enumerate()
+            .map(|(i, function)| {
+                let key = Frame {
+                    function,
+                    depth: shared_depth + i,
+                };
 
-        let frame_time = tmp.remove(&key).unwrap_or_else(|| {
-            unreachable!("did not have start time for {:?}", key);
-        });
+                // ensures all frames have `Some(0)` if a delta is provided,
+                // delta rendering handles it differently to `None`
+                let delta = match delta {
+                    Some(_) if i != last => Some(0),
+                    d => d,
+                };
 
-        let frame = TimedFrame {
-            location: key,
-            start_time: frame_time.start_time,
-            end_time: time,
-            delta: frame_time.delta,
-        };
-        frames.push(frame);
-    }
-
-    let mut i = 0;
-    while this.peek().is_some() {
-        let func = this.next().unwrap();
-        let key = Frame {
-            function: func,
-            depth: shared_depth + i,
-        };
-
-        let is_last = this.peek().is_none();
-        let delta = match delta {
-            Some(_) if !is_last => Some(0),
-            d => d,
-        };
-        let frame_time = FrameTime {
-            start_time: time,
-            // For some reason the Perl version does a `+=` for `delta`, but I can't figure out why.
-            // See https://github.com/brendangregg/FlameGraph/blob/1b1c6deede9c33c5134c920bdb7a44cc5528e9a7/flamegraph.pl#L588
-            delta,
-        };
-
-        if let Some(frame_time) = tmp.insert(key, frame_time) {
-            unreachable!(
-                "start time {} already registered for frame",
-                frame_time.start_time
-            );
-        }
-
-        i += 1;
+                let frame_time = FrameTime {
+                    start_time: time,
+                    // For some reason the Perl version does a `+=` for `delta`, but I can't figure out why.
+                    // See https://github.com/brendangregg/FlameGraph/blob/1b1c6deede9c33c5134c920bdb7a44cc5528e9a7/flamegraph.pl#L588
+                    delta,
+                };
+                (key, frame_time)
+            });
+        tmp.extend(new_frames);
     }
 }
 
@@ -113,7 +93,8 @@ where
 {
     let mut time = 0;
     let mut ignored = 0;
-    let mut last = "";
+    let mut last = Vec::new();
+    let mut this = Vec::new();
     let mut tmp = Default::default();
     let mut frames = Default::default();
     let mut delta_max = 1;
@@ -162,22 +143,12 @@ where
         let stack = line;
 
         // inject empty first-level stack frame to capture "all"
-        let this = iter::once("").chain(stack.split(';'));
-        if last.is_empty() {
-            // need to special-case this, because otherwise iter("") + "".split(';') == ["", ""]
-            flow(&mut tmp, &mut frames, None, this, time, delta);
-        } else {
-            flow(
-                &mut tmp,
-                &mut frames,
-                iter::once("").chain(last.split(';')),
-                this,
-                time,
-                delta,
-            );
-        }
+        this.extend(iter::once("").chain(stack.split(';')));
 
-        last = stack;
+        flow(&mut tmp, &mut frames, &last, &this, time, delta);
+
+        mem::swap(&mut last, &mut this);
+        this.clear();
         time += nsamples;
         prev_line = Some(line);
     }
@@ -186,14 +157,7 @@ where
         // NOTE: the `delta` parameter is unused by `flow` when `this` is `None` (which is the case
         // here), so we can pass any arbitrary value in that position. but `None` seems the most
         // reasonable.
-        flow(
-            &mut tmp,
-            &mut frames,
-            iter::once("").chain(last.split(';')),
-            None,
-            time,
-            None,
-        );
+        flow(&mut tmp, &mut frames, &last, &this, time, None);
     }
 
     if ignored != 0 {

--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -60,7 +60,6 @@ fn flow<'a, LI, TI>(
             depth: shared_depth + i,
         };
 
-        //eprintln!("at {} ending frame {:?}", time, key);
         let frame_time = tmp.remove(&key).unwrap_or_else(|| {
             unreachable!("did not have start time for {:?}", key);
         });
@@ -94,7 +93,6 @@ fn flow<'a, LI, TI>(
             delta,
         };
 
-        //eprintln!("stored tmp for time {}: {:?}", time, key);
         if let Some(frame_time) = tmp.insert(key, frame_time) {
             unreachable!(
                 "start time {} already registered for frame",
@@ -167,10 +165,8 @@ where
         let this = iter::once("").chain(stack.split(';'));
         if last.is_empty() {
             // need to special-case this, because otherwise iter("") + "".split(';') == ["", ""]
-            //eprintln!("flow(_, {}, {})", stack, time);
             flow(&mut tmp, &mut frames, None, this, time, delta);
         } else {
-            //eprintln!("flow({}, {}, {})", last, stack, time);
             flow(
                 &mut tmp,
                 &mut frames,
@@ -187,7 +183,6 @@ where
     }
 
     if !last.is_empty() {
-        //eprintln!("flow({}, _, {})", last, time);
         // NOTE: the `delta` parameter is unused by `flow` when `this` is `None` (which is the case
         // here), so we can pass any arbitrary value in that position. but `None` seems the most
         // reasonable.

--- a/src/flamegraph/merge.rs
+++ b/src/flamegraph/merge.rs
@@ -107,7 +107,7 @@ fn flow<'a, LI, TI>(
 pub(super) fn frames<'a, I>(
     lines: I,
     suppress_sort_check: bool,
-) -> io::Result<(Vec<TimedFrame<'a>>, u64, usize, usize)>
+) -> io::Result<(Vec<TimedFrame<'a>>, u64, usize)>
 where
     I: IntoIterator<Item = &'a str>,
 {
@@ -196,7 +196,11 @@ where
         );
     }
 
-    Ok((frames, time, ignored, delta_max))
+    if ignored != 0 {
+        warn!("Ignored {} lines with invalid format", ignored);
+    }
+
+    Ok((frames, time, delta_max))
 }
 
 // Parse and remove the number of samples from the end of a line.
@@ -243,7 +247,7 @@ mod tests {
         // frame should have delta = None, not the stale value from
         // the previous line.
         let lines = vec!["a;b 10 5", "a;c 3"];
-        let (frames, _time, _ignored, _delta_max) = frames(lines, true).unwrap();
+        let (frames, _time, _delta_max) = frames(lines, true).unwrap();
 
         let c_frame = frames
             .iter()

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -404,7 +404,7 @@ where
         .map(|line| line.trim())
         .filter(|line| !(line.is_empty() || line.starts_with("# ")));
 
-    let (mut frames, time, ignored, delta_max) = if opt.reverse_stack_order {
+    let (mut frames, time, delta_max) = if opt.reverse_stack_order {
         if opt.no_sort {
             warn!(
                 "Input lines are always sorted when `reverse_stack_order` is `true`. \
@@ -473,10 +473,6 @@ where
         lines.sort_unstable();
         merge::frames(lines, false)?
     };
-
-    if ignored != 0 {
-        warn!("Ignored {} lines with invalid format", ignored);
-    }
 
     let mut buffer = StrStack::new();
 


### PR DESCRIPTION
Split from https://github.com/jonhoo/inferno/pull/355 for a smaller changeset / easier review.

This changes `merge` and `flow` to use a `Vec` instead of a `HashMap`:


```
collapse/dtrace/1       time:   [2.8601 ms 2.8605 ms 2.8610 ms]
                        change: [−2.6285% −2.5659% −2.5035%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
Benchmarking collapse/dtrace/32: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.4s, enable flat sampling, or reduce sample count to 50.
collapse/dtrace/32      time:   [1.4648 ms 1.4695 ms 1.4744 ms]
                        thrpt:  [894.22 MiB/s 897.20 MiB/s 900.06 MiB/s]
                 change:
                        time:   [−3.7081% −3.1143% −2.4975%] (p = 0.00 < 0.05)
                        thrpt:  [+2.5615% +3.2144% +3.8509%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

collapse/perf/1         time:   [6.0919 ms 6.0961 ms 6.1005 ms]
                        change: [−1.2866% −1.1898% −1.0983%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking collapse/perf/32: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.9s, enable flat sampling, or reduce sample count to 40.
collapse/perf/32        time:   [1.9667 ms 1.9717 ms 1.9767 ms]
                        thrpt:  [1.4790 GiB/s 1.4828 GiB/s 1.4866 GiB/s]
                 change:
                        time:   [−2.7162% −2.2773% −1.8490%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8839% +2.3304% +2.7921%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

sample/collapse         time:   [2.9114 ms 2.9139 ms 2.9165 ms]
                        change: [+0.8133% +0.9177% +1.0046%] (p = 0.00 < 0.05)
                        Change within noise threshold.

     Running benches/flamegraph.rs (target/release/deps/flamegraph-af6050c0ec451745)
Gnuplot not found, using plotters backend
flamegraph/flamegraph   time:   [16.217 ms 16.288 ms 16.360 ms]
                        change: [−7.6264% −7.0837% −6.5656%] (p = 0.00 < 0.05)
                        Performance has improved.
```