### PR TITLE
fix: avoid integer overflow when computing percentage for large sample counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Avoid integer overflow when computing percentages for very large sample counts. [#367](https://github.com/jonhoo/inferno/pull/367)
+
 ### Security
 
 ## [0.12.7] - 2026-07-05

--- a/src/flamegraph/mod.rs
+++ b/src/flamegraph/mod.rs
@@ -612,7 +612,7 @@ where
         let info = if frame.location.function.is_empty() && frame.location.depth == 0 {
             write!(buffer, "all ({} {}, 100%)", samples_txt, opt.count_name)
         } else {
-            let pct = (100 * samples) as f64 / (timemax as f64 * opt.factor);
+            let pct = 100.0 * samples as f64 / (timemax as f64 * opt.factor);
             let function = deannotate(frame.location.function);
             match frame.delta {
                 None => write!(
@@ -630,7 +630,7 @@ where
                     if opt.negate_differentials {
                         delta = -delta;
                     }
-                    let delta_pct = (100 * delta) as f64 / (timemax as f64 * opt.factor);
+                    let delta_pct = 100.0 * delta as f64 / (timemax as f64 * opt.factor);
                     write!(
                         buffer,
                         "{} ({} {}, {:.2}%; {:+.2}%)",

--- a/tests/flamegraph.rs
+++ b/tests/flamegraph.rs
@@ -973,3 +973,17 @@ fn flamegraph_austin() {
     let opts = flamegraph::Options::default();
     test_flamegraph(input_file, expected_result_file, opts).unwrap();
 }
+
+// Regression test for https://github.com/jonhoo/inferno/issues/170
+// Sample counts large enough that `100 * samples` overflowed the integer
+// type used to compute the percentage caused a panic.
+#[test]
+fn flamegraph_huge_sample_counts() {
+    let lines = "\
+swapper/0;start_kernel;do_idle 239807672958951499
+swapper/1;start_secondary;do_idle 129127208516546613
+";
+    let mut opts = flamegraph::Options::default();
+    let mut result = Cursor::new(Vec::new());
+    flamegraph::from_lines(&mut opts, lines.lines(), &mut result).unwrap();
+}


### PR DESCRIPTION
Fixes #170.

When a stack has a very large sample count (e.g. `offwaketime` output with values around 2.4e17), `100 * samples` overflowed the integer type and panicked with "attempt to multiply with overflow" at `src/flamegraph/mod.rs`. The same applied to `100 * delta` in the differential path.

Performing the `* 100` in floating point (`100.0 * x as f64`) avoids the overflow. Output is unchanged for normal-magnitude inputs.

Added a regression test that feeds large sample counts through `from_lines` and asserts it does not panic.