### PR TITLE
Switch from libflate to flate2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
@@ -38,12 +38,6 @@ checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -270,15 +264,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,12 +357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "dary_heap"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
-
-[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,16 +420,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"
@@ -501,7 +484,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -509,11 +492,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "heck"
@@ -551,9 +529,9 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
+ "flate2",
  "indexmap",
  "itoa",
- "libflate",
  "log",
  "maplit",
  "num-format",
@@ -612,30 +590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
-name = "libflate"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
-dependencies = [
- "core2",
- "hashbrown 0.16.1",
- "rle-decode-fast",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +615,16 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "num-format"
@@ -995,6 +959,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ once_cell = "1.12.0"
 [dev-dependencies]
 assert_cmd = "2.1.1"
 criterion = "0.8"
-libflate = "2"
+flate2 = "1.1.9"
 maplit = "1.0.1"
 pretty_assertions = "1"
 rand = { version = "0.10", features = ["thread_rng"] }

--- a/benches/collapse.rs
+++ b/benches/collapse.rs
@@ -2,8 +2,8 @@ use std::fs::File;
 use std::io::{self, Read};
 
 use criterion::*;
+use flate2::read::GzDecoder;
 use inferno::collapse::{dtrace, perf, sample, Collapse};
-use libflate::gzip::Decoder;
 use once_cell::sync::Lazy;
 
 const INFILE_DTRACE: &str = "flamegraph/example-dtrace-stacks.txt";
@@ -16,7 +16,7 @@ static NTHREADS: Lazy<usize> = Lazy::new(|| std::thread::available_parallelism()
 fn read_infile(infile: &str, buf: &mut Vec<u8>) -> io::Result<()> {
     let mut f = File::open(infile)?;
     if infile.ends_with(".gz") {
-        let mut r = io::BufReader::new(Decoder::new(f)?);
+        let mut r = GzDecoder::new(f);
         r.read_to_end(buf)?;
     } else {
         f.read_to_end(buf)?;

--- a/src/collapse/common.rs
+++ b/src/collapse/common.rs
@@ -573,7 +573,7 @@ pub(crate) mod testing {
     use std::path::{Path, PathBuf};
     use std::time::Instant;
 
-    use libflate::gzip::Decoder;
+    use flate2::read::GzDecoder;
 
     use super::*;
     use crate::collapse::Collapse;
@@ -589,7 +589,7 @@ pub(crate) mod testing {
                 let mut buf = Vec::new();
                 let mut file = File::open(path)?;
                 if path.to_str().unwrap().ends_with(".gz") {
-                    let mut reader = Decoder::new(file)?;
+                    let mut reader = GzDecoder::new(file);
                     reader.read_to_end(&mut buf)?;
                 } else {
                     file.read_to_end(&mut buf)?;

--- a/tests/common/collapse.rs
+++ b/tests/common/collapse.rs
@@ -1,8 +1,8 @@
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Cursor};
 
+use flate2::read::GzDecoder;
 use inferno::collapse::Collapse;
-use libflate::gzip::Decoder;
 use pretty_assertions::assert_eq;
 use testing_logger::CapturedLog;
 
@@ -55,7 +55,7 @@ where
     let mut collapse = move |out: &mut dyn io::Write| {
         if test_filename.ends_with(".gz") {
             let test_file = File::open(test_filename)?;
-            let r = BufReader::new(Decoder::new(test_file).unwrap());
+            let r = BufReader::new(GzDecoder::new(test_file));
             collapser.collapse(r, out)
         } else {
             collapser.collapse_file(Some(test_filename), out)
@@ -123,7 +123,7 @@ where
     let mut collapse = move |out: &mut dyn io::Write| {
         if test_filename.ends_with(".gz") {
             let test_file = File::open(test_filename)?;
-            let r = BufReader::new(Decoder::new(test_file).unwrap());
+            let r = BufReader::new(GzDecoder::new(test_file));
             collapser.collapse(r, out)
         } else {
             collapser.collapse_file(Some(test_filename), out)


### PR DESCRIPTION
The `flate2` crate is more popular and as far as I can tell, `inferno` makes no attempt to be `no_std`. The `GzDecoder::new` constructor is infallible because `libflate` attempts to read and validate the gzip header on construction, whereas `flate2` does not and waits until the decoder is actually used to perform validation. Additionally, `flate2` uses a `BufReader` internally, though `GzDecoder` only exposes a `Read` interface.