### PR TITLE
Generate "ignore case" button on flamegraphs

### DIFF
--- a/src/flamegraph/flamegraph.css
+++ b/src/flamegraph/flamegraph.css
@@ -1,6 +1,8 @@
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }

--- a/src/flamegraph/flamegraph.js
+++ b/src/flamegraph/flamegraph.js
@@ -1,8 +1,9 @@
 "use strict";
-var details, searchbtn, unzoombtn, matchedtxt, svg, searching, frames, known_font_width;
+var details, searchbtn, ignorecasebtn, unzoombtn, matchedtxt, svg, searching, frames, known_font_width, case_insensitive, current_search_term;
 function init(evt) {
     details = document.getElementById("details").firstChild;
     searchbtn = document.getElementById("search");
+    ignorecasebtn = document.getElementById("ignorecase");
     unzoombtn = document.getElementById("unzoom");
     matchedtxt = document.getElementById("matched");
     svg = document.getElementsByTagName("svg")[0];
@@ -10,6 +11,8 @@ function init(evt) {
     known_font_width = get_monospace_width(frames);
     total_samples = parseInt(frames.attributes.total_samples.value);
     searching = 0;
+    case_insensitive = 0;
+    current_search_term = null;
 
     // Use GET parameters to restore a flamegraph's state.
     var restore_state = function() {
@@ -41,7 +44,8 @@ function init(evt) {
 
             // Keep search elements at a fixed distance from right edge.
             var svgWidth = svg.width.baseVal.value;
-            searchbtn.attributes.x.value = svgWidth - xpad;
+            ignorecasebtn.attributes.x.value = svgWidth - xpad;
+            searchbtn.attributes.x.value = svgWidth - xpad - fontsize * fontwidth * 4;
             matchedtxt.attributes.x.value = svgWidth - xpad;
         };
         window.addEventListener('resize', function() {
@@ -87,6 +91,7 @@ window.addEventListener("click", function(e) {
         history.replaceState(null, null, parse_params(params));
     }
     else if (e.target.id == "search") search_prompt();
+    else if (e.target.id == "ignorecase") toggle_ignorecase();
 }, false)
 // mouse-over for info
 // show
@@ -104,6 +109,13 @@ window.addEventListener("keydown",function (e) {
     if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
         e.preventDefault();
         search_prompt();
+    }
+}, false)
+// ctrl-I to toggle case-insensitive search
+window.addEventListener("keydown",function (e) {
+    if (e.ctrlKey && e.keyCode === 73) {
+        e.preventDefault();
+        toggle_ignorecase();
     }
 }, false)
 // functions
@@ -375,14 +387,17 @@ function reset_search() {
 }
 function search_prompt() {
     if (!searching) {
+        var casemsg = case_insensitive ? ", ignoring case" : "";
         var term = prompt("Enter a search term (regexp " +
-            "allowed, eg: ^ext4_)", "");
+            "allowed, eg: ^ext4_)" + casemsg + "\nPress Ctrl+i to toggle case sensitivity", "");
         if (term != null) {
+            current_search_term = term;
             search(term)
         }
     } else {
         reset_search();
         searching = 0;
+        current_search_term = null;
         searchbtn.classList.remove("show");
         searchbtn.firstChild.nodeValue = "Search"
         matchedtxt.classList.add("hide");
@@ -390,7 +405,7 @@ function search_prompt() {
     }
 }
 function search(term) {
-    var re = new RegExp(term);
+    var re = new RegExp(term, case_insensitive ? "i" : "");
     var el = frames.children;
     var matches = new Object();
     var maxwidth = 0;
@@ -464,6 +479,19 @@ function search(term) {
     var pct = 100 * count / maxwidth;
     if (pct != 100) pct = pct.toFixed(1);
     matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+}
+function toggle_ignorecase() {
+    case_insensitive = !case_insensitive;
+    if (case_insensitive) {
+        ignorecasebtn.classList.add("show");
+    } else {
+        ignorecasebtn.classList.remove("show");
+    }
+    if (searching && current_search_term != null) {
+        reset_search();
+        searching = 0;
+        search(current_search_term);
+    }
 }
 function format_percent(n) {
     return n.toFixed(4) + "%";

--- a/src/flamegraph/flamegraph.js
+++ b/src/flamegraph/flamegraph.js
@@ -19,8 +19,14 @@ function init(evt) {
         var params = get_params();
         if (params.x && params.y)
             zoom(find_group(document.querySelector('[*|x="' + params.x + '"][y="' + params.y + '"]')));
-        if (params.s)
+        if (params.s) {
+            if (params.ic) {
+                case_insensitive = 1;
+                ignorecasebtn.classList.add("show");
+            }
+            current_search_term = params.s;
             search(params.s);
+        }
     };
 
     if (fluiddrawing) {
@@ -383,6 +389,7 @@ function reset_search() {
     }
     var params = get_params();
     delete params.s;
+    delete params.ic;
     history.replaceState(null, null, parse_params(params));
 }
 function search_prompt() {
@@ -444,6 +451,11 @@ function search(term) {
         return;
     var params = get_params();
     params.s = term;
+    if (case_insensitive) {
+        params.ic = "1";
+    } else {
+        delete params.ic;
+    }
     history.replaceState(null, null, parse_params(params));
 
     searchbtn.classList.add("show");

--- a/src/flamegraph/flamegraph.js
+++ b/src/flamegraph/flamegraph.js
@@ -447,8 +447,13 @@ function search(term) {
             searching = 1;
         }
     }
-    if (!searching)
+    if (!searching) {
+        searchbtn.classList.remove("show");
+        searchbtn.firstChild.nodeValue = "Search";
+        matchedtxt.classList.add("hide");
+        matchedtxt.firstChild.nodeValue = "";
         return;
+    }
     var params = get_params();
     params.s = term;
     if (case_insensitive) {

--- a/src/flamegraph/flamegraph.js
+++ b/src/flamegraph/flamegraph.js
@@ -487,7 +487,7 @@ function toggle_ignorecase() {
     } else {
         ignorecasebtn.classList.remove("show");
     }
-    if (searching && current_search_term != null) {
+    if (current_search_term != null) {
         reset_search();
         searching = 0;
         search(current_search_term);

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -232,19 +232,24 @@ text {{ font-family:{}; font-size:{}px }}
         },
     )?;
 
-    // "ic" indicator for case-insensitive search, right-aligned at the edge
-    write_str(
-        svg,
-        &mut buf,
-        TextItem {
-            x: Dimension::Pixels(image_width as usize - super::XPAD),
-            y: (opt.font_size * 2) as f64,
-            text: "ic".into(),
-            extra: vec![("id", "ignorecase"), ("fill", &style_options.uicolor)],
-        },
-    )?;
+    {
+        let x = write!(buf, "{:.2}", image_width as usize - super::XPAD);
+        let y = write!(buf, "{:.2}", (opt.font_size * 2) as f64);
+        svg.write_event(Event::Start(BytesStart::new("text").with_attributes(
+            args!(
+                "id" => "ignorecase",
+                "fill" => &*style_options.uicolor,
+                "x" => &buf[x],
+                "y" => &buf[y]
+            ),
+        )))?;
+        svg.write_event(Event::Start(BytesStart::new("title")))?;
+        svg.write_event(Event::Text(BytesText::new("ignore case")))?;
+        svg.write_event(Event::End(BytesEnd::new("title")))?;
+        svg.write_event(Event::Text(BytesText::new("ic")))?;
+        svg.write_event(Event::End(BytesEnd::new("text")))?;
+    }
 
-    // Search button, shifted left to make room for the "ic" indicator
     let ic_offset = (opt.font_size as f64 * opt.font_width * 4.0) as usize;
     write_str(
         svg,

--- a/src/flamegraph/svg.rs
+++ b/src/flamegraph/svg.rs
@@ -232,11 +232,25 @@ text {{ font-family:{}; font-size:{}px }}
         },
     )?;
 
+    // "ic" indicator for case-insensitive search, right-aligned at the edge
     write_str(
         svg,
         &mut buf,
         TextItem {
             x: Dimension::Pixels(image_width as usize - super::XPAD),
+            y: (opt.font_size * 2) as f64,
+            text: "ic".into(),
+            extra: vec![("id", "ignorecase"), ("fill", &style_options.uicolor)],
+        },
+    )?;
+
+    // Search button, shifted left to make room for the "ic" indicator
+    let ic_offset = (opt.font_size as f64 * opt.font_width * 4.0) as usize;
+    write_str(
+        svg,
+        &mut buf,
+        TextItem {
+            x: Dimension::Pixels(image_width as usize - super::XPAD - ic_offset),
             y: (opt.font_size * 2) as f64,
             text: "Search".into(),
             extra: vec![("id", "search"), ("fill", &style_options.uicolor)],

--- a/tests/data/flamegraph/austin/flame.svg
+++ b/tests/data/flamegraph/austin/flame.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="277.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="277.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="291">
         <g>

--- a/tests/data/flamegraph/base/multi-base.svg
+++ b/tests/data/flamegraph/base/multi-base.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Chart</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="181.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="181.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="381200">
         <g>

--- a/tests/data/flamegraph/base/single-base.svg
+++ b/tests/data/flamegraph/base/single-base.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Chart</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="213.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="213.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="198800">
         <g>

--- a/tests/data/flamegraph/colors/async-profiler-java.svg
+++ b/tests/data/flamegraph/colors/async-profiler-java.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1941.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1941.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="3279">
         <g>

--- a/tests/data/flamegraph/colors/deterministic.svg
+++ b/tests/data/flamegraph/colors/deterministic.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1941.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1941.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="3279">
         <g>

--- a/tests/data/flamegraph/colors/java.svg
+++ b/tests/data/flamegraph/colors/java.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1189.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1189.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="46">
         <g>

--- a/tests/data/flamegraph/colors/js.svg
+++ b/tests/data/flamegraph/colors/js.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="373.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="373.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="2">
         <g>

--- a/tests/data/flamegraph/differential/diff-negated.svg
+++ b/tests/data/flamegraph/differential/diff-negated.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/differential/diff.svg
+++ b/tests/data/flamegraph/differential/diff.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/example-perf-stacks/example-perf-stacks.svg
+++ b/tests/data/flamegraph/example-perf-stacks/example-perf-stacks.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1253.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1253.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="1315">
         <g>

--- a/tests/data/flamegraph/factor/factor-2.5.svg
+++ b/tests/data/flamegraph/factor/factor-2.5.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1173.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1173.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="286">
         <g>

--- a/tests/data/flamegraph/flamechart/flame.svg
+++ b/tests/data/flamegraph/flamechart/flame.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Chart</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="293.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="293.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="598400">
         <g>

--- a/tests/data/flamegraph/fractional-samples/fractional-reversed.svg
+++ b/tests/data/flamegraph/fractional-samples/fractional-reversed.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="333">
         <g>

--- a/tests/data/flamegraph/fractional-samples/with-space-reversed.svg
+++ b/tests/data/flamegraph/fractional-samples/with-space-reversed.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="333">
         <g>

--- a/tests/data/flamegraph/grey-frames/grey-frames.svg
+++ b/tests/data/flamegraph/grey-frames/grey-frames.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="333">
         <g>

--- a/tests/data/flamegraph/inverted/inverted.svg
+++ b/tests/data/flamegraph/inverted/inverted.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Icicle Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="40.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1183.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="286">
         <g>

--- a/tests/data/flamegraph/nameattr/nameattr.svg
+++ b/tests/data/flamegraph/nameattr/nameattr.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="333">
         <g>

--- a/tests/data/flamegraph/nameattr/nameattr_duplicate_attributes.svg
+++ b/tests/data/flamegraph/nameattr/nameattr_duplicate_attributes.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="333">
         <g>

--- a/tests/data/flamegraph/narrow-blocks/narrow-blocks.svg
+++ b/tests/data/flamegraph/narrow-blocks/narrow-blocks.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="149.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="149.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="386001">
         <g>

--- a/tests/data/flamegraph/options/colordiffusion.svg
+++ b/tests/data/flamegraph/options/colordiffusion.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1173.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1173.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="286">
         <g>

--- a/tests/data/flamegraph/options/count_name_simple.svg
+++ b/tests/data/flamegraph/options/count_name_simple.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/count_name_with_symbols.svg
+++ b/tests/data/flamegraph/options/count_name_with_symbols.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/default.svg
+++ b/tests/data/flamegraph/options/default.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/font_type_cursive.svg
+++ b/tests/data/flamegraph/options/font_type_cursive.svg
@@ -15,6 +15,8 @@ text { font-family:cursive; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:cursive; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/font_type_fantasy.svg
+++ b/tests/data/flamegraph/options/font_type_fantasy.svg
@@ -15,6 +15,8 @@ text { font-family:fantasy; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:fantasy; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/font_type_monospace.svg
+++ b/tests/data/flamegraph/options/font_type_monospace.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/font_type_sans-serif.svg
+++ b/tests/data/flamegraph/options/font_type_sans-serif.svg
@@ -15,6 +15,8 @@ text { font-family:sans-serif; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:sans-serif; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/font_type_serif.svg
+++ b/tests/data/flamegraph/options/font_type_serif.svg
@@ -15,6 +15,8 @@ text { font-family:serif; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:serif; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/font_type_simple.svg
+++ b/tests/data/flamegraph/options/font_type_simple.svg
@@ -15,6 +15,8 @@ text { font-family:"Andale Mono"; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:"Andale Mono"; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/font_type_with_quote.svg
+++ b/tests/data/flamegraph/options/font_type_with_quote.svg
@@ -15,6 +15,8 @@ text { font-family:"Andale Mono\""; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:"Andale Mono\""; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/name_type_simple.svg
+++ b/tests/data/flamegraph/options/name_type_simple.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/name_type_with_backslash.svg
+++ b/tests/data/flamegraph/options/name_type_with_backslash.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/name_type_with_quote.svg
+++ b/tests/data/flamegraph/options/name_type_with_quote.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/notes_simple.svg
+++ b/tests/data/flamegraph/options/notes_simple.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/notes_with_symbols.svg
+++ b/tests/data/flamegraph/options/notes_with_symbols.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/search_color.svg
+++ b/tests/data/flamegraph/options/search_color.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/stroke_color.svg
+++ b/tests/data/flamegraph/options/stroke_color.svg
@@ -16,6 +16,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -36,7 +38,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/subtitle_simple.svg
+++ b/tests/data/flamegraph/options/subtitle_simple.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -36,7 +38,9 @@ text { font-family:monospace; font-size:12px }
     <text id="subtitle" x="50.0000%" y="48.00">Test Subtitle</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="253.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="253.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/subtitle_with_symbols.svg
+++ b/tests/data/flamegraph/options/subtitle_with_symbols.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -36,7 +38,9 @@ text { font-family:monospace; font-size:12px }
     <text id="subtitle" x="50.0000%" y="48.00">Test Subtitle &lt;&amp; &apos; &quot;</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="253.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="253.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/title_simple.svg
+++ b/tests/data/flamegraph/options/title_simple.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Test Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/title_with_symbols.svg
+++ b/tests/data/flamegraph/options/title_with_symbols.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Test &lt;&amp; &apos; &quot;</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/options/truncate-right.svg
+++ b/tests/data/flamegraph/options/truncate-right.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1189.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1189.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="46">
         <g>

--- a/tests/data/flamegraph/options/uicolor_color.svg
+++ b/tests/data/flamegraph/options/uicolor_color.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(255,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(255,0,0)" x="10" y="229.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(255,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(255,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(255,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(255,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(255,0,0)" x="1190" y="229.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="513">
         <g>

--- a/tests/data/flamegraph/palette-map/consistent-palette.svg
+++ b/tests/data/flamegraph/palette-map/consistent-palette.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1173.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1173.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="286">
         <g>

--- a/tests/data/flamegraph/perf-vertx-stacks/perf-vertx-stacks-01-collapsed-all-reversed-stacks.svg
+++ b/tests/data/flamegraph/perf-vertx-stacks/perf-vertx-stacks-01-collapsed-all-reversed-stacks.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1173.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1173.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="286">
         <g>

--- a/tests/data/flamegraph/perf-vertx-stacks/perf-vertx-stacks-01-collapsed-all.svg
+++ b/tests/data/flamegraph/perf-vertx-stacks/perf-vertx-stacks-01-collapsed-all.svg
@@ -15,6 +15,8 @@ text { font-family:monospace; font-size:12px }
 #matched { text-anchor:end; }
 #search { text-anchor:end; opacity:0.1; cursor:pointer; }
 #search:hover, #search.show { opacity:1; }
+#ignorecase { text-anchor:end; opacity:0.1; cursor:pointer; }
+#ignorecase:hover, #ignorecase.show { opacity:1; }
 #subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
 #unzoom { cursor:pointer; }
 #frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
@@ -35,7 +37,9 @@ text { font-family:monospace; font-size:12px }
     <text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text>
     <text id="details" fill="rgb(0,0,0)" x="10" y="1173.00"> </text>
     <text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text>
-    <text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text>
+    <text id="ignorecase" fill="rgb(0,0,0)" x="1190" y="24.00">
+        <title>ignore case</title>ic</text>
+    <text id="search" fill="rgb(0,0,0)" x="1162" y="24.00">Search</text>
     <text id="matched" fill="rgb(0,0,0)" x="1190" y="1173.00"> </text>
     <svg id="frames" x="10" width="1180" total_samples="286">
         <g>


### PR DESCRIPTION
This feature is already implemented in the original perl script.

Changes:
- Adds an "ignore case" button to the top right of flamegraphs, shifting the search button left slightly
  - Added a tooltip for this, which forced direct use of the svg library instead of calling `write_str`
- `Ctrl+i` can be used to toggle this dynamically

"ignore case" is additionally bound into the URI parameters.

To verify, I ran `cargo run --bin inferno-flamegraph < tests/data/flamegraph/base/flames.txt > test.svg` and got the following flamegraph:
<img width="1009" height="280" alt="image" src="https://github.com/user-attachments/assets/db31209f-15f8-4aee-b7f9-8e4c89ddfc0d" />

Hovering:
<img width="129" height="79" alt="image" src="https://github.com/user-attachments/assets/d91caf8a-21ed-490e-9c94-40257c35d5a6" />

Searching `final` (standard behavior):
<img width="1010" height="293" alt="image" src="https://github.com/user-attachments/assets/9ccf11fe-1cdb-416f-b740-0897773c446a" />

Searching `final` with ignore case:
<img width="1009" height="305" alt="image" src="https://github.com/user-attachments/assets/8a2a32db-fceb-4a16-8305-033bc7c8148b" />

