### PR TITLE
Upgrade quick-xml to 0.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgrade quick-xml to 0.40. [#369](https://github.com/jonhoo/inferno/pull/369)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade quick-xml to 0.40. [#369](https://github.com/jonhoo/inferno/pull/369)
+- Upgrade quick-xml to 0.41. [#369](https://github.com/jonhoo/inferno/pull/369)
+  This addresses [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194)
+  and [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195).
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ indexmap = { version = "2.0", optional = true }
 itoa = "1"
 log = "0.4"
 num-format = { version = "0.4.3", default-features = false }
-quick-xml = { version = "0.39", default-features = false }
+quick-xml = { version = "0.40", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 clap = { version = "4.0.1", optional = true, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ indexmap = { version = "2.0", optional = true }
 itoa = "1"
 log = "0.4"
 num-format = { version = "0.4.3", default-features = false }
-quick-xml = { version = "0.40", default-features = false }
+quick-xml = { version = "0.41", default-features = false }
 rgb = "0.8.13"
 str_stack = "0.1"
 clap = { version = "4.0.1", optional = true, features = ["derive"] }


### PR DESCRIPTION
https://github.com/tafia/quick-xml/blob/v0.41.0/Changelog.md

~~Nothing special in this release that I’m aware of.~~ I’m ~~just~~ updating the `rust-quick-xml` package in Fedora, trying to avoid a `rust-quick-xml0.39` compat package, and sending my patches upstream. Originally, this PR targeted `quick-xml` 0.40, which was the latest release at the time. Now that it targets `quick-xml` 0.41, it fixes https://rustsec.org/advisories/RUSTSEC-2026-0194 and https://rustsec.org/advisories/RUSTSEC-2026-0195.